### PR TITLE
Penalty parameter updated for 1D case

### DIFF
--- a/src/gsAssembler/gsVisitorNitsche.h
+++ b/src/gsAssembler/gsVisitorNitsche.h
@@ -134,7 +134,8 @@ public:
         geoEval.transformGradients(k, bGrads, pGrads);
         
         // Get penalty parameter
-        const T mu = penalty / element.getCellSize();
+        const T h = element.getCellSize();
+        const T mu = penalty / (0!=h?h:2);
 
         // Sum up quadrature point evaluations
         localRhs.noalias() -= weight * (( pGrads.transpose() * unormal - mu * bVals )

--- a/src/gsAssembler/gsVisitorNitsche.h
+++ b/src/gsAssembler/gsVisitorNitsche.h
@@ -135,7 +135,7 @@ public:
         
         // Get penalty parameter
         const T h = element.getCellSize();
-        const T mu = penalty / (0!=h?h:2);
+        const T mu = penalty / (0!=h?h:1);
 
         // Sum up quadrature point evaluations
         localRhs.noalias() -= weight * (( pGrads.transpose() * unormal - mu * bVals )

--- a/src/gsAssembler/gsVisitorNitscheBiharmonic.h
+++ b/src/gsAssembler/gsVisitorNitscheBiharmonic.h
@@ -117,7 +117,8 @@ public:
         geoEval.transformLaplaceHgrad(k, basisGrads, basis2ndDerivs, physBasisLaplace);
         
         // Get penalty parameter
-        const T mu = penalty / element.getCellSize();
+        const T h = element.getCellSize();
+        const T mu = penalty / (0!=h?h:2);
 
         // Sum up quadrature point evaluations
         localRhs.noalias() += weight * (( physBasisLaplace.transpose() + mu * physBasisGrads.transpose() * unormal )

--- a/src/gsAssembler/gsVisitorNitscheBiharmonic.h
+++ b/src/gsAssembler/gsVisitorNitscheBiharmonic.h
@@ -118,7 +118,7 @@ public:
         
         // Get penalty parameter
         const T h = element.getCellSize();
-        const T mu = penalty / (0!=h?h:2);
+        const T mu = penalty / (0!=h?h:1);
 
         // Sum up quadrature point evaluations
         localRhs.noalias() += weight * (( physBasisLaplace.transpose() + mu * physBasisGrads.transpose() * unormal )


### PR DESCRIPTION
In the 1D case with Nitsche's method for BC, we have element.getCellSize() = 0, leading to mu = Inf

Therefore, the following updates are proposed. 

-----
