### PR TITLE
Permutation of dofmapper indices

### DIFF
--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -319,8 +319,8 @@ void gsDofMapper::permuteFreeDofs(const gsVector<index_t>& permutation)
             if(is_tagged_index(idx))
                 tagged_permuted.push_back(m_dofs[i]);
         }
-        else if(is_tag_index(idx)) //Take care about eliminated tagged dofs
-	    tagged.push_back(idx);
+        else if(is_tagged_index(idx)) //Take care about eliminated tagged dofs
+            tagged_permuted.push_back(idx);
     }
     m_tagged.swap(tagged_permuted);
 

--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -285,7 +285,7 @@ void gsDofMapper::setIdentity(index_t nPatches, size_t nDofs)
     m_dofs.resize( m_numFreeDofs, 0);
 }
 
-void gsDofMapper::permuteFree(const gsVector<index_t>& permutation)
+void gsDofMapper::permuteFreeDofs(const gsVector<index_t>& permutation)
 {
     GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
     GISMO_ASSERT(m_numFreeDofs == permutation.size(), "permutation size does not match number of free dofs");

--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -186,6 +186,11 @@ void gsDofMapper::markCoupledAsTagged()
     m_tagged.reserve(m_tagged.size()+m_numCpldDofs);
     for(int i=0; i< m_numCpldDofs;++i)
         m_tagged.push_back(m_numFreeDofs-m_numCpldDofs+i);
+    
+    //sort and delete the duplicated ones
+    std::sort(m_tagged.begin(),m_tagged.end());
+    std::vector<index_t>::iterator it = std::unique(m_tagged.begin(),m_tagged.end());
+    m_tagged.resize( std::distance(m_tagged.begin(),it) );
 }
 
 void gsDofMapper::eliminateDof( index_t i, index_t k )

--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -18,11 +18,9 @@ namespace gismo
 {
 
 gsDofMapper::gsDofMapper() : 
-m_shift(0), m_numFreeDofs(0), m_numCpldDofs(1), m_curElimId(-1)
+m_shift(0), m_numFreeDofs(0), m_numCpldDofs(1), m_curElimId(-1),m_isPermuted(false)
 { 
     m_offset.resize(1,0);
-
-    m_isPermuted = false;
 }
 
 
@@ -296,7 +294,7 @@ void gsDofMapper::permuteFreeDofs(const gsVector<index_t>& permutation)
     std::vector<index_t> dofs = m_dofs;
     m_isCoupledIdx.clear();
     m_isCoupledIdx.resize(m_numFreeDofs,false);
-    m_coupledIdxCount.clear();
+    m_coupledIndexNumber.clear();
 
     index_t cIdx = 0;
     for(index_t i=0; i<(index_t)dofs.size();++i)
@@ -309,7 +307,7 @@ void gsDofMapper::permuteFreeDofs(const gsVector<index_t>& permutation)
             if(is_coupled_index(idx) && m_isCoupledIdx[permutation[idx]] == false)
             {
                 m_isCoupledIdx[permutation[idx]]=true;
-                m_coupledIdxCount.insert(std::make_pair(permutation[idx],cIdx));
+                m_coupledIndexNumber.insert(std::make_pair(permutation[idx],cIdx));
                 cIdx++;
             }
         }
@@ -328,7 +326,7 @@ void gsDofMapper::permute(const gsVector<index_t>& permutation)
     std::vector<index_t> dofs = m_dofs;
     m_isCoupledIdx.clear();
     m_isCoupledIdx.resize(m_numFreeDofs,false);
-    m_coupledIdxCount.clear();
+    m_coupledIndexNumber.clear();
 
     index_t cIdx = 0;
     for(index_t i=0; i<(index_t)m_dofs.size();++i)
@@ -339,7 +337,7 @@ void gsDofMapper::permute(const gsVector<index_t>& permutation)
         if(is_coupled_index(idx)  && m_isCoupledIdx[permutation[idx]] == false )
         {
             m_isCoupledIdx[permutation[idx]]=true;
-            m_coupledIdxCount.insert(std::make_pair(permutation[idx],cIdx));
+            m_coupledIndexNumber.insert(std::make_pair(permutation[idx],cIdx));
             cIdx++;
         }
     }

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -250,8 +250,9 @@ public:
     void setShift(index_t shift);
 
     /// \brief Permutes the mapped free indices according to permutation, i.e.,  dofs_perm[idx] = dofs_old[permutation[idx]]
-    /// Important: Applying a permutation makes the functions regarding coupled dofs (cindex, is_coupled_index,.. ) invalid.
-    /// The dofs are still coupled, but you have now way of extracting them. If you need this functions, first call
+    ///
+    /// \Warning Applying a permutation makes the functions regarding coupled dofs (cindex, is_coupled_index,.. ) invalid.
+    /// The dofs are still coupled, but you have no way of extracting them. If you need this functions, first call
     /// markCoupledAsTagged() and then use the corresponding functions for tagged dofs.
     void permuteFreeDofs(const gsVector<index_t>& permutation);
 

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -245,7 +245,7 @@ public:
 
     /// \brief Permutes the mapped free indices according to permutation, i.e.,  dofs_perm[idx] = dofs_old[permutation[idx]]
     /// Permutation can be performed only once.
-    void permuteFree(const gsVector<index_t>& permutation);
+    void permuteFreeDofs(const gsVector<index_t>& permutation);
 
     /// \brief Permutes all the mapped indices according to permutation (including the eliminated ones),
     /// i.e.,  dofs_perm[idx] = dofs_old[permutation[idx]]. Permutation can be performed only once.

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -321,7 +321,7 @@ public:
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
         if(m_isPermuted) 
-            return m_coupledIdxCount.find(MAPPER_PATCH_DOF(i,k))->second;
+            return m_coupledIndexNumber.find(MAPPER_PATCH_DOF(i,k))->second;
         else
             return MAPPER_PATCH_DOF(i,k) + m_numCpldDofs - m_numFreeDofs;
     }
@@ -464,7 +464,7 @@ private:
     //vector of length m_numFreeDofs, which stores if a dof is also coupled. (only used after permutation)
     std::vector<bool> m_isCoupledIdx;
     //maps a coupled index to its corresponding number, i.e. 22 -> 2, the free dof 22 is the third coupled index (only used after permutation)
-    std::map<index_t,index_t> m_coupledIdxCount;
+    std::map<index_t,index_t> m_coupledIndexNumber;
 
 }; // class gsDofMapper
 


### PR DESCRIPTION
This should allows for more flexibility, when using the dofmapper. The user can now permute the ordering of the dofs. The only restriction is, that the eliminated dofs have to be still ordered last (makes no sense otherwise).  Moreover, it is only allowed to perform a  permutation once (see also flag m_isPermuted). This could be implemented at some point, but I think is not required now. The permutation can be combined before.

It is then getting a bit more complex with the coupled dofs, since they may be mixed with the pure free dofs. In order to have a fast checking if a dofs is coupled (and which coupled idx it is), while having a small memory consumption, additional members are added to store precomputed information. Other functions are not affected.

