### PR TITLE
Make Eigen exceptions to behave like G+Smo exceptions

### DIFF
--- a/src/gsCore/gsLinearAlgebra.h
+++ b/src/gsCore/gsLinearAlgebra.h
@@ -17,6 +17,11 @@
 #include <gsCore/gsMath.h>
 
 // Eigen linear algebra library (http://eigen.tuxfamily.org)
+
+// Make Eigen use GISMO_ASSERT which throws exceptions
+//
+// Must be defined before including Eigen headers
+// https://eigen.tuxfamily.org/dox/classEigen_1_1SelfAdjointView.html
 #define eigen_assert( cond ) GISMO_ASSERT( cond, "" )
 
 // Plugin provides extra members

--- a/src/gsCore/gsLinearAlgebra.h
+++ b/src/gsCore/gsLinearAlgebra.h
@@ -21,7 +21,7 @@
 // Make Eigen use GISMO_ASSERT which throws exceptions
 //
 // Must be defined before including Eigen headers
-// https://eigen.tuxfamily.org/dox/classEigen_1_1SelfAdjointView.html
+// http://eigen.tuxfamily.org/dox-3.2/TopicPreprocessorDirectives.html
 #define eigen_assert( cond ) GISMO_ASSERT( cond, "" )
 
 // Plugin provides extra members

--- a/src/gsCore/gsLinearAlgebra.h
+++ b/src/gsCore/gsLinearAlgebra.h
@@ -17,6 +17,7 @@
 #include <gsCore/gsMath.h>
 
 // Eigen linear algebra library (http://eigen.tuxfamily.org)
+#define eigen_assert( cond ) GISMO_ASSERT( cond, "" )
 
 // Plugin provides extra members
 #define EIGEN_MATRIXBASE_PLUGIN <gsMatrix/gsMatrixAddons.h>


### PR DESCRIPTION
Eigen's assertions call abort. This is not good if they happen within unittests. So, we might have thmen to throw exceptions, as GISMO_ASSERT does.

Defining such a macro is a customization point in Eigen:

http://eigen.tuxfamily.org/dox-3.2/TopicPreprocessorDirectives.html