### PR TITLE
Bugfix in GMRES

### DIFF
--- a/src/gsSolver/gsGMRes.hpp
+++ b/src/gsSolver/gsGMRes.hpp
@@ -103,8 +103,8 @@ bool gsGMRes<T>::step( typename gsGMRes<T>::VectorType& x )
     }
     h_tmp(k+1,0) = w.norm();
 
-    if (math::abs(h_tmp(k+1,0)) < 1e-16) //If exact solution
-        return true;
+  //  if (math::abs(h_tmp(k+1,0)) < 1e-16) //If exact solution
+  //      return true;
 
     v.push_back(w/h_tmp(k+1,0));
 


### PR DESCRIPTION
early exit in this function leads to a mismatch of matrix sizes later in gsGMRes<T>::finalizeIteration() with the effect that it crashes in line 49. 
Anyway I dont see a reason why this check is needed, the normal exit should be sufficient.
