### PR TITLE
gsAssemblerBase: use give for gsMultiPatch (rvalue instead of lvalue)

### DIFF
--- a/src/gsAssembler/gsAssemblerBase.h
+++ b/src/gsAssembler/gsAssemblerBase.h
@@ -95,7 +95,7 @@ public:
                     gsMultiBasis<T> const         & basis,
                     gsBoundaryConditions<T> const & bconditions)
     {
-        m_patches = patches;
+        m_patches = give(patches);
         m_bases.clear();
         m_bases.push_back(basis);
         m_bConditions = bconditions;

--- a/src/gsAssembler/gsAssemblerBase.h
+++ b/src/gsAssembler/gsAssemblerBase.h
@@ -77,7 +77,6 @@ public:
                     gsStdVectorRef<gsMultiBasis<T> > const & bases,
                     gsBoundaryConditions<T> const          & bconditions)
     {
-
         m_patches = give(patches);
         m_bases.clear();
         m_bases = bases;

--- a/src/gsAssembler/gsAssemblerBase.h
+++ b/src/gsAssembler/gsAssemblerBase.h
@@ -73,11 +73,12 @@ public:
     /// using a multi-patch, a vector of multi-basis and boundary conditions.
     /// \note Rest of the data fields should be initialized in the
     /// derived function initializePdeSpecific() .
-    void initialize(const gsMultiPatch<T>                   & patches,
-                    gsStdVectorRef<gsMultiBasis<T> > const   & bases,
-                    gsBoundaryConditions<T> const           & bconditions)
+    void initialize(gsMultiPatch<T>                          patches,
+                    gsStdVectorRef<gsMultiBasis<T> > const & bases,
+                    gsBoundaryConditions<T> const          & bconditions)
     {
-        m_patches = patches;
+
+        m_patches = give(patches);
         m_bases.clear();
         m_bases = bases;
         m_bConditions = bconditions;
@@ -90,7 +91,7 @@ public:
     /// using a multi-patch, a multi-basis and boundary conditions.
     /// \note Rest of the data fields should be initialized in the
     /// derived function initializePdeSpecific() .
-    void initialize(const gsMultiPatch<T>         & patches,
+    void initialize(gsMultiPatch<T>                 patches,
                     gsMultiBasis<T> const         & basis,
                     gsBoundaryConditions<T> const & bconditions)
     {
@@ -104,13 +105,13 @@ public:
     }
 
     // Same as initialize with options
-    void initialize(const gsMultiPatch<T>         & patches,
+    void initialize(gsMultiPatch<T>                 patches,
                     gsMultiBasis<T> const         & basis,
                     gsBoundaryConditions<T> const & bconditions,
                     gsAssemblerOptions      const & options )
     {
         m_options = options;
-        initialize(patches, basis, bconditions);
+        initialize(give(patches), basis, bconditions);
     }
 
     /// @brief Intitialize function for single patch assembling, sets data fields


### PR DESCRIPTION
use give for assignment of gsMultiPatch (rvalue instead of lvalue)