### PR TITLE
add patchSide::getContainedCorners (int dim, std::vector<patchCorner> &corners)

### DIFF
--- a/src/gsCore/gsBoundary.cpp
+++ b/src/gsCore/gsBoundary.cpp
@@ -32,6 +32,16 @@ void boxSide::getContainedCorners (int dim, std::vector<boxCorner> &corners) con
     }
 }
 
+void patchSide::getContainedCorners (int dim, std::vector<patchCorner> &corners) const
+{
+    std::vector<boxCorner> tmp;
+    boxSide::getContainedCorners(dim, tmp);
+    corners.resize(0);
+    corners.reserve(tmp.size());
+    for (std::vector<boxCorner>::iterator it=tmp.begin(); it<tmp.end(); ++it)
+        corners.push_back( patchCorner(patch, *it) );
+}
+
 void boundaryInterface::faceData(gsVector<bool> & flip, gsVector<index_t> & perm) const
 { 
     const index_t d = directionMap.size();

--- a/src/gsCore/gsBoundary.cpp
+++ b/src/gsCore/gsBoundary.cpp
@@ -21,7 +21,7 @@ namespace gismo {
 void boxSide::getContainedCorners (int dim, std::vector<boxCorner> &corners) const
 {
     GISMO_ASSERT(dim>=0, "Dimension must be non negative");
-    corners.resize(0);
+    corners.clear();
     corners.reserve( 1ULL<<(dim-1) );
     const index_t dir = direction();
     const bool    par = parameter();
@@ -36,7 +36,7 @@ void patchSide::getContainedCorners (int dim, std::vector<patchCorner> &corners)
 {
     std::vector<boxCorner> tmp;
     boxSide::getContainedCorners(dim, tmp);
-    corners.resize(0);
+    corners.clear();
     corners.reserve(tmp.size());
     for (std::vector<boxCorner>::iterator it=tmp.begin(); it<tmp.end(); ++it)
         corners.push_back( patchCorner(patch, *it) );

--- a/src/gsCore/gsBoundary.h
+++ b/src/gsCore/gsBoundary.h
@@ -247,6 +247,8 @@ public:
      */
     void getContainedCorners (int dim, std::vector<patchCorner> &corners) const;
 
+    using boxSide::getContainedCorners; // unhiding
+
     bool operator== (const patchSide & other) const
     {
         return patch==other.patch && m_index==other.m_index;

--- a/src/gsCore/gsBoundary.h
+++ b/src/gsCore/gsBoundary.h
@@ -240,6 +240,13 @@ public:
     boxSide& side()       {return *this;}
     const boxSide& side() const {return *this;}
 
+    /**
+     * @brief returns the vector of the corners contained in the side
+     * @param dim is the ambient dimension
+     * @param corners
+     */
+    void getContainedCorners (int dim, std::vector<patchCorner> &corners) const;
+
     bool operator== (const patchSide & other) const
     {
         return patch==other.patch && m_index==other.m_index;

--- a/src/gsCore/gsBoundary.h
+++ b/src/gsCore/gsBoundary.h
@@ -68,7 +68,9 @@ struct boundary
     };
 };
 
-struct boxCorner;// defined later
+// forward declarations; defined later
+struct boxCorner;
+struct patchCorner;
 
 /**
    @brief Struct which represents a certain side of a box.


### PR DESCRIPTION
We can ask a patchCorner for the coressponding patchSides, but we cannot ask a patchSide for the corresponding patchCorners.

This commit fixes that.
