### PR TITLE
Updated documentation

### DIFF
--- a/cmake/gsConfig.cmake
+++ b/cmake/gsConfig.cmake
@@ -46,7 +46,7 @@ if(NOT GISMO_INDEX_TYPE)
    set (GISMO_INDEX_TYPE "int" CACHE STRING
    #math(EXPR BITSZ_VOID_P "8*${CMAKE_SIZEOF_VOID_P}")
    #set (GISMO_INDEX_TYPE "int${BITSZ_VOID_P}_t" CACHE STRING
-   "Index type(int, unsigned, size_t)" FORCE)
+   "Index type(int, int32_t, int64_t, unsigned, size_t)" FORCE)
    set_property(CACHE GISMO_INDEX_TYPE PROPERTY STRINGS
    "int" "int32_t" "int64_t" "unsigned" "size_t" )
 endif()


### PR DESCRIPTION
Updated documentation about `index_t` to include `int32_t` and `int64_t` in the CMake documentation.