### PR TITLE
fix error in gsBasis

### DIFF
--- a/src/gsCore/gsBasis.hpp
+++ b/src/gsCore/gsBasis.hpp
@@ -435,7 +435,7 @@ const gsBasis<T>& gsBasis<T>::component(unsigned i) const
 
 template<class T>
 gsBasis<T>& gsBasis<T>::component(unsigned i)
-{ return const_cast<gsBasis<T>&>(component(i));}
+{ return const_cast<gsBasis<T>&>(const_cast<const gsBasis<T>*>(this)->component(i));}
 
 template<class T>
 void gsBasis<T>::refine(gsMatrix<T> const & boxes, int refExt)


### PR DESCRIPTION
clang claims:

src/gsCore/gsBasis.hpp:438:1: warning: all paths through this function will call itself [-Winfinite-recursion]

and I concur.

I do not know if this is the best possible fix.