### PR TITLE
Improved readability of gsOption.cmake/gsConfig.h.in and top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,31 +152,12 @@ if(GISMO_WITH_CODIPACK)
   include_directories(${CODIPACK_INCLUDE_DIR})
 endif(GISMO_WITH_CODIPACK)
 
-#include_directories(${METIS_INCLUDE_DIR})
-#set(gismo_LINKER ${gismo_LINKER} ${METIS_LIBRARIES}
-#    CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
-
-if(GISMO_WITH_PSOLID)
-  add_subdirectory(extensions/gsParasolid)
-endif(GISMO_WITH_PSOLID)
-
-if(GISMO_WITH_ONURBS)
-  add_subdirectory(extensions/gsOpennurbs)
-endif(GISMO_WITH_ONURBS)
-
 if(GISMO_WITH_FDBB)
   add_subdirectory(extensions/gsFdbb)
   set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${FDBB_INCLUDE_DIR}
   CACHE INTERNAL "${PROJECT_NAME} include directories")
   include_directories(${FDBB_INCLUDE_DIR})
 endif(GISMO_WITH_FDBB)
-
-if(GISMO_WITH_SPECTRA)
-  add_subdirectory(extensions/gsSpectra)
-  set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${SPECTRA_INCLUDE_DIR}
-  CACHE INTERNAL "${PROJECT_NAME} include directories")
-  include_directories(${SPECTRA_INCLUDE_DIR})
-endif(GISMO_WITH_SPECTRA)
 
 if(GISMO_WITH_IPOPT)
   add_subdirectory(extensions/gsIpopt)
@@ -185,12 +166,48 @@ if(GISMO_WITH_IPOPT)
   #include_directories(${IPOPT_INCLUDE_DIR})
 endif(GISMO_WITH_IPOPT)
 
+#if(GISMO_WITH_METIS)
+#include_directories(${METIS_INCLUDE_DIR})
+#set(gismo_LINKER ${gismo_LINKER} ${METIS_LIBRARIES}
+#    CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
+#endif(GISMO_WITH_METIS)
+
+if(GISMO_WITH_MPI)
+  find_package(MPI REQUIRED)
+  set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${MPI_INCLUDE_PATH}
+  CACHE INTERNAL "${PROJECT_NAME} include directories")
+  set(gismo_LINKER ${gismo_LINKER} ${MPI_CXX_LIBRARIES}
+  CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
+  include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+endif(GISMO_WITH_MPI)
+
+if(GISMO_WITH_ONURBS)
+  add_subdirectory(extensions/gsOpennurbs)
+endif(GISMO_WITH_ONURBS)
+
+if(GISMO_WITH_PARDISO)
+endif(GISMO_WITH_PARDISO)
+
+if(GISMO_WITH_PASTIX)
+endif(GISMO_WITH_PASTIX)
+
+if(GISMO_WITH_PSOLID)
+  add_subdirectory(extensions/gsParasolid)
+endif(GISMO_WITH_PSOLID)
+
+if(GISMO_WITH_SPECTRA)
+  add_subdirectory(extensions/gsSpectra)
+  set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${SPECTRA_INCLUDE_DIR}
+  CACHE INTERNAL "${PROJECT_NAME} include directories")
+  include_directories(${SPECTRA_INCLUDE_DIR})
+endif(GISMO_WITH_SPECTRA)
+
 if(GISMO_WITH_SUPERLU)
   find_package(SuperLU REQUIRED)
   set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${SUPERLU_INCLUDES}
   CACHE INTERNAL "${PROJECT_NAME} include directories")
   set(gismo_LINKER ${gismo_LINKER} ${SUPERLU_LIBRARIES}
-    CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
+  CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
   include_directories(SYSTEM ${SUPERLU_INCLUDES})
 endif(GISMO_WITH_SUPERLU)
 
@@ -199,7 +216,7 @@ if(GISMO_WITH_TAUCS)
   set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${TAUCS_INCLUDES}
   CACHE INTERNAL "${PROJECT_NAME} include directories")
   set(gismo_LINKER ${gismo_LINKER} ${TAUCS_LIBRARIES}
-    CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
+  CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
   include_directories(SYSTEM ${SUPERLU_INCLUDES})
 endif(GISMO_WITH_TAUCS)
 
@@ -208,27 +225,9 @@ if(GISMO_WITH_UMFPACK)
   set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${UMFPACK_INCLUDES}
   CACHE INTERNAL "${PROJECT_NAME} include directories")
   set(gismo_LINKER ${gismo_LINKER} ${UMFPACK_LIBRARIES}
-    CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
+  CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
   include_directories(SYSTEM ${UMFPACK_INCLUDES})
 endif(GISMO_WITH_UMFPACK)
-
-#if(GISMO_WITH_METIS)
-
-if(GISMO_WITH_MPI)
-  find_package(MPI REQUIRED)
-  set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${MPI_INCLUDE_PATH}
-  CACHE INTERNAL "${PROJECT_NAME} include directories")
-  set(gismo_LINKER ${gismo_LINKER} ${MPI_CXX_LIBRARIES}
-    CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
-  include_directories(SYSTEM ${MPI_INCLUDE_PATH})
-endif(GISMO_WITH_MPI)
-
-if(GISMO_WITH_TRILINOS)
-  add_subdirectory(extensions/gsTrilinos)
-  set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${TRILINOS_INCLUDE_DIR} 
-    CACHE INTERNAL "${PROJECT_NAME} include directories") 
-  include_directories(${TRILINOS_INCLUDE_DIR})
-endif(GISMO_WITH_TRILINOS)
 
 if(GISMO_WITH_UNUM)
   add_subdirectory(extensions/gsUnum)
@@ -236,6 +235,13 @@ if(GISMO_WITH_UNUM)
   CACHE INTERNAL "${PROJECT_NAME} include directories")
   include_directories(${UNUM_INCLUDE_DIR})
 endif(GISMO_WITH_UNUM)
+
+if(GISMO_WITH_TRILINOS)
+  add_subdirectory(extensions/gsTrilinos)
+  set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${TRILINOS_INCLUDE_DIR} 
+  CACHE INTERNAL "${PROJECT_NAME} include directories") 
+  include_directories(${TRILINOS_INCLUDE_DIR})
+endif(GISMO_WITH_TRILINOS)
 
 ## #################################################################
 ## Build G+Smo library instantized for GISMO_COEFF_TYPE number type
@@ -275,14 +281,17 @@ if(GISMO_BUILD_AXL)
   add_subdirectory(plugins/gsAxel)
 endif(GISMO_BUILD_AXL)
 
-if(GISMO_BUILD_RHINOPLUGINS)
-  add_subdirectory(plugins/RhinoTHBSplines)
-endif(GISMO_BUILD_RHINOPLUGINS)
-
 if(GISMO_BUILD_MEX)
   add_subdirectory(plugins/gsMex)
 endif(GISMO_BUILD_MEX)
 
+if(GISMO_BUILD_PVIEW)
+  add_subdirectory(plugins/gsParaview)
+endif(GISMO_BUILD_PVIEW)
+
+if(GISMO_BUILD_RHINOPLUGINS)
+  add_subdirectory(plugins/RhinoTHBSplines)
+endif(GISMO_BUILD_RHINOPLUGINS)
 
 ## #################################################################
 ## Install

--- a/cmake/gsConfig.cmake
+++ b/cmake/gsConfig.cmake
@@ -31,16 +31,18 @@ endif()
 # Set a default coefficient numeric types if not specified
 if(NOT GISMO_COEFF_TYPE)
   set (GISMO_COEFF_TYPE "double" CACHE STRING
-   "Coefficient type(float, double, long double, mpfr::mpreal, mpq_class)" FORCE)
+   "Coefficient type(float, double, long double, mpfr::mpreal, mpq_class, posit_32_2)" FORCE)
 elseif(${GISMO_COEFF_TYPE} STREQUAL "mpfr::mpreal")
   set(GISMO_WITH_MPFR ON CACHE INTERNAL "Use MPFR")
   set(GISMO_WITH_MPQ OFF CACHE INTERNAL "Use GMP/mpq_class")
 elseif(${GISMO_COEFF_TYPE} STREQUAL "mpq_class")
   set(GISMO_WITH_MPQ ON CACHE INTERNAL "Use GMP/mpq_class")
   set(GISMO_WITH_MPFR OFF CACHE INTERNAL "Use MPFR")
+elseif(${GISMO_COEFF_TYPE} STREQUAL "posit_32_2")
+  set(GISMO_WITH_UNUM ON CACHE INTERNAL "Use UNUM")
 endif()
 set_property(CACHE GISMO_COEFF_TYPE PROPERTY STRINGS
-"float" "double" "long double" "mpfr::mpreal" "mpq_class")
+"float" "double" "long double" "mpfr::mpreal" "mpq_class" "posit_32_2")
 
 if(NOT GISMO_INDEX_TYPE)
    set (GISMO_INDEX_TYPE "int" CACHE STRING

--- a/cmake/gsOptions.cmake
+++ b/cmake/gsOptions.cmake
@@ -6,134 +6,197 @@
 ## Copyright (C) 2012 - 2016 RICAM-Linz.
 ######################################################################
 
-#macro(print_gismo_option NAME)
-##option(${NAME} ${DESCR} false)
-#if (${NAME})
-#  message ("  ${NAME}        ${${NAME}}")
-#endif()
-#endmacro(print_gismo_option)
-
-## #################################################################
-## Options list
-## #################################################################
-
-#Standard options
-option(GISMO_EXTRA_DEBUG         "Extra debug features"      false  )
-option(GISMO_BUILD_LIB           "Build shared library"      true   )
-option(GISMO_BUILD_PCH           "Build precompiled headers" false  )
-option(GISMO_BUILD_EXAMPLES      "Build examples"            true   )
-option(GISMO_BUILD_UNITTESTS     "Build unittests"           false  )
-option(GISMO_BUILD_AXL           "Build Axel Plugin"         false  )
-option(GISMO_BUILD_RHINOPLUGINS  "Build Rhino THB Plugins"   false  )
-option(GISMO_BUILD_PVIEW         "Build Paraview Plugin"     false  )
-option(GISMO_BUILD_MEX           "Build Mex files"           false  )
-option(GISMO_WITH_OPENMP         "With OpenMP"               false  )
-option(GISMO_WITH_MPI            "With MPI"                  false  )
-option(GISMO_WITH_PSOLID         "With Parasolid"            false  )
-option(GISMO_WITH_ONURBS         "With OpenNurbs"            false  )
-option(GISMO_WITH_FDBB           "With FDBB"                 false  )
-option(GISMO_WITH_IPOPT          "With IpOpt"                false  )
-option(GISMO_WITH_ADIFF          "With auto-diff"            false  )
-option(GISMO_WITH_CODIPACK       "With CoDiPack"             false  )
-option(GISMO_WITH_SUPERLU        "With SuperLU"              false  )
-option(GISMO_WITH_TAUCS          "With Taucs"                false  )
-option(GISMO_WITH_UMFPACK        "With Umfpack"              false  )
-option(GISMO_WITH_PARDISO        "With PARDISO"              false  )
-#option(GISMO_WITH_METIS          "With METIS"                false )
-option(GISMO_WITH_TRILINOS       "With TRILINOS"             false  )
-option(GISMO_WITH_PASTIX         "With PastiX"               false  )
-option(GISMO_WITH_SPECTRA        "With Spectra"              false  )
-option(GISMO_WITH_UNUM           "With Universal NUMber"     false  )
-
-#Extra options
-option(GISMO_BUILD_QT_APP        "Build Qt application"          false  )
-option(GISMO_WARNINGS            "Enable G+Smo related warnings" false)
-#option(GISMO_WITH_VTK            "With VTK"                      false  )
-option(GISMO_BUILD_CPPLOT        "Build cpplot"                  false  )
-option(EIGEN_USE_MKL_ALL         "Eigen use MKL"                 false  )
-if(CMAKE_COMPILER_IS_GNUCXX)
- option(GISMO_BUILD_COVERAGE      "Build with coverage"          false )
-endif(CMAKE_COMPILER_IS_GNUCXX)
-
 message ("Configuration (cmake ${CMAKE_VERSION}):")
+
 message ("  Source folder:          ${CMAKE_SOURCE_DIR}")
 message ("  CMAKE_BUILD_TYPE        ${CMAKE_BUILD_TYPE}")
-message ("  GISMO_COEFF_TYPE        ${GISMO_COEFF_TYPE}")
-message ("  GISMO_BUILD_LIB         ${GISMO_BUILD_LIB}")
 message ("  CMAKE_C_COMPILER        ${CMAKE_C_COMPILER}")
 message ("  CMAKE_CXX_COMPILER      ${CMAKE_CXX_COMPILER}")
 message ("  CMAKE_CXX_STANDARD      ${CMAKE_CXX_STANDARD}")
 
-if (${GISMO_BUILD_PCH})
-message ("  GISMO_BUILD_PCH         ${GISMO_BUILD_PCH}")
-endif()
-if (${GISMO_EXTRA_DEBUG})
-message ("  GISMO_EXTRA_DEBUG       ${GISMO_EXTRA_DEBUG}")
-endif()
-if (${GISMO_BUILD_EXAMPLES})
-message ("  GISMO_BUILD_EXAMPLES    ${GISMO_BUILD_EXAMPLES}")
-endif()
-if (${GISMO_BUILD_UNITTESTS})
-message ("  GISMO_BUILD_UNITTESTS   ${GISMO_BUILD_UNITTESTS}")
-endif()
-if (${GISMO_BUILD_AXL})
+message ("  GISMO_COEFF_TYPE        ${GISMO_COEFF_TYPE}")
+message ("  GISMO_INDEX_TYPE        ${GISMO_INDEX_TYPE}")
+
+## #################################################################
+## Options list: Standard options
+## #################################################################
+
+option(GISMO_BUILD_AXL           "Build Axel Plugin"         false  )
+if  (${GISMO_BUILD_AXL})
 message ("  GISMO_BUILD_AXL         ${GISMO_BUILD_AXL}")
 endif()
-#message ("  GISMO_BUILD_PVIEW       ${GISMO_BUILD_PVIEW}")
+
+option(GISMO_BUILD_EXAMPLES      "Build examples"            true   )
+if  (${GISMO_BUILD_EXAMPLES})
+message ("  GISMO_BUILD_EXAMPLES    ${GISMO_BUILD_EXAMPLES}")
+endif()
+
+option(GISMO_BUILD_LIB           "Build shared library"      true   )
+message ("  GISMO_BUILD_LIB         ${GISMO_BUILD_LIB}")
+
+option(GISMO_BUILD_MEX           "Build Mex files"           false  )
+if  (${GISMO_BUILD_MEX})
 message ("  GISMO_BUILD_MEX         ${GISMO_BUILD_MEX}")
-#message ("  GISMO_WITH_OPENMP       ${GISMO_WITH_OPENMP}")
-if (${GISMO_WITH_PSOLID})
-message ("  GISMO_WITH_PSOLID       ${GISMO_WITH_PSOLID}")
 endif()
-#message ("  GISMO_WITH_MPFR         ${GISMO_WITH_MPFR}")
-if (${GISMO_WITH_ONURBS})
-message ("  GISMO_WITH_ONURBS       ${GISMO_WITH_ONURBS}")
+
+option(GISMO_BUILD_PCH           "Build precompiled headers" false  )
+if  (${GISMO_BUILD_PCH})
+message ("  GISMO_BUILD_PCH         ${GISMO_BUILD_PCH}")
 endif()
-if (${GISMO_WITH_FDBB})
-message ("  GISMO_WITH_FDBB         ${GISMO_WITH_FDBB}")
+
+option(GISMO_BUILD_PVIEW         "Build Paraview Plugin"     false  )
+if  (${GISMO_BUILD_PVIEW})
+message ("  GISMO_BUILD_PVIEW        ${GISMO_BUILD_VIEW}")
 endif()
-if (${GISMO_WITH_IPOPT})
-message ("  GISMO_WITH_IPOPT        ${GISMO_WITH_IPOPT}")
+
+option(GISMO_BUILD_RHINOPLUGINS  "Build Rhino THB Plugins"   false  )
+if  (${GISMO_BUILD_RHINOPLUGINS})
+message ("  GISMO_BUILD_RHINOPLUGINS ${GISMO_BUILD_RHINOPLUGINS}")
 endif()
-if (${GISMO_WITH_SUPERLU})
-message ("  GISMO_WITH_SUPERLU      ${GISMO_WITH_SUPERLU}")
+
+option(GISMO_BUILD_UNITTESTS     "Build unittests"           false  )
+if  (${GISMO_BUILD_UNITTESTS})
+message ("  GISMO_BUILD_UNITTESTS   ${GISMO_BUILD_UNITTESTS}")
 endif()
-if (${GISMO_WITH_TAUCS})
-message ("  GISMO_WITH_TAUCS        ${GISMO_WITH_TAUCS}")
+
+option(GISMO_EXTRA_DEBUG         "Extra debug features"      false  )
+if  (${GISMO_EXTRA_DEBUG})
+message ("  GISMO_EXTRA_DEBUG       ${GISMO_EXTRA_DEBUG}")
 endif()
-if (${GISMO_WITH_UMFPACK})
-message ("  GISMO_WITH_UMFPACK      ${GISMO_WITH_UMFPACK}")
-endif()
-if (${GISMO_WITH_PARDISO})
-message ("  GISMO_WITH_PARDISO      ${GISMO_WITH_PARDISO}")
-endif()
-if (${GISMO_WITH_TRILINOS})
-message ("  GISMO_WITH_TRILINOS     ${GISMO_WITH_TRILINOS}")
-endif()
-if (${GISMO_WITH_OPENMP})
-message ("  GISMO_WITH_OPENMP       ${GISMO_WITH_OPENMP}")
-endif()
-if (${GISMO_WITH_MPI})
-message ("  GISMO_WITH_MPI          ${GISMO_WITH_MPI}")
-endif()
-if (${GISMO_WITH_ADIFF})
+
+option(GISMO_WITH_ADIFF          "With auto-diff"            false  )
+if  (${GISMO_WITH_ADIFF})
 message ("  GISMO_WITH_ADIFF        ${GISMO_WITH_ADIFF}")
 endif()
-if (${GISMO_WITH_CODIPACK})
+
+option(GISMO_WITH_CODIPACK       "With CoDiPack"             false  )
+if  (${GISMO_WITH_CODIPACK})
 message ("  GISMO_WITH_CODIPACK     ${GISMO_WITH_CODIPACK}")
 endif()
-if (${GISMO_WITH_SPECTRA})
+
+option(GISMO_WITH_FDBB           "With FDBB"                 false  )
+if  (${GISMO_WITH_FDBB})
+message ("  GISMO_WITH_FDBB         ${GISMO_WITH_FDBB}")
+endif()
+
+option(GISMO_WITH_IPOPT          "With IpOpt"                false  )
+if  (${GISMO_WITH_IPOPT})
+message ("  GISMO_WITH_IPOPT        ${GISMO_WITH_IPOPT}")
+endif()
+
+#option(GISMO_WITH_METIS          "With METIS"                false )
+#if  (${GISMO_WITH_METIS})
+#message ("  GISMO_WITH_METIS        ${GISMO_WITH_METIS}")
+#endif()
+
+option(GISMO_WITH_MPFR           "With MPFR"                  false  )
+if  (${GISMO_WITH_MPFR})
+message ("  GISMO_WITH_MPFR         ${GISMO_WITH_MPFR}")
+endif()
+
+option(GISMO_WITH_MPI            "With MPI"                  false  )
+if  (${GISMO_WITH_MPI})
+message ("  GISMO_WITH_MPI          ${GISMO_WITH_MPI}")
+endif()
+
+option(GISMO_WITH_MPQ            "With MPQ"                  false  )
+if  (${GISMO_WITH_MPQ})
+message ("  GISMO_WITH_MPQ          ${GISMO_WITH_MPQ}")
+endif()
+
+option(GISMO_WITH_ONURBS         "With OpenNurbs"            false  )
+if  (${GISMO_WITH_ONURBS})
+message ("  GISMO_WITH_ONURBS       ${GISMO_WITH_ONURBS}")
+endif()
+
+option(GISMO_WITH_OPENMP         "With OpenMP"               false  )
+if  (${GISMO_WITH_OPENMP})
+message ("  GISMO_WITH_OPENMP       ${GISMO_WITH_OPENMP}")
+endif()
+
+option(GISMO_WITH_PARDISO        "With PARDISO"              false  )
+if  (${GISMO_WITH_PARDISO})
+message ("  GISMO_WITH_PARDISO      ${GISMO_WITH_PARDISO}")
+endif()
+
+option(GISMO_WITH_PASTIX         "With PastiX"               false  )
+if  (${GISMO_WITH_PASTIX})
+message ("  GISMO_WITH_PASTIX       ${GISMO_WITH_PASTIX}")
+endif()
+
+option(GISMO_WITH_PSOLID         "With Parasolid"            false  )
+if  (${GISMO_WITH_PSOLID})
+message ("  GISMO_WITH_PSOLID       ${GISMO_WITH_PSOLID}")
+endif()
+
+option(GISMO_WITH_SPECTRA        "With Spectra"              false  )
+if  (${GISMO_WITH_SPECTRA})
 message ("  GISMO_WITH_SPECTRA      ${GISMO_WITH_SPECTRA}")
 endif()
-if (${GISMO_WITH_UNUM})
+
+option(GISMO_WITH_SUPERLU        "With SuperLU"              false  )
+if  (${GISMO_WITH_SUPERLU})
+message ("  GISMO_WITH_SUPERLU      ${GISMO_WITH_SUPERLU}")
+endif()
+
+option(GISMO_WITH_TAUCS          "With Taucs"                false  )
+if  (${GISMO_WITH_TAUCS})
+message ("  GISMO_WITH_TAUCS        ${GISMO_WITH_TAUCS}")
+endif()
+
+option(GISMO_WITH_TRILINOS       "With TRILINOS"             false  )
+if  (${GISMO_WITH_TRILINOS})
+message ("  GISMO_WITH_TRILINOS     ${GISMO_WITH_TRILINOS}")
+endif()
+
+option(GISMO_WITH_UMFPACK        "With Umfpack"              false  )
+if  (${GISMO_WITH_UMFPACK})
+message ("  GISMO_WITH_UMFPACK      ${GISMO_WITH_UMFPACK}")
+endif()
+
+option(GISMO_WITH_UNUM           "With Universal NUMber"     false  )
+if  (${GISMO_WITH_UNUM})
 message ("  GISMO_WITH_UNUM         ${GISMO_WITH_UNUM}")
 endif()
+
+## #################################################################
+## Options list: Extra options
+## #################################################################
+
+option(EIGEN_USE_MKL_ALL         "Eigen use MKL"                 false  )
 if (EIGEN_USE_MKL_ALL)
 message ("  EIGEN_USE_MKL_ALL       ${EIGEN_USE_MKL_ALL}")
 endif()
 
+option(GISMO_BUILD_CPPLOT        "Build cpplot"                  false  )
+if (GISMO_BUILD_CPPLOT)
+message ("  GISMO_BUILD_CPPLOT      ${GISMO_BUILD_CPPLOT}")
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+option(GISMO_BUILD_COVERAGE      "Build with coverage"          false )
+if (GISMO_BUILD_COVERAGE)
+message ("  GISMO_BUILD_COVERAGE    ${GISMO_BUILD_COVERAGE}")
+endif()
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
+option(GISMO_BUILD_QT_APP        "Build Qt application"          false  )
+if (GISMO_BUILD_QT_APP)
+message ("  GISMO_BUILD_QT_APP      ${GISMO_BUILD_QT_APP}")
+endif()
+
+option(GISMO_WARNINGS            "Enable G+Smo related warnings" false  )
+if (GISMO_WARNINGS)
+message ("  GISMO_WARNINGS          ${GISMO_WARNINGS}")
+endif()
+
+option(GISMO_WITH_VTK            "With VTK"                      false  )
+if (GISMO_WITH_VTK)
+message ("  GISMO_WITH_VTK          ${GISMO_WITH_VTK}")
+endif()
+
+
 #https://www.threadingbuildingblocks.org/documentation
 #message ("  GISMO_WITH_ITBB          ${GISMO_WITH_ITBB}")
-
 
 #message(STATUS "Type cmake -LAH to see all variables")

--- a/src/gsCore/gsConfig.h.in
+++ b/src/gsCore/gsConfig.h.in
@@ -43,7 +43,11 @@
 #cmakedefine GISMO_WITH_IPOPT
 #cmakedefine GISMO_WITH_ADIFF
 #cmakedefine GISMO_WITH_CODIPACK
+
 #cmakedefine GISMO_WITH_UNUM
+#ifdef GISMO_WITH_UNUM
+#include <gsUnum/gsUnum.h>
+#endif
 
 #cmakedefine GISMO_WITH_SUPERLU
 #cmakedefine GISMO_WITH_PARDISO
@@ -57,7 +61,6 @@
 #endif
 
 #cmakedefine GISMO_WITH_MPQ
-
 #ifdef GISMO_WITH_MPQ
 #include <gmpxx.h>
 #include <unsupported/Eigen/MPQClassExtra>

--- a/src/gsCore/gsConfig.h.in
+++ b/src/gsCore/gsConfig.h.in
@@ -38,32 +38,35 @@
 #define GISMO_CONFIG_DIR "@GISMO_CONFIG_DIR@"
 
 /* Enabled Extensions */
-#cmakedefine GISMO_WITH_PSOLID
-#cmakedefine GISMO_WITH_ONURBS
-#cmakedefine GISMO_WITH_IPOPT
 #cmakedefine GISMO_WITH_ADIFF
 #cmakedefine GISMO_WITH_CODIPACK
-
-#cmakedefine GISMO_WITH_UNUM
-#ifdef GISMO_WITH_UNUM
-#include <gsUnum/gsUnum.h>
-#endif
-
-#cmakedefine GISMO_WITH_SUPERLU
-#cmakedefine GISMO_WITH_PARDISO
-#cmakedefine GISMO_WITH_TRILINOS
-#cmakedefine GISMO_WITH_PASTIX
-#cmakedefine GISMO_WITH_MPI
-
+#cmakedefine GISMO_WITH_FDBB
+#cmakedefine GISMO_WITH_IPOPT
 #cmakedefine GISMO_WITH_MPFR
+#cmakedefine GISMO_WITH_MPI
+#cmakedefine GISMO_WITH_MPQ
+#cmakedefine GISMO_WITH_ONURBS
+#cmakedefine GISMO_WITH_PARDISO
+#cmakedefine GISMO_WITH_PASTIX
+#cmakedefine GISMO_WITH_PSOLID
+#cmakedefine GISMO_WITH_SPECTRA
+#cmakedefine GISMO_WITH_SUPERLU
+#cmakedefine GISMO_WITH_TAUCS
+#cmakedefine GISMO_WITH_TRILINOS
+#cmakedefine GISMO_WITH_UMFPACK
+#cmakedefine GISMO_WITH_UNUM
+
 #ifdef GISMO_WITH_MPFR
 #include <mpreal.h>
 #endif
 
-#cmakedefine GISMO_WITH_MPQ
 #ifdef GISMO_WITH_MPQ
 #include <gmpxx.h>
 #include <unsupported/Eigen/MPQClassExtra>
+#endif
+
+#ifdef GISMO_WITH_UNUM
+#include <gsUnum/gsUnum.h>
 #endif
 
 /* Determine if only header files should be used. */


### PR DESCRIPTION
Option lists in gsOption.cmake and use of GISMO_WITH_xxx flags in
gsConfig.h.in were unordered and some options lacked a report
message. Sorted all options alphabetically (separated between standard
and extra options) and added missing report messages.
    
Also ordered the section in the top-level CMakeLists.txt file that
includes the GISMO_WITH_xxx functionality.

Functionality has NOT changed!
