### PR TITLE
Update gsUtils.h

### DIFF
--- a/src/gsUtils/gsUtils.h
+++ b/src/gsUtils/gsUtils.h
@@ -18,6 +18,7 @@
 
 #include <gsCore/gsExport.h>
 #include <gsCore/gsDebug.h>
+#include <gsCore/gsMemory.h>
 
 #ifdef __GNUC__ 
 #include <cxxabi.h>


### PR DESCRIPTION
File gsUtils.h uses features from gsMemory.h but does not include it explicitly. The error becomes visible when compiling in non-lib mode.
