### PR TITLE
Remove warnings

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,9 +1,9 @@
 ######################################################################
 ## CMakeLists.txt ---
 ## This file is part of the G+Smo library.
-## 
-## Author: Angelos Mantzaflaris 
-## Copyright (C) 2012-2015 - RICAM-Linz.
+##
+## Author: Angelos Mantzaflaris
+## Copyright (C) 2012-2018 - RICAM-Linz.
 ######################################################################
 
 project(GismoDoc)
@@ -32,8 +32,8 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 # Set some Doxygen flags
 set(GISMO_DOXY_PROJECT_NAME             "G+Smo")
 set(GISMO_DOXY_OUTPUT_DIRECTORY_SUFFIX  "")
-set(GISMO_DOXY_INPUT                    "\"${gismo_SOURCE_DIR}/src\" \"${gismo_SOURCE_DIR}/doc\" \"${gismo_SOURCE_DIR}/plugins\" \"${gismo_SOURCE_DIR}/extensions\" \"${gismo_BINARY_DIR}/gsCore\"") #\"${gismo_SOURCE_DIR}/examples\" 
-# Uncomment the line below to have doxygen process only 
+set(GISMO_DOXY_INPUT                    "\"${gismo_SOURCE_DIR}/src\" \"${gismo_SOURCE_DIR}/doc\" \"${gismo_SOURCE_DIR}/plugins\" \"${gismo_SOURCE_DIR}/extensions\" \"${gismo_BINARY_DIR}/gsCore\"") #\"${gismo_SOURCE_DIR}/examples\"
+# Uncomment the line below to have doxygen process only
 # what is inside the doc folder when typing 'make doc'
 #set(GISMO_DOXY_INPUT                    " \"${gismo_SOURCE_DIR}/doc\" ")
 set(IMAGE_PATH        "\"${gismo_SOURCE_DIR}/doc/figs\"")
@@ -112,7 +112,7 @@ endif()
 add_custom_target(doc #ALL
   COMMAND doxygen
   WORKING_DIRECTORY ${gismo_BINARY_DIR}/doc
-  COMMENT "Generating doc: ${gismo_BINARY_DIR}/doc/html/index.html" VERBATIM	
+  COMMENT "Generating doc: ${gismo_BINARY_DIR}/doc/html/index.html" VERBATIM
 )
 
 add_custom_target(doctar #ALL
@@ -121,7 +121,7 @@ add_custom_target(doctar #ALL
   COMMAND ${CMAKE_COMMAND} -E tar cvfz gismo-doc/gismo-doc.tgz gismo-doc
   COMMAND ${CMAKE_COMMAND} -E rename gismo-doc html
   WORKING_DIRECTORY ${gismo_BINARY_DIR}/doc
-  COMMENT "Generating API documentation with Doxygen plus tar file" VERBATIM 
+  COMMENT "Generating API documentation with Doxygen plus tar file" VERBATIM
   DEPENDS doc
 )
 

--- a/doc/snippets/CMakeLists.txt
+++ b/doc/snippets/CMakeLists.txt
@@ -2,7 +2,7 @@
 ## CMakeLists.txt ---
 ## This file is part of the G+Smo library.
 ##
-## Author: Angelos Mantzaflaris 
+## Author: Angelos Mantzaflaris
 ## Copyright (C) 2012 - RICAM-Linz.
 ######################################################################
 
@@ -35,6 +35,7 @@ foreach(snippet_src ${snippets_SRCS})
     target_link_libraries(${snippet_target} gismo)
   endif()
 
+find_package(Doxygen)
 if(DOXYGEN_FOUND)
   add_custom_command(
     TARGET ${snippet_target}

--- a/examples/heatEquation_example.cpp
+++ b/examples/heatEquation_example.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     gsPoissonAssembler<> stationary(pde, refine_bases);
     stationary.options().setInt("DirichletStrategy", dirichlet::elimination);
     stationary.options().setInt("InterfaceStrategy", iFace::glue);
-    gsHeatEquation<real_t> assembler(stationary, stationary.options());
+    gsHeatEquation<real_t> assembler(stationary);
     assembler.setTheta(theta);
     gsInfo<<assembler.options()<<"\n";
 

--- a/examples/trilinos_example.cpp
+++ b/examples/trilinos_example.cpp
@@ -201,14 +201,15 @@ int main(int argc, char**argv)
         if (verbose) gsInfo << t_solver.currentParams();
 
         /// Compute solution
-        const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        //const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        t_solver.solve(t_b);
 
         /// Get solver status and timing
         if (status) gsInfo << t_solver.status();
         if (timing) gsInfo << t_solver.timing();
 
         /// Check error
-        GISMO_UNUSED(t_vx);
+        //GISMO_UNUSED(t_vx);
         bool OK = false;
         gsVector<> t_x;
         t_solver.getSolution(t_x); // collect solution at Proc 0
@@ -275,14 +276,15 @@ int main(int argc, char**argv)
         if (verbose) gsInfo << t_solver.currentParams();
 
         /// Compute solution
-        const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        //const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        t_solver.solve(t_b);
 
         /// Get solver status and timing
         if (status) gsInfo << t_solver.status();
         if (timing) gsInfo << t_solver.timing();
 
         /// Check error
-        GISMO_UNUSED(t_vx);
+        //GISMO_UNUSED(t_vx);
         bool OK = false;
         gsVector<> t_x;
         t_solver.getSolution(t_x); // collect solution at Proc 0
@@ -364,7 +366,8 @@ int main(int argc, char**argv)
         t_solver.setPreconditioner(t_precond);
 
         /// Compute solution
-        const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        //const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        t_solver.solve(t_b);
 
         /// Get solver status and timing
         if (status) gsInfo << t_solver.status();
@@ -374,7 +377,7 @@ int main(int argc, char**argv)
         if (timing) gsInfo << t_precond.timing();
 
         /// Check error
-        GISMO_UNUSED(t_vx);
+        //GISMO_UNUSED(t_vx);
         bool OK = false;
         gsVector<> t_x;
         t_solver.getSolution(t_x); // collect solution at Proc 0
@@ -456,14 +459,15 @@ int main(int argc, char**argv)
         if (verbose) gsInfo << t_solver.currentParams();
 
         /// Compute solution
-        const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        //const trilinos::Vector & t_vx = t_solver.solve(t_b);
+        t_solver.solve(t_b);
 
         /// Get solver status and timing
         if (status) gsInfo << t_solver.status();
         if (timing) gsInfo << t_solver.timing();
 
         /// Check error
-        GISMO_UNUSED(t_vx);
+        //GISMO_UNUSED(t_vx);
         bool OK = false;
         gsVector<> t_x;
         t_solver.getSolution(t_x); // collect solution at Proc 0
@@ -490,14 +494,15 @@ int main(int argc, char**argv)
     //     if (verbose) gsInfo << t_solver.currentParams();
 
     //     /// Compute solution
-    //     const trilinos::Vector & t_vx = t_solver.solve(t_b);
+    //     //const trilinos::Vector & t_vx = t_solver.solve(t_b);
+    //     t_solver.solve(t_b);
 
     //     /// Get solver status and timing
     //     if (status) gsInfo << t_solver.status();
     //     if (timing) gsInfo << t_solver.timing();
 
     //     /// Check error
-    //     GISMO_UNUSED(t_vx);
+    //     //GISMO_UNUSED(t_vx);
     //     bool OK = false;
     //     gsVector<> t_x;
     //     t_solver.getSolution(t_x); // collect solution at Proc 0

--- a/extensions/gsIpopt/gsOptProblem.h
+++ b/extensions/gsIpopt/gsOptProblem.h
@@ -59,8 +59,7 @@ public:
     virtual void jacobCon_into( const gsAsConstVector<T> & u, gsAsVector<T> & result ) const = 0;
 
     /// \brief Returns Hessian Lagrangian of the constraints at design value
-    /// \a u
-    virtual void hessLagr_into( const gsAsConstVector<T> & u, gsAsVector<T> & result ) const
+    virtual void hessLagr_into( const gsAsConstVector<T> &, gsAsVector<T> &) const
     {GISMO_NO_IMPLEMENTATION }
 
     /// @brief Computes the sparsity pattern of the constraint Jacobian matrix.

--- a/extensions/gsTrilinos/Vector.h
+++ b/extensions/gsTrilinos/Vector.h
@@ -51,7 +51,7 @@ public:
     
     void copyTo(gsVector<real_t> & gsVec, const int rank = 0) const;
 
-    void copyTo(gsMatrix<real_t> & gsVec, const int rank = 0) const
+    void copyTo(gsMatrix<real_t> & gsVec, const int = 0) const
     {
         gsVector<real_t> tmp;
         copyTo(tmp);

--- a/src/gsAssembler/gsAssembler.hpp
+++ b/src/gsAssembler/gsAssembler.hpp
@@ -386,7 +386,7 @@ void gsAssembler<T>::computeDirichletDofsIntpl(const gsDofMapper & mapper,
 
 template<class T>
 void gsAssembler<T>::computeDirichletDofsL2Proj(const gsDofMapper & mapper,
-                                                const gsMultiBasis<T> & mbasis,
+                                                const gsMultiBasis<T> & ,
                                                 const int unk_)
 {
     m_ddof[unk_].resize( mapper.boundarySize(), m_pde_ptr->numRhs() );

--- a/src/gsAssembler/gsAssembler.hpp
+++ b/src/gsAssembler/gsAssembler.hpp
@@ -50,7 +50,7 @@ void gsAssembler<T>::assemble()
 {GISMO_NO_IMPLEMENTATION}
 
 template<class T>
-void gsAssembler<T>::assemble(const gsMultiPatch<T> & curSolution)
+void gsAssembler<T>::assemble(const gsMultiPatch<T> &)
 {GISMO_NO_IMPLEMENTATION}
 
 template<class T>

--- a/src/gsAssembler/gsAssemblerBase.h
+++ b/src/gsAssembler/gsAssemblerBase.h
@@ -192,18 +192,18 @@ public:
 
     /// @brief Main non-linear assemble routine with input from
     /// current solution
-    virtual void assemble(const gsMultiPatch<T> & curSolution)
+    virtual void assemble(const gsMultiPatch<T> &)
     {GISMO_NO_IMPLEMENTATION}
 
     /// @brief Reconstruct solution from computed solution vector
-    virtual void constructSolution(const gsMatrix<T>& solVector, 
-                                   gsMultiPatch<T>& result) const
+    virtual void constructSolution(const gsMatrix<T>&,
+                                   gsMultiPatch<T>&) const
     {GISMO_NO_IMPLEMENTATION}
 
     /// @brief Update solution by adding the computed solution vector
     /// to the current solution
-    virtual void updateSolution(const gsMatrix<T>& solVector, 
-                                gsMultiPatch<T>& result) const
+    virtual void updateSolution(const gsMatrix<T>&,
+                                gsMultiPatch<T>&) const
     {GISMO_NO_IMPLEMENTATION}
 
 

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -478,7 +478,7 @@ private:
         template <typename E> void operator() (const gismo::expr::_expr<E> & v)
         { v.setFlag(); }
 
-        void operator() (const expr::_expr<expr::gsNullExpr<T> > & ne) {}
+        void operator() (const expr::_expr<expr::gsNullExpr<T> > &) {}
     } _setFlag;
 
     struct __printExpr

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -519,8 +519,7 @@ private:
                 push<false>(ee.rowVar(), ee.colVar(), m_patchInd);
         }// operator()
 
-        void operator() (const expr::_expr<expr::gsNullExpr<T> > & ne)
-        {/*GISMO_UNUSED(ne);*/}
+        void operator() (const expr::_expr<expr::gsNullExpr<T> > &) {}
 
         template<bool isMatrix> void push(const expr::gsFeVariable<T> & v,
                                           const expr::gsFeVariable<T> & u,

--- a/src/gsAssembler/gsExprEvaluator.h
+++ b/src/gsAssembler/gsExprEvaluator.h
@@ -237,7 +237,7 @@ public:
     }
 
     // Interpolates the expression \a expr over the isogeometric domain \a G
-    template<class E> void interpolate(const expr::_expr<E> & expr)
+    template<class E> void interpolate(const expr::_expr<E> &)
     {
         GISMO_NO_IMPLEMENTATION
         // for all patches
@@ -293,18 +293,16 @@ private:
     struct min_op
     {
         static inline T init() { return math::limits::max(); }
-        static inline void acc (const T contrib, const T w, T & res)
+        static inline void acc (const T contrib, const T, T & res)
         {
-            GISMO_UNUSED(w);
             res = math::min(contrib, res);
         }
     };
     struct max_op
     {
         static inline T init() { return math::limits::min(); }
-        static inline void acc (const T contrib, const T w, T & res)
+        static inline void acc (const T contrib, const T, T & res)
         {
-            GISMO_UNUSED(w);
             res = math::max(contrib, res);
         }
     };

--- a/src/gsAssembler/gsExprHelper.h
+++ b/src/gsAssembler/gsExprHelper.h
@@ -141,6 +141,7 @@ public:
 
     nonConstVariable getVar(const gsFunctionSet<T> & mp, geometryMap G)
     {
+        GISMO_UNUSED(G);
         GISMO_ASSERT(&G==&mapVar, "geometry map not known");
         m_vlist.push_back( expr::gsFeVariable<T>() );
         expr::gsFeVariable<T> & var = m_vlist.back();

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -288,7 +288,7 @@ public:
     inline index_t rows() const { GISMO_ERROR("gsNullExpr"); }
     inline index_t cols() const { GISMO_ERROR("gsNullExpr"); }
     inline void setFlag() const {/* gsInfo<<"gsNullExpr emtpy flag\n"; */ }
-    void parse(gsSortedVector<const gsFunctionSet<T>*> & evList) const { GISMO_UNUSED(evList); }
+    void parse(gsSortedVector<const gsFunctionSet<T>*> &) const { }
 
     const gsFeVariable<T> & rowVar() const { GISMO_ERROR("gsNullExpr"); }
     const gsFeVariable<T> & colVar() const { GISMO_ERROR("gsNullExpr"); }
@@ -359,7 +359,7 @@ public:
     index_t rows() const { return 0; }
     index_t cols() const { return 0; }
     void setFlag() const { }
-    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> & evList) const { GISMO_UNUSED(evList); }
+    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> &) const { }
     static bool rowSpan() {return false;}
     static bool colSpan() {return false;}
     const gsFeVariable<T> & rowVar() const { return gsNullExpr<T>(); }
@@ -489,7 +489,7 @@ public:
     inline index_t rows() const { return 0; }
     inline index_t cols() const { return 0; }
     inline void setFlag() const { }
-    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> & evList) const { GISMO_UNUSED(evList); }
+    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> & ) const { }
 
     const gsFeVariable<T> & rowVar() const { return gsNullExpr<T>(); }
     const gsFeVariable<T> & colVar() const { return gsNullExpr<T>(); }
@@ -518,7 +518,7 @@ public:
     inline index_t rows() const { return 0; }
     inline index_t cols() const { return 0; }
     inline void setFlag() const { }
-    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> & evList) const { GISMO_UNUSED(evList); }
+    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> &) const { }
     const gsFeVariable<T> & rowVar() const { gsNullExpr<T>(); }
     const gsFeVariable<T> & colVar() const { gsNullExpr<T>(); }
     static bool rowSpan() {return false; }

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -284,7 +284,7 @@ public:
     }
     
     typedef T Scalar;
-    gsMatrix<T> eval(const index_t k) const { GISMO_ERROR("gsNullExpr"); }
+    gsMatrix<T> eval(const index_t) const { GISMO_ERROR("gsNullExpr"); }
     inline index_t rows() const { GISMO_ERROR("gsNullExpr"); }
     inline index_t cols() const { GISMO_ERROR("gsNullExpr"); }
     inline void setFlag() const {/* gsInfo<<"gsNullExpr emtpy flag\n"; */ }
@@ -1373,7 +1373,7 @@ public:
 
 public:
 
-    gsMatrix<Scalar>::IdentityReturnType eval(const index_t k) const
+    gsMatrix<Scalar>::IdentityReturnType eval(const index_t) const
     {
         return gsMatrix<Scalar>::Identity(_dim,_dim);
     }
@@ -1381,7 +1381,7 @@ public:
     index_t rows() const { return _dim; }
     index_t cols() const { return  _dim; }
     void setFlag() const { }
-    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> & evList) const {  }
+    void parse(gsSortedVector<const gsFunctionSet<Scalar>*> & ) const {  }
 
     static bool rowSpan() {return false;}
     static bool colSpan() {return false;}

--- a/src/gsAssembler/gsHeatEquation.h
+++ b/src/gsAssembler/gsHeatEquation.h
@@ -38,8 +38,7 @@ public:
 public:
 
     /// Construction receiving all necessary data
-    gsHeatEquation(gsAssembler<T> & stationary,
-                   const gsOptionList & opt = Base::defaultOptions() )
+    explicit gsHeatEquation(gsAssembler<T> & stationary)
     :  Base(stationary),  // note: unnecessary sliced copy here
        m_stationary(&stationary), m_theta(0.5)
     {

--- a/src/gsAssembler/gsNormL2.h
+++ b/src/gsAssembler/gsNormL2.h
@@ -92,7 +92,7 @@ protected:
     }
     
     // assemble on element
-    T compute(gsDomainIterator<T>    & element, 
+    T compute(gsDomainIterator<T>    & ,
               gsGeometryEvaluator<T> & geoEval,
               gsVector<T> const      & quWeights,
               T & accumulated)

--- a/src/gsAssembler/gsQuadRule.h
+++ b/src/gsAssembler/gsQuadRule.h
@@ -57,8 +57,8 @@ public:
      * rule will use precomputed tables if possible. If greater then 0,
      * it will force to compute it everytime.
      */
-    virtual void setNodes( gsVector<index_t> const & numNodes,
-                           unsigned digits = 0)
+    virtual void setNodes( gsVector<index_t> const &,
+                           unsigned = 0)
     { GISMO_NO_IMPLEMENTATION }
 
     /**

--- a/src/gsAssembler/gsSeminormH1.h
+++ b/src/gsAssembler/gsSeminormH1.h
@@ -83,7 +83,7 @@ protected:
     }
 
     // assemble on element
-    inline T compute(gsDomainIterator<T>    & element, 
+    inline T compute(gsDomainIterator<T>    & ,
                      gsGeometryEvaluator<T> & geoEval,
                      gsVector<T> const      & quWeights,
                      T & accumulated)

--- a/src/gsAssembler/gsSeminormH2.h
+++ b/src/gsAssembler/gsSeminormH2.h
@@ -89,7 +89,7 @@ protected:
     }
 
     // assemble on element
-    inline T compute(gsDomainIterator<T>    & element, 
+    inline T compute(gsDomainIterator<T>    & ,
                      gsGeometryEvaluator<T> & geoEval,
                      gsVector<T> const      & quWeights,
                      T & accumulated)

--- a/src/gsAssembler/gsSparseSystem.h
+++ b/src/gsAssembler/gsSparseSystem.h
@@ -1227,11 +1227,11 @@ public: /* Add local contributions to system matrix and right-hand side */
      * @param[in] r the row blocks where the matrices should be pushed
      * @param[in] c the colum blocks where the matrices shouldbe pushed
      */
-    void push(const std::vector<gsMatrix<T> > & localMat,
-              const std::vector<gsMatrix<T> > & localRhs,
-              const std::vector<gsMatrix<unsigned> > & actives,
-              const std::vector<gsMatrix<T> > & fixedDofs,
-              const gsVector<size_t> & r, const gsVector<size_t> & c)
+    void push(const std::vector<gsMatrix<T> > &,
+              const std::vector<gsMatrix<T> > &,
+              const std::vector<gsMatrix<unsigned> > &,
+              const std::vector<gsMatrix<T> > &,
+              const gsVector<size_t> &, const gsVector<size_t> &)
     {
         GISMO_NO_IMPLEMENTATION
     }

--- a/src/gsAssembler/gsVisitorBiharmonic.h
+++ b/src/gsAssembler/gsVisitorBiharmonic.h
@@ -60,7 +60,7 @@ public:
     }
 
     void initialize(const gsBasis<T> & basis,
-                    const index_t patchIndex,
+                    const index_t ,
                     const gsOptionList & options, 
                     gsQuadRule<T>    & rule,
                     unsigned         & evFlags )
@@ -100,7 +100,7 @@ public:
     }
 
 
-    inline void assemble(gsDomainIterator<T>    & element,
+    inline void assemble(gsDomainIterator<T>    & ,
                          gsGeometryEvaluator<T> & geoEval,
                          gsVector<T> const      & quWeights)
     {

--- a/src/gsAssembler/gsVisitorCDR.h
+++ b/src/gsAssembler/gsVisitorCDR.h
@@ -86,7 +86,7 @@ public:
     }
 
     void initialize(const gsBasis<T> & basis,
-                    const index_t patchIndex,
+                    const index_t ,
                     const gsOptionList & options,
                     gsQuadRule<T>    & rule,
                     unsigned         & evFlags )

--- a/src/gsAssembler/gsVisitorDg.h
+++ b/src/gsAssembler/gsVisitorDg.h
@@ -39,11 +39,11 @@ public:
      * Where \f[v\f] is the test function and \f[ u \f] is trial function.
      */
 
-    gsVisitorDg(const gsPde<T> & pde)
+    gsVisitorDg(const gsPde<T> &)
     {}
 
     void initialize(const gsBasis<T> & basis1,
-                    const gsBasis<T> & basis2,
+                    const gsBasis<T> & ,
                     const boundaryInterface & bi,
                     const gsOptionList & options,
                     gsQuadRule<T> & rule,

--- a/src/gsAssembler/gsVisitorMass.h
+++ b/src/gsAssembler/gsVisitorMass.h
@@ -39,7 +39,7 @@ public:
     { }
 
     void initialize(const gsBasis<T> & basis,
-                    const index_t patchIndex,
+                    const index_t ,
                     const gsOptionList & options, 
                     gsQuadRule<T>    & rule,
                     unsigned         & evFlags )
@@ -72,7 +72,7 @@ public:
         localMat.setZero(numActive, numActive);
     }
 
-    inline void assemble(gsDomainIterator<T>    & element, 
+    inline void assemble(gsDomainIterator<T>    & ,
                          gsGeometryEvaluator<T> & geoEval,
                          gsVector<T> const      & quWeights)
     {
@@ -82,7 +82,7 @@ public:
     }
 
     inline void localToGlobal(const int patchIndex,
-                              const std::vector<gsMatrix<T> >    & eliminatedDofs,
+                              const std::vector<gsMatrix<T> >    & ,
                               gsSparseSystem<T>     & system)
     {
         // Map patch-local DoFs to global DoFs

--- a/src/gsAssembler/gsVisitorNeumann.h
+++ b/src/gsAssembler/gsVisitorNeumann.h
@@ -27,7 +27,7 @@ class gsVisitorNeumann
 {
 public:
 
-    gsVisitorNeumann(const gsPde<T> & pde, const boundary_condition<T> & s) 
+    gsVisitorNeumann(const gsPde<T> & , const boundary_condition<T> & s)
     : neudata_ptr( s.function().get() ), side(s.side())
     { }
 
@@ -61,7 +61,7 @@ public:
     }
 
     void initialize(const gsBasis<T> & basis,
-                    const index_t patchIndex,
+                    const index_t ,
                     const gsOptionList & options, 
                     gsQuadRule<T>    & rule,
                     unsigned         & evFlags )
@@ -97,7 +97,7 @@ public:
         localRhs.setZero(numActive, neudata_ptr->targetDim() );
     }
 
-    inline void assemble(gsDomainIterator<T>    & element, 
+    inline void assemble(gsDomainIterator<T>    & ,
                          gsGeometryEvaluator<T> & geoEval,
                          gsVector<T> const      & quWeights)
     {
@@ -114,7 +114,7 @@ public:
     }
     
     inline void localToGlobal(const int patchIndex,
-                              const std::vector<gsMatrix<T> >   & eliminatedDofs,
+                              const std::vector<gsMatrix<T> >   & ,
                               gsSparseSystem<T>     & system)
     {
         // Map patch-local DoFs to global DoFs

--- a/src/gsAssembler/gsVisitorNeumannBiharmonic.h
+++ b/src/gsAssembler/gsVisitorNeumannBiharmonic.h
@@ -30,7 +30,7 @@ class gsVisitorNeumannBiharmonic
 {
 public:
 
-    gsVisitorNeumannBiharmonic(const gsPde<T> & pde, const boundary_condition<T> & s) 
+    gsVisitorNeumannBiharmonic(const gsPde<T> & , const boundary_condition<T> & s)
     : neudata_ptr( s.function().get() ), side(s.side())
     { }
 
@@ -57,7 +57,7 @@ public:
     }
 
     void initialize(const gsBasis<T> & basis,
-                    const index_t patchIndex,
+                    const index_t ,
                     const gsOptionList & options, 
                     gsQuadRule<T>    & rule,
                     unsigned         & evFlags )
@@ -95,7 +95,7 @@ public:
         localRhs.setZero(numActive, neudata_ptr->targetDim() );
     }
 
-    inline void assemble(gsDomainIterator<T>    & element, 
+    inline void assemble(gsDomainIterator<T>    & ,
                          gsGeometryEvaluator<T> & geoEval,
                          gsVector<T> const      & quWeights)
     {
@@ -115,7 +115,7 @@ public:
     }
     
     inline void localToGlobal(const int patchIndex,
-                              const std::vector<gsMatrix<T> >    & eliminatedDofs,
+                              const std::vector<gsMatrix<T> >    & ,
                               gsSparseSystem<T>     & system)
     {
         // Map patch-local DoFs to global DoFs

--- a/src/gsAssembler/gsVisitorNitsche.h
+++ b/src/gsAssembler/gsVisitorNitsche.h
@@ -31,7 +31,7 @@ class gsVisitorNitsche
 {
 public:
 
-    gsVisitorNitsche(const gsPde<T> & pde, const boundary_condition<T> & s) 
+    gsVisitorNitsche(const gsPde<T> & , const boundary_condition<T> & s)
     : dirdata_ptr( s.function().get() ), side(s.side())
     { }
 
@@ -66,7 +66,7 @@ public:
     }
 
     void initialize(const gsBasis<T> & basis,
-                    const index_t patchIndex,
+                    const index_t ,
                     const gsOptionList & options, 
                     gsQuadRule<T>    & rule,
                     unsigned         & evFlags )
@@ -147,7 +147,7 @@ public:
     }
 
     inline void localToGlobal(const int patchIndex,
-                              const std::vector<gsMatrix<T> >    & eliminatedDofs,
+                              const std::vector<gsMatrix<T> >    & ,
                               gsSparseSystem<T>     & system)
     {
         // Map patch-local DoFs to global DoFs

--- a/src/gsAssembler/gsVisitorPoisson.h
+++ b/src/gsAssembler/gsVisitorPoisson.h
@@ -80,7 +80,7 @@ public:
         localRhs.setZero(numActive, rhsVals.rows() );//multiple right-hand sides
     }
     
-    inline void assemble(gsDomainIterator<T>    & element, 
+    inline void assemble(gsDomainIterator<T>    & ,
                          gsGeometryEvaluator<T> & geoEval,
                          gsVector<T> const      & quWeights)
     {

--- a/src/gsCore/gsBasis.hpp
+++ b/src/gsCore/gsBasis.hpp
@@ -26,7 +26,7 @@ gsBasis<T>::gsBasis()
 { }
 
 template<class T>
-gsBasis<T>::gsBasis(const gsBasis& other)
+gsBasis<T>::gsBasis(const gsBasis& )
 { }
         
 template<class T>
@@ -454,7 +454,7 @@ void gsBasis<T>::uniformRefine(int, int)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::uniformRefine_withCoefs(gsMatrix<T>& coefs, int , int )
+void gsBasis<T>::uniformRefine_withCoefs(gsMatrix<T>& , int , int )
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>

--- a/src/gsCore/gsBasis.hpp
+++ b/src/gsCore/gsBasis.hpp
@@ -454,7 +454,7 @@ void gsBasis<T>::uniformRefine(int, int)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::uniformRefine_withCoefs(gsMatrix<T>& coefs, int numKnots, int mul)
+void gsBasis<T>::uniformRefine_withCoefs(gsMatrix<T>& coefs, int , int )
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>

--- a/src/gsCore/gsBasis.hpp
+++ b/src/gsCore/gsBasis.hpp
@@ -264,11 +264,11 @@ gsGeometry<T> * gsBasis<T>::projectL2(gsFunction<T> const & func) const
 */
 
 template<class T> inline
-void gsBasis<T>::anchors_into(gsMatrix<T>& result) const
+void gsBasis<T>::anchors_into(gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T> inline
-void gsBasis<T>::anchor_into(unsigned i, gsMatrix<T>& result) const
+void gsBasis<T>::anchor_into(unsigned, gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 
@@ -281,43 +281,43 @@ void gsBasis<T>::connectivityAtAnchors(gsMesh<T> & mesh) const
 }
 
 template<class T>
-void gsBasis<T>::connectivity(const gsMatrix<T> & nodes, gsMesh<T> & mesh) const
+void gsBasis<T>::connectivity(const gsMatrix<T> &, gsMesh<T> &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::active_into(const gsMatrix<T> & u, gsMatrix<unsigned>& result) const
+void gsBasis<T>::active_into(const gsMatrix<T> &, gsMatrix<unsigned>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template <class T>
-bool gsBasis<T>::isActive(const unsigned i, const gsVector<T> & u) const 
+bool gsBasis<T>::isActive(const unsigned, const gsVector<T> &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::numActive_into(const gsMatrix<T> & u, gsVector<unsigned>& result) const
+void gsBasis<T>::numActive_into(const gsMatrix<T> &, gsVector<unsigned>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::activeCoefs_into(const gsVector<T> & u, const gsMatrix<T> & coefs, 
-                                  gsMatrix<T>& result) const
-{ GISMO_NO_IMPLEMENTATION }
-
-template<class T>
-gsMatrix<unsigned>
-gsBasis<T>::allBoundary( ) const
+void gsBasis<T>::activeCoefs_into(const gsVector<T> &, const gsMatrix<T> &,
+                                  gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
 gsMatrix<unsigned>
-gsBasis<T>::boundaryOffset(boxSide const & s,unsigned offset) const
+gsBasis<T>::allBoundary() const
+{ GISMO_NO_IMPLEMENTATION }
+
+template<class T>
+gsMatrix<unsigned>
+gsBasis<T>::boundaryOffset(boxSide const &,unsigned) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
 unsigned
-gsBasis<T>::functionAtCorner(boxCorner const & c) const
+gsBasis<T>::functionAtCorner(boxCorner const &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-gsBasis<T> * gsBasis<T>::boundaryBasis_impl(boxSide const & s) const
+gsBasis<T> * gsBasis<T>::boundaryBasis_impl(boxSide const &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -325,7 +325,7 @@ gsMatrix<T> gsBasis<T>::support() const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-gsMatrix<T> gsBasis<T>::support(const unsigned & i) const
+gsMatrix<T> gsBasis<T>::support(const unsigned &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -333,31 +333,31 @@ gsMatrix<T> gsBasis<T>::supportInterval(unsigned dir) const
 { return support().row(dir); }
 
 template<class T>
-void gsBasis<T>::eval_into(const gsMatrix<T> & u, gsMatrix<T>& result) const
-    { GISMO_NO_IMPLEMENTATION }
-
-template<class T>
-void gsBasis<T>::evalSingle_into(unsigned i, const gsMatrix<T> & u, gsMatrix<T>& result) const
+void gsBasis<T>::eval_into(const gsMatrix<T> &, gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::deriv_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const
+void gsBasis<T>::evalSingle_into(unsigned, const gsMatrix<T> &, gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::derivSingle_into(unsigned i, 
-                                  const gsMatrix<T> & u, 
-                                  gsMatrix<T>& result ) const
+void gsBasis<T>::deriv_into(const gsMatrix<T> &, gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::deriv2_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const
+void gsBasis<T>::derivSingle_into(unsigned,
+                                  const gsMatrix<T> &,
+                                  gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::deriv2Single_into(unsigned i, 
-                                   const gsMatrix<T> & u, 
-                                   gsMatrix<T>& result ) const
+void gsBasis<T>::deriv2_into(const gsMatrix<T> &, gsMatrix<T>&) const
+{ GISMO_NO_IMPLEMENTATION }
+
+template<class T>
+void gsBasis<T>::deriv2Single_into(unsigned,
+                                   const gsMatrix<T> &,
+                                   gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -387,14 +387,14 @@ void gsBasis<T>::evalAllDers_into(const gsMatrix<T> & u, int n,
 }
 
 template<class T>
-void gsBasis<T>::evalAllDersSingle_into(unsigned i, const gsMatrix<T> & u, 
-                                        int n, gsMatrix<T>& result) const
+void gsBasis<T>::evalAllDersSingle_into(unsigned, const gsMatrix<T> &,
+                                        int, gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::evalDerSingle_into(unsigned i, const 
-                                    gsMatrix<T> & u, int n, 
-                                    gsMatrix<T>& result) const
+void gsBasis<T>::evalDerSingle_into(unsigned, const
+                                    gsMatrix<T> &, int,
+                                    gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 
@@ -404,7 +404,7 @@ typename gsBasis<T>::uPtr gsBasis<T>::create() const
 
 
 template<class T>
-typename gsBasis<T>::uPtr gsBasis<T>::tensorize(const gsBasis & other) const
+typename gsBasis<T>::uPtr gsBasis<T>::tensorize(const gsBasis &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -414,7 +414,7 @@ gsBasis<T>::makeDomainIterator() const
 
 template<class T>
 typename gsBasis<T>::domainIter
-gsBasis<T>::makeDomainIterator(const boxSide & s) const
+gsBasis<T>::makeDomainIterator(const boxSide &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -422,15 +422,15 @@ int gsBasis<T>::numElements() const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-int gsBasis<T>::numElements(boxSide const & s) const
+int gsBasis<T>::numElements(boxSide const &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-int gsBasis<T>::elementIndex(const gsVector<T> & u) const
+int gsBasis<T>::elementIndex(const gsVector<T> &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-const gsBasis<T>& gsBasis<T>::component(unsigned i) const
+const gsBasis<T>& gsBasis<T>::component(unsigned) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -438,19 +438,19 @@ gsBasis<T>& gsBasis<T>::component(unsigned i)
 { return const_cast<gsBasis<T>&>(const_cast<const gsBasis<T>*>(this)->component(i));}
 
 template<class T>
-void gsBasis<T>::refine(gsMatrix<T> const & boxes, int refExt)
+void gsBasis<T>::refine(gsMatrix<T> const &, int)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::refineElements(std::vector<unsigned> const & boxes)
+void gsBasis<T>::refineElements(std::vector<unsigned> const &)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::refineElements_withCoefs(gsMatrix<T> & coefs,std::vector<unsigned> const & boxes)
+void gsBasis<T>::refineElements_withCoefs(gsMatrix<T> &,std::vector<unsigned> const &)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::uniformRefine(int numKnots, int mul)
+void gsBasis<T>::uniformRefine(int, int)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -458,33 +458,33 @@ void gsBasis<T>::uniformRefine_withCoefs(gsMatrix<T>& coefs, int numKnots, int m
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::uniformRefine_withTransfer(gsSparseMatrix<T,RowMajor> & transfer, 
-                                            int numKnots, int mul)
+void gsBasis<T>::uniformRefine_withTransfer(gsSparseMatrix<T,RowMajor> &,
+                                            int, int)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::uniformCoarsen(int numKnots)
+void gsBasis<T>::uniformCoarsen(int)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::uniformCoarsen_withTransfer(gsSparseMatrix<T,RowMajor> & transfer, 
-                                            int numKnots)
+void gsBasis<T>::uniformCoarsen_withTransfer(gsSparseMatrix<T,RowMajor> &,
+                                            int)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::degreeElevate(int const & i, int const dir)
+void gsBasis<T>::degreeElevate(int const &, int const)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::degreeReduce(int const & i, int const dir)
+void gsBasis<T>::degreeReduce(int const &, int const)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::degreeIncrease(int const & i, int const dir)
+void gsBasis<T>::degreeIncrease(int const &, int const)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::degreeDecrease(int const & i, int const dir)
+void gsBasis<T>::degreeDecrease(int const &, int const)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -521,11 +521,11 @@ void gsBasis<T>::setDegreePreservingMultiplicity(int const& i)
 }
 
 template<class T>
-void gsBasis<T>::elevateContinuity(int const & i)
+void gsBasis<T>::elevateContinuity(int const &)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::reduceContinuity(int const & i)
+void gsBasis<T>::reduceContinuity(int const &)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -545,7 +545,7 @@ int gsBasis<T>::totalDegree() const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-int gsBasis<T>::degree(int i) const 
+int gsBasis<T>::degree(int) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
@@ -553,8 +553,8 @@ void gsBasis<T>::reverse()
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsBasis<T>::matchWith(const boundaryInterface & bi, const gsBasis<T> & other,
-               gsMatrix<unsigned> & bndThis, gsMatrix<unsigned> & bndOther) const
+void gsBasis<T>::matchWith(const boundaryInterface &, const gsBasis<T> &,
+               gsMatrix<unsigned> &, gsMatrix<unsigned> &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>

--- a/src/gsCore/gsBasis.hpp
+++ b/src/gsCore/gsBasis.hpp
@@ -26,7 +26,7 @@ gsBasis<T>::gsBasis()
 { }
 
 template<class T>
-gsBasis<T>::gsBasis(const gsBasis& )
+gsBasis<T>::gsBasis(const gsBasis& other) : Base(other)
 { }
         
 template<class T>

--- a/src/gsCore/gsBasisFun.h
+++ b/src/gsCore/gsBasisFun.h
@@ -82,7 +82,7 @@ public:
     unsigned index() const { return m_index; }
     
     // temporary hack
-    virtual const gsBasisFun & piece(const index_t k) const
+    virtual const gsBasisFun & piece(const index_t) const
     {
         return *this; 
     }

--- a/src/gsCore/gsBoundary.h
+++ b/src/gsCore/gsBoundary.h
@@ -153,8 +153,8 @@ public:
      * @param dim
      * @return the first valid side in an dim-dimensional box
     **/
-    static  boxSide    getFirst     (int dim) 
-    {GISMO_UNUSED(dim); return boxSide(1);}
+    static  boxSide    getFirst     (int)
+    { return boxSide(1); }
 
     /**
      * @brief helper for iterating on sides of an n-dimensional box
@@ -353,11 +353,10 @@ public:
 
     /**
      * @brief helper for iterating on corners of an n-dimensional box
-     * @param dim
      * @return the first valid corners in an dim-dimensional box
     **/
-    static  boxCorner    getFirst     (int dim) 
-    {GISMO_UNUSED(dim); return boxCorner(1);}
+    static  boxCorner    getFirst     (int)
+    { return boxCorner(1); }
 
     /**
      * @brief helper for iterating on corners of an n-dimensional box

--- a/src/gsCore/gsBulk.h
+++ b/src/gsCore/gsBulk.h
@@ -63,8 +63,6 @@ public:
 
     int domainDim() const { return 4; }
 
-    void toMesh(gsMesh<T> & msh, int npoints = 3375) const;
-
     virtual gsGeometryEvaluator<Scalar_t> * evaluator(unsigned flags) const;
 
 }; // class gsBulk

--- a/src/gsCore/gsBulk.hpp
+++ b/src/gsCore/gsBulk.hpp
@@ -21,7 +21,7 @@ namespace gismo
 
 
 template<class T> 
-void gsBulk<T>::toMesh(gsMesh<T> & msh, int npoints) const
+void gsBulk<T>::toMesh(gsMesh<T> & msh, int ) const
 {   
     // OLD CODE NEVER USED gsTensorGridIter has been superseded
 

--- a/src/gsCore/gsBulk.hpp
+++ b/src/gsCore/gsBulk.hpp
@@ -19,35 +19,6 @@
 namespace gismo
 {
 
-
-template<class T> 
-void gsBulk<T>::toMesh(gsMesh<T> & msh, int ) const
-{   
-    // OLD CODE NEVER USED gsTensorGridIter has been superseded
-
-
-    // const gsMatrix<T> param        = this->parameterRange(); 
-    // const gsVector<unsigned> np    = uniformSampleCount(param.col(0), param.col(1), npoints );
-
-    // gsMatrix<T> cp; // Curve point
-
-    // gsTensorGridIter<3,T> grid(param, np);
-
-    // for(; grid.isGood(); grid.next() )
-    // {
-    //     this->eval_into(grid.currPoint, cp);
-    //     msh.addVertex( cp );
-    // }
-
-    // gsVector<unsigned> v;
-    // v.setZero(3);
-    // do 
-    // {
-    //     msh.addFace(v[0], v[0]+1, v[1]+1, v[1]);
-    // }
-    // while( nextLexicographic(v, np) )
-}
-
 template<class T> 
 gsGeometryEvaluator<T> *
 gsBulk<T>::evaluator(unsigned flags) const

--- a/src/gsCore/gsConstantFunction.h
+++ b/src/gsCore/gsConstantFunction.h
@@ -100,10 +100,9 @@ public:
 
     GISMO_CLONE_FUNCTION(gsConstantFunction)
 
-    const gsConstantFunction<T> & piece(const index_t k) const
+    const gsConstantFunction<T> & piece(const index_t) const
     {
         // same on all pieces
-        GISMO_UNUSED(k);
         return *this; 
     }
 

--- a/src/gsCore/gsCurve.h
+++ b/src/gsCore/gsCurve.h
@@ -77,7 +77,7 @@ public: inline uPtr clone() const { return uPtr(clone_impl()); }
         this->basis().reverse();
     }
 
-    virtual bool isOn(gsMatrix<T> const &u, T tol = 1e-3) const
+    virtual bool isOn(gsMatrix<T> const &, T = 1e-3) const
     { GISMO_NO_IMPLEMENTATION }
 
 }; // class gsCurve

--- a/src/gsCore/gsDomain.h
+++ b/src/gsCore/gsDomain.h
@@ -52,9 +52,7 @@ public:
     /// Returns a bounding box for the domain
     /// eg. This coincides to the domain in case of tensor-product domains
     virtual gsMatrix<T> boundingBox()
-    {
-        GISMO_NO_IMPLEMENTATION
-    }
+    {GISMO_NO_IMPLEMENTATION}
 
     /// Returns a list of elements
     virtual gsMatrix<T> elements()

--- a/src/gsCore/gsDomainIterator.h
+++ b/src/gsCore/gsDomainIterator.h
@@ -232,8 +232,8 @@ public:
 
     /// Updates \a other with and adjacent element
     /// \todo upgrade to return adjacent range instead
-    virtual void adjacent( const gsVector<bool> & orient, 
-                           gsDomainIterator & other )
+    virtual void adjacent( const gsVector<bool> & ,
+                           gsDomainIterator & )
     {
         GISMO_NO_IMPLEMENTATION
     }

--- a/src/gsCore/gsField.h
+++ b/src/gsCore/gsField.h
@@ -168,13 +168,12 @@ public:
     /// func on the physical domain
     T distanceH1(gsFunction<T> const & func, 
                  bool isFunc_param = false,
-                 int numEvals=1000) const 
+                 int = 1000) const
     {
         if ( m_parametric ) // isogeometric field
             return igaFieldH1Distance(*this, func, isFunc_param);
         else
         {
-            GISMO_UNUSED(numEvals);
             gsWarn <<"H1 seminorm not implemented.\n";
             return -1;
         }
@@ -185,13 +184,12 @@ public:
     T distanceH1(gsFunction<T> const & func,
                  gsMultiBasis<T> const & B,
                  bool isFunc_param = false,
-                 int numEvals=1000) const
+                 int = 1000) const
     {
         if ( m_parametric ) // isogeometric field
             return igaFieldH1Distance(*this, func, B,isFunc_param);
         else
         {
-            GISMO_UNUSED(numEvals);
             gsWarn <<"H1 seminorm not implemented.\n";
             return -1;
         }
@@ -201,13 +199,12 @@ public:
     /// func on the physical domain
     T distanceDG(gsFunction<T> const & func, 
                  bool isFunc_param = false,
-                 int numEvals=1000) const 
+                 int = 1000) const
     {
         if ( m_parametric ) // isogeometric field
             return igaFieldDGDistance(*this, func, isFunc_param);
         else
         {
-            GISMO_UNUSED(numEvals);
             gsWarn <<"DG norm not implemented.\n";
             return -1;
         }

--- a/src/gsCore/gsFuncData.h
+++ b/src/gsCore/gsFuncData.h
@@ -74,7 +74,7 @@ public:
      * @param patch in case of multipatch structures, on which patch to compute
      */
     explicit gsFuncData(unsigned flags = 0, int patch = 0)
-    : flags(flags), patchId(0)
+    : flags(flags), patchId(patch)
     { }
 
 public:

--- a/src/gsCore/gsFunction.h
+++ b/src/gsCore/gsFunction.h
@@ -208,8 +208,8 @@ public:
 
     /// @brief Computes the L2-distance between this function and the
     /// field and a function \a func
-    virtual T distanceL2(gsFunction<T> const & func) const
-    { GISMO_UNUSED(func); GISMO_NO_IMPLEMENTATION }
+    virtual T distanceL2(gsFunction<T> const &) const
+    { GISMO_NO_IMPLEMENTATION }
 
     /// Newton-Raphson method to find a solution of the equation f(\a
     /// arg) = \a value with starting vector \a arg.

--- a/src/gsCore/gsFunction.hpp
+++ b/src/gsCore/gsFunction.hpp
@@ -232,9 +232,9 @@ int gsFunction<T>::targetDim() const
 */
 
 template <class T>
-void gsFunction<T>::eval_component_into(const gsMatrix<T>& u, 
-                                        const index_t comp,
-                                        gsMatrix<T>& result) const
+void gsFunction<T>::eval_component_into(const gsMatrix<T>&,
+                                        const index_t,
+                                        gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template <class T> gsMatrix<T>

--- a/src/gsCore/gsFunctionExpr.h
+++ b/src/gsCore/gsFunctionExpr.h
@@ -119,9 +119,8 @@ public:
 
     // Function expression can be used as a global function defined
     // for any real value, on any subdomain
-    virtual const gsFunctionExpr & piece(const index_t k) const
+    virtual const gsFunctionExpr & piece(const index_t) const
     {
-        GISMO_UNUSED(k);
         return *this; 
     }
 

--- a/src/gsCore/gsFunctionSet.h
+++ b/src/gsCore/gsFunctionSet.h
@@ -209,7 +209,7 @@ public:
     GISMO_UPTR_FUNCTION_NO_IMPLEMENTATION(gsFunctionSet, clone)
 
     /// @brief Returns the piece(s) of the function(s) at subdomain \a k
-    virtual const gsFunctionSet & piece(const index_t k) const {return *this;}
+    virtual const gsFunctionSet & piece(const index_t) const {return *this;}
 
     /// @brief Helper which casts and returns the k-th piece of this
     /// function set as a gsFunction
@@ -512,8 +512,8 @@ public:
 
        @param[in] in 
        @param[out] out
-     */
-    virtual void compute(const gsMapData<T> & in, gsFuncData<T> & out) const;
+     */ // TODO: remove me, update devel
+    //virtual void compute(const gsMapData<T> & in, gsFuncData<T> & out) const;
 
 public:
     /**

--- a/src/gsCore/gsFunctionSet.h
+++ b/src/gsCore/gsFunctionSet.h
@@ -498,23 +498,6 @@ public:
      */
     virtual void compute(const gsMatrix<T> & in, gsFuncData<T> & out) const;
 
-    /**
-       @brief Computes function data
-
-       This function evaluates the functions and their derivatives at
-       the points contained in the gsMapData geo. The computed values
-       are written in the corresponding fields of \a result.  Which
-       field to write (and what to compute) is controlled by the \a
-       out.flags (see also gsFuncData).  Contrarily to
-       compute(const gsMatrix<T> &, gsFuncData<T> &) where the caller
-       must provide either parametric or physical points this call
-       differenciate automatically.  
-
-       @param[in] in 
-       @param[out] out
-     */ // TODO: remove me, update devel
-    //virtual void compute(const gsMapData<T> & in, gsFuncData<T> & out) const;
-
 public:
     /**
        @brief Dimension of the (source) domain.

--- a/src/gsCore/gsFunctionSet.h
+++ b/src/gsCore/gsFunctionSet.h
@@ -202,7 +202,7 @@ public:
 
     gsFunctionSet();
 
-    gsFunctionSet(const gsFunctionSet & o);
+    gsFunctionSet(const gsFunctionSet &);
 
     virtual ~gsFunctionSet();
 

--- a/src/gsCore/gsFunctionSet.hpp
+++ b/src/gsCore/gsFunctionSet.hpp
@@ -19,22 +19,13 @@ namespace gismo
 {
 
 template <class T>
-gsFunctionSet<T>::gsFunctionSet()
-{ 
-
-}
+gsFunctionSet<T>::gsFunctionSet() {}
 
 template <class T>
-gsFunctionSet<T>::gsFunctionSet(const gsFunctionSet & o)
-{ 
-
-}
+gsFunctionSet<T>::gsFunctionSet(const gsFunctionSet &) {}
 
 template <class T>
-gsFunctionSet<T>::~gsFunctionSet ()
-{ 
-
-}
+gsFunctionSet<T>::~gsFunctionSet () {}
 
 template <class T>
 const gsFunction<T>& gsFunctionSet<T>::function(const index_t k) const

--- a/src/gsCore/gsFunctionSet.hpp
+++ b/src/gsCore/gsFunctionSet.hpp
@@ -191,29 +191,4 @@ void gsFunctionSet<T>::compute(const gsMatrix<T> & in,
     }
 }
 
-// Always returns quantities on mapped (physical) domain coordinates
-//template <class T>
-//void gsFunctionSet<T>::compute(const gsMapData<T> & in, gsFuncData<T> & out) const
-//{
-//    // the dafault implementation assumes a representation in parametric coordinates
-//    compute(in.points, out);
-//
-///* // todo gsFunctionExpr par/phys..
-//    const int parDim = domainDim();
-//    const int nGrads = out.values[1].rows() / parDim;
-//
-//    if (out.flags & NEED_DERIV)
-//    {
-//        for (index_t p = 0; p != in.points.cols(); ++p) // for all points
-//        {
-//            // first fundamental form at the current point
-//            const gsAsConstMatrix<T> fform = in.fundForm(p);
-//            gsAsMatrix<T> grads(out.values[1].col(p).data(), parDim, nGrads);
-//            grads = fform * grads;//tmp
-//        }
-//    }
-//*/
-//}
-
-
 } // namespace gismo

--- a/src/gsCore/gsFunctionSet.hpp
+++ b/src/gsCore/gsFunctionSet.hpp
@@ -62,7 +62,7 @@ gsMatrix<T> gsFunctionSet<T>::support() const
 // actives
 
 template <typename T>
-void gsFunctionSet<T>::active_into     (const gsMatrix<T> &u, gsMatrix<unsigned> &result) const
+void gsFunctionSet<T>::active_into (const gsMatrix<T> &, gsMatrix<unsigned> &) const
 {
     GISMO_NO_IMPLEMENTATION
     // Single function 0 globally active:
@@ -72,15 +72,15 @@ void gsFunctionSet<T>::active_into     (const gsMatrix<T> &u, gsMatrix<unsigned>
 // evaluation
 
 template <typename T>
-void gsFunctionSet<T>::eval_into (const gsMatrix<T> &u, gsMatrix<T> &result) const
+void gsFunctionSet<T>::eval_into (const gsMatrix<T> &, gsMatrix<T> &) const
 {GISMO_NO_IMPLEMENTATION}
 
 template <typename T>
-void gsFunctionSet<T>::deriv_into (const gsMatrix<T> &u, gsMatrix<T> &result) const 
+void gsFunctionSet<T>::deriv_into (const gsMatrix<T> &, gsMatrix<T> &) const
 {GISMO_NO_IMPLEMENTATION}
 
 template <typename T>
-void gsFunctionSet<T>::deriv2_into (const gsMatrix<T> &u, gsMatrix<T> &result) const
+void gsFunctionSet<T>::deriv2_into (const gsMatrix<T> &, gsMatrix<T> &) const
 {GISMO_NO_IMPLEMENTATION}
 
 template <typename T>

--- a/src/gsCore/gsFunctionSet.hpp
+++ b/src/gsCore/gsFunctionSet.hpp
@@ -201,28 +201,28 @@ void gsFunctionSet<T>::compute(const gsMatrix<T> & in,
 }
 
 // Always returns quantities on mapped (physical) domain coordinates
-template <class T>
-void gsFunctionSet<T>::compute(const gsMapData<T> & in, gsFuncData<T> & out) const
-{
-    // the dafault implementation assumes a representation in parametric coordinates
-    compute(in.points, out);
-
-/* // todo gsFunctionExpr par/phys..
-    const int parDim = domainDim();
-    const int nGrads = out.values[1].rows() / parDim;
-
-    if (out.flags & NEED_DERIV)
-    {
-        for (index_t p = 0; p != in.points.cols(); ++p) // for all points
-        {
-            // first fundamental form at the current point
-            const gsAsConstMatrix<T> fform = in.fundForm(p);
-            gsAsMatrix<T> grads(out.values[1].col(p).data(), parDim, nGrads);
-            grads = fform * grads;//tmp
-        }
-    }
-*/
-}
+//template <class T>
+//void gsFunctionSet<T>::compute(const gsMapData<T> & in, gsFuncData<T> & out) const
+//{
+//    // the dafault implementation assumes a representation in parametric coordinates
+//    compute(in.points, out);
+//
+///* // todo gsFunctionExpr par/phys..
+//    const int parDim = domainDim();
+//    const int nGrads = out.values[1].rows() / parDim;
+//
+//    if (out.flags & NEED_DERIV)
+//    {
+//        for (index_t p = 0; p != in.points.cols(); ++p) // for all points
+//        {
+//            // first fundamental form at the current point
+//            const gsAsConstMatrix<T> fform = in.fundForm(p);
+//            gsAsMatrix<T> grads(out.values[1].col(p).data(), parDim, nGrads);
+//            grads = fform * grads;//tmp
+//        }
+//    }
+//*/
+//}
 
 
 } // namespace gismo

--- a/src/gsCore/gsGeometry.hpp
+++ b/src/gsCore/gsGeometry.hpp
@@ -93,7 +93,7 @@ void gsGeometry<T>::evaluateMesh(gsMesh<T>& mesh) const
     }
 }
 template<class T>
-std::vector<gsGeometry<T>* >  gsGeometry<T>::uniformSplit(index_t dir) const
+std::vector<gsGeometry<T>* > gsGeometry<T>::uniformSplit(index_t) const
 {
     GISMO_NO_IMPLEMENTATION
 }
@@ -136,20 +136,20 @@ void gsGeometry<T>::invertPoints(const gsMatrix<T> & points,
 
 
 template<class T>
-void gsGeometry<T>::merge( gsGeometry * other )
+void gsGeometry<T>::merge(gsGeometry *)
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
 gsGeometryEvaluator<typename gsGeometry<T>::Scalar_t> * 
-gsGeometry<T>:: evaluator(unsigned flags) const
+gsGeometry<T>:: evaluator(unsigned) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsGeometry<T>::toMesh(gsMesh<T> & msh, int npoints) const
+void gsGeometry<T>::toMesh(gsMesh<T> &, int) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
-void gsGeometry<T>::outerNormal_into(const gsMatrix<T>& u, gsMatrix<T> & result) const
+void gsGeometry<T>::outerNormal_into(const gsMatrix<T>&, gsMatrix<T> &) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>

--- a/src/gsCore/gsMultiBasis.h
+++ b/src/gsCore/gsMultiBasis.h
@@ -36,6 +36,8 @@ template<class T>
 class gsMultiBasis : public gsFunctionSet<T>
 {
 public:
+    typedef gsFunctionSet<T> Base;
+
     typedef memory::shared_ptr<gsMultiBasis> Ptr;
     typedef memory::unique_ptr<gsMultiBasis> uPtr;
 

--- a/src/gsCore/gsMultiBasis.hpp
+++ b/src/gsCore/gsMultiBasis.hpp
@@ -39,7 +39,8 @@ gsMultiBasis<T>::gsMultiBasis( const gsMultiPatch<T> & mpatch, bool NoRational)
   
 template<class T>
 gsMultiBasis<T>::gsMultiBasis( const gsMultiBasis& other )
-: m_bases         ( other.m_bases.size() ),
+: Base(other),
+  m_bases         ( other.m_bases.size() ),
   m_topology      ( other.m_topology     )
 {
     cloneAll( other.m_bases.begin(), other.m_bases.end(), this->m_bases.begin() );

--- a/src/gsCore/gsMultiBasis.hpp
+++ b/src/gsCore/gsMultiBasis.hpp
@@ -125,7 +125,7 @@ void gsMultiBasis<T>::addInterface( gsBasis<T>* g1, boxSide s1,
 namespace {
 template <typename T>
 struct take_first {
-    T operator() (const T& a, const T&b) { return a; }
+    T operator() (const T& a, const T&) { return a; }
 };
 }
 

--- a/src/gsCore/gsMultiPatch.h
+++ b/src/gsCore/gsMultiPatch.h
@@ -34,7 +34,9 @@ class gsMultiPatch : public gsBoxTopology, public gsFunctionSet<T>
 {
 
 public:
-    typedef gsBoxTopology Base;
+    typedef gsBoxTopology    BaseA;
+    typedef gsFunctionSet<T> BaseB;
+    
     /// Shared pointer for gsMultiPatch
     typedef memory::shared_ptr< gsMultiPatch > Ptr;
     /// Unique pointer for gsMultiPatch
@@ -66,7 +68,7 @@ public:
 #else
     /// Move constructor
     gsMultiPatch( gsMultiPatch&& other )
-        : gsBoxTopology( give(other) ), m_patches( give(other.m_patches) )
+        : BaseA( give(other) ), m_patches( give(other.m_patches) )
     {}
 
     /// Assignment operator 
@@ -139,7 +141,7 @@ public:
     /// \brief Swap with another gsMultiPatch
     void swap(gsMultiPatch& other)
     {
-        gsBoxTopology::swap( other );
+        BaseA::swap( other );
         m_patches.swap( other.m_patches );
     }
 
@@ -180,7 +182,7 @@ public:
     /// \brief Returns a vector of patches // to do : replace by copies
     PatchContainer const& patches() const { return m_patches; }
 
-    const gsBoxTopology & topology() const { return *this; }
+    const BaseA & topology() const { return *this; }
     
     /// \brief Return the \a i-th patch.
     const gsGeometry<T> & operator []( size_t i ) const { return *m_patches[i]; }
@@ -221,12 +223,12 @@ public:
     GISMO_DEPRECATED void addInterface( gsGeometry<T>* g1, boxSide s1,
             gsGeometry<T>* g2, boxSide s2 );
 
-    using Base::addInterface; // unhide base function
+    using BaseA::addInterface; // unhide base function
     
     /// Add side \a s of patch \a g to the outer boundary of the domain
     void addPatchBoundary( gsGeometry<T>* g, boxSide s ) {
         int p = findPatchIndex( g );
-        gsBoxTopology::addBoundary( patchSide( p, s ) );
+        BaseA::addBoundary( patchSide( p, s ) );
     }
 
     /// Get coordinates of the patchCorner \a pc in the physical domain
@@ -270,7 +272,7 @@ public:
     /// Clear (delete) all patches
     void clear()
     {
-        Base::clearAll();
+        BaseA::clearAll();
         freeAll(m_patches);
         m_patches.clear();
     }

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -25,7 +25,7 @@ namespace gismo
 
 template<class T>
 gsMultiPatch<T>::gsMultiPatch(const gsGeometry<T> & geo )
-    : gsBoxTopology( geo.parDim() )
+    : BaseA( geo.parDim() )
 {
     m_patches.push_back(geo.clone().release());
     //m_patches[0]->setId(0); // Note: for the single-patch constructor the id remains unchanged
@@ -35,7 +35,7 @@ gsMultiPatch<T>::gsMultiPatch(const gsGeometry<T> & geo )
 
 template<class T>
 gsMultiPatch<T>::gsMultiPatch( const gsMultiPatch& other )
-    : gsBoxTopology( other ), m_patches( other.m_patches.size() )
+    : BaseA( other ), BaseB( other ), m_patches( other.m_patches.size() )
 {
     // clone all geometries
     cloneAll( other.m_patches.begin(), other.m_patches.end(),
@@ -50,7 +50,7 @@ gsMultiPatch<T>& gsMultiPatch<T>::operator=( const gsMultiPatch& other )
     if (this!=&other)
     {
         freeAll(m_patches);
-        Base::operator=(other);
+        BaseA::operator=(other);
         m_patches.resize(other.m_patches.size());
         // clone all geometries
         cloneAll( other.m_patches.begin(), other.m_patches.end(),
@@ -63,7 +63,7 @@ template<class T>
 gsMultiPatch<T>& gsMultiPatch<T>::operator=( gsMultiPatch&& other )
 {
     freeAll(m_patches);
-    Base::operator=(give(other));
+    BaseA::operator=(give(other));
     m_patches = give(other.m_patches);
     return *this;
 }
@@ -73,7 +73,7 @@ gsMultiPatch<T>& gsMultiPatch<T>::operator=( gsMultiPatch&& other )
 
 template<class T>
 gsMultiPatch<T>::gsMultiPatch(PatchContainer & patches )
-    : gsBoxTopology( patches[0]->parDim(), patches.size() )
+    : BaseA( patches[0]->parDim(), patches.size() )
 {
     m_patches.swap(patches); // patches are consumed
     setIds();
@@ -84,7 +84,7 @@ template<class T>
 gsMultiPatch<T>::gsMultiPatch( PatchContainer& patches,
                                const std::vector<patchSide>& boundary,
                                const std::vector<boundaryInterface>& interfaces )
-    : gsBoxTopology( patches[0]->parDim(), patches.size(), boundary, interfaces )
+    : BaseA( patches[0]->parDim(), patches.size(), boundary, interfaces )
 {
     m_patches.swap(patches); // patches are consumed
     setIds();
@@ -126,7 +126,7 @@ std::string gsMultiPatch<T>::detail() const
     print(os);
     if ( nPatches() > 0 ) 
     {
-        gsBoxTopology::print( os );
+        BaseA::print( os );
     }
     return os.str();
 }
@@ -230,7 +230,7 @@ void gsMultiPatch<T>::addInterface( gsGeometry<T>* g1, boxSide s1,
 {
     int p1 = findPatchIndex( g1 );
     int p2 = findPatchIndex( g2 );
-    gsBoxTopology::addInterface( p1, s1, p2, s2 );
+    BaseA::addInterface( p1, s1, p2, s2 );
 }
 
 template<class T>
@@ -315,7 +315,7 @@ gsMultiPatch<T> gsMultiPatch<T>::uniformSplit() const
 template<class T>
 bool gsMultiPatch<T>::computeTopology( T tol, bool cornersOnly )
 {
-    gsBoxTopology::clearTopology();
+    BaseA::clearTopology();
 
     const size_t   np    = m_patches.size();
     const index_t  nCorP = 1 << m_dim;     // corners per patch
@@ -406,7 +406,7 @@ bool gsMultiPatch<T>::computeTopology( T tol, bool cornersOnly )
             {
                 dirMap(side.direction()) = pSide[other].direction();
                 dirOr (side.direction()) = !( side.parameter() == pSide[other].parameter() );
-                gsBoxTopology::addInterface( boundaryInterface(side, pSide[other], dirMap, dirOr));
+                BaseA::addInterface( boundaryInterface(side, pSide[other], dirMap, dirOr));
                 // done with pSide[other], remove it from candidate list
                 std::swap( pSide[other], pSide.back() );
                 pSide.pop_back();
@@ -415,7 +415,7 @@ bool gsMultiPatch<T>::computeTopology( T tol, bool cornersOnly )
             }
         }
         if (!done) // not an interface ?
-            gsBoxTopology::addBoundary( side );
+            BaseA::addBoundary( side );
     }
 
     return true;

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -496,7 +496,6 @@ template<class T>
 void gsMultiPatch<T>::closeGaps(T tol)
 {
     const T tol2 = tol*tol;
-    //GISMO_UNUSED(tol);
     gsMatrix<unsigned> bdr1, bdr2; // indices of the boundary control points
 
     // Create a map which assigns to all meeting patch-local indices a

--- a/src/gsCore/gsPiecewiseFunction.h
+++ b/src/gsCore/gsPiecewiseFunction.h
@@ -41,23 +41,23 @@ public:
 
 public:
 
-    gsPiecewiseFunction(index_t npieces = 0)
+    explicit gsPiecewiseFunction(index_t npieces = 0) : gsFunctionSet<T>()
     { m_funcs.reserve(2+npieces); }
 
-    gsPiecewiseFunction(const gsFunction<T> & func)
+    gsPiecewiseFunction(const gsFunction<T> & func) : gsFunctionSet<T>(func)
     {
         m_funcs.push_back(func.clone().release());
         //m_funcs.resize(n, func.clone());
     }
 
-    gsPiecewiseFunction(const gsPiecewiseFunction & other)
+    gsPiecewiseFunction(const gsPiecewiseFunction & other) : gsFunctionSet<T>(other)
     {
         m_funcs.resize(other.m_funcs.size() );
         cloneAll( other.m_funcs.begin(), other.m_funcs.end(),
                   m_funcs.begin() );
     }
 
-    gsPiecewiseFunction(FunctionContainer & funcs)
+    gsPiecewiseFunction(FunctionContainer & funcs) : gsFunctionSet<T>()
     {
         m_funcs.swap(funcs); // funcs are consumed
     }

--- a/src/gsCore/gsVolume.h
+++ b/src/gsCore/gsVolume.h
@@ -65,8 +65,6 @@ public: inline uPtr clone() const { return uPtr(clone_impl()); }
 
     int domainDim() const { return 3; }
 
-    void toMesh(gsMesh<T> & msh, int npoints = 3375) const;
-
     virtual gsGeometryEvaluator<Scalar_t> * evaluator(unsigned flags) const;
 
 }; // class gsVolume

--- a/src/gsCore/gsVolume.hpp
+++ b/src/gsCore/gsVolume.hpp
@@ -19,34 +19,6 @@
 namespace gismo
 {
 
-
-template<class T> 
-void gsVolume<T>::toMesh(gsMesh<T> & msh, int npoints) const
-{   
-    // OLD CODE NEVER USED gsTensorGridIter has been superseded
-
-    // const gsMatrix<T> param        = this->parameterRange();
-    // const gsVector<unsigned> np    = uniformSampleCount(param.col(0), param.col(1), npoints );
-
-    // gsMatrix<T> cp; // Curve point
-
-    // gsTensorGridIter<3,T> grid(param, np);
-
-    // for(; grid.isGood(); grid.next() )
-    // {
-    //     this->eval_into(grid.currPoint, cp);
-    //     msh.addVertex( cp );
-    // }
-
-    // gsVector<unsigned> v;
-    // v.setZero(3);
-    // do 
-    // {
-    //     msh.addFace(v[0], v[0]+1, v[1]+1, v[1]);
-    // }
-    // while( nextLexicographic(v, np) )
-}
-
 template<class T> 
 gsGeometryEvaluator<T> *
 gsVolume<T>::evaluator(unsigned flags) const

--- a/src/gsHSplines/gsHDomain.h
+++ b/src/gsHSplines/gsHDomain.h
@@ -668,7 +668,7 @@ private:
         typedef int return_type;
         static const return_type init = 0;
         
-        static void visitLeaf(kdnode<d,T> * leafNode, return_type & i)
+        static void visitLeaf(kdnode<d,T> * , return_type & i)
         {
             i++;
         }
@@ -680,7 +680,7 @@ private:
         typedef int return_type;
         static const return_type init = 0;
         
-        static void visitNode(kdnode<d,T> * _node, return_type & i)
+        static void visitNode(kdnode<d,T> * , return_type & i)
         {
             i++;
         }
@@ -692,7 +692,7 @@ private:
         typedef int return_type;
         static const return_type init = 0;
         
-        static void visitNode(kdnode<d,T> * leafNode, return_type & i)
+        static void visitNode(kdnode<d,T> * leafNode, return_type &)
         {
             leafNode->multiplyByTwo();
         }

--- a/src/gsHSplines/gsHDomain.h
+++ b/src/gsHSplines/gsHDomain.h
@@ -566,7 +566,7 @@ private:
     static bool isDegenerate(box const & someBox);
 
     /// Adds \a nlevels new index levels in the tree
-    void setIndexLevel(int nlevels) const
+    void setIndexLevel(int) const
     {
         GISMO_NO_IMPLEMENTATION
     }
@@ -644,9 +644,8 @@ private:
         typedef int return_type;
         static const return_type init = 0;
         
-        static void visitLeaf(kdnode<d,T> * leafNode, return_type & i)
+        static void visitLeaf(kdnode<d,T> * leafNode, return_type &)
         {
-            GISMO_UNUSED(i);
             leafNode->level++;
         }
     };
@@ -657,9 +656,8 @@ private:
         typedef int return_type;
         static const return_type init = 0;
         
-        static void visitLeaf(kdnode<d,T> * leafNode, return_type & i)
+        static void visitLeaf(kdnode<d,T> * leafNode, return_type &)
         {
-            GISMO_UNUSED(i);
             leafNode->level--;
         }
     };
@@ -706,9 +704,8 @@ private:
         typedef int return_type;
         static const return_type init = 0;
         
-        static void visitLeaf(kdnode<d,T> * leafNode, return_type & i)
+        static void visitLeaf(kdnode<d,T> * leafNode, return_type &)
         {
-            GISMO_UNUSED(i);
             gsInfo << *leafNode;
         }
     };

--- a/src/gsHSplines/gsHDomain.hpp
+++ b/src/gsHSplines/gsHDomain.hpp
@@ -85,7 +85,7 @@ namespace {
         static const return_type init = 1000000;
 
         template<unsigned d, class T >
-        static void visitLeaf(gismo::kdnode<d,T> * leafNode , int level, return_type & res)
+        static void visitLeaf(gismo::kdnode<d,T> * leafNode , int , return_type & res)
         {
             //if ( (!isDegenerate(*leafNode->box)) && leafNode->level < res )
             if ( leafNode->level < res )
@@ -103,7 +103,7 @@ namespace {
         static const return_type init = -1;
 
         template<unsigned d, class T >
-        static void visitLeaf(gismo::kdnode<d,T> * leafNode , int level, return_type & res)
+        static void visitLeaf(gismo::kdnode<d,T> * leafNode , int , return_type & res)
         {
             //if ( (!isDegenerate(*leafNode->box)) && leafNode->level > res )
             if ( leafNode->level > res )

--- a/src/gsHSplines/gsHTensorBasis.hpp
+++ b/src/gsHSplines/gsHTensorBasis.hpp
@@ -1046,6 +1046,7 @@ void gsHTensorBasis<d,T>::evalAllDers_into(const gsMatrix<T> & u, int n,
 template<unsigned d, class T>
 void gsHTensorBasis<d,T>::uniformRefine(int numKnots, int mul)
 {
+    GISMO_UNUSED(numKnots);
     GISMO_ASSERT(numKnots == 1, "Only implemented for numKnots = 1");
 
     GISMO_ASSERT( m_tree.getMaxInsLevel() < static_cast<unsigned>(m_bases.size()),

--- a/src/gsHSplines/gsTHBSpline.hpp
+++ b/src/gsHSplines/gsTHBSpline.hpp
@@ -82,6 +82,10 @@ template<unsigned d, class T>
 //void gsTHBSpline<d,T>::getBsplinePatches(gsMatrix<unsigned>& b1, gsMatrix<unsigned>& b2, gsVector<unsigned>& level, std::vector< gsTensorBSpline<2> >& bpatches) const
 void gsTHBSpline<d, T>::getBsplinePatches(gsMatrix<unsigned>& b1, gsMatrix<unsigned>& b2, gsVector<unsigned>& level) const
 {
+    GISMO_UNUSED(b1);
+    GISMO_UNUSED(b2);
+    GISMO_UNUSED(level);
+    GISMO_NO_IMPLEMENTATION
     //------------------------------------------------------------------------------------------------------------------------------
     // define the 6 boxes and the corresponding levels for the MTU fillet example *** TO BE SUBSTITUTED WITH AUTOMATIC SPLITTING ***
     //------------------------------------------------------------------------------------------------------------------------------

--- a/src/gsIO/gsCmdLine.cpp
+++ b/src/gsIO/gsCmdLine.cpp
@@ -121,9 +121,9 @@ public:
     class GismoNullOut : public TCLAP::CmdLineOutput
     {
     public:
-        void failure(TCLAP::CmdLineInterface& c, TCLAP::ArgException& e) { }
-        void usage(TCLAP::CmdLineInterface& c)  { }
-        void version(TCLAP::CmdLineInterface& c) { }
+        void failure(TCLAP::CmdLineInterface& , TCLAP::ArgException& ) { }
+        void usage(TCLAP::CmdLineInterface& )  { }
+        void version(TCLAP::CmdLineInterface& ) { }
     };
 
 

--- a/src/gsIO/gsCmdLine.cpp
+++ b/src/gsIO/gsCmdLine.cpp
@@ -404,9 +404,8 @@ void gsCmdLinePrivate::GismoCmdOut::usage(TCLAP::CmdLineInterface& c)
 }
 
 
-void gsCmdLinePrivate::GismoCmdOut::version(TCLAP::CmdLineInterface& c)
+void gsCmdLinePrivate::GismoCmdOut::version(TCLAP::CmdLineInterface&)
 {
-    GISMO_UNUSED(c);
     gsCmdLine::printVersion();
 }
 

--- a/src/gsIO/gsFileData.hpp
+++ b/src/gsIO/gsFileData.hpp
@@ -1291,7 +1291,8 @@ bool gsFileData<T>::readStlFile( String const & fn )
 
 template<class T>
 bool gsFileData<T>::readObjFile( String const & fn )
-{    
+{
+    GISMO_UNUSED(fn);
     //gsWarn<<"Assuming Linux file, please convert dos2unix first.\n";
 
 #if FALSE

--- a/src/gsIO/gsXmlUtils.hpp
+++ b/src/gsIO/gsXmlUtils.hpp
@@ -129,7 +129,7 @@ public:
             if (trimID>-1)
                 m->addFace(vert, getById< gsTrimSurface<T> >( toplevel, trimID ) );
             else if (trimID==-1 && nLoops == 1)
-                m->addFace(vert[0]);
+                GISMO_ERROR("Case not handled");
             else if (trimID==-1)
             {
                 gsWarn<<"\nAutomatic creation of trimmed surfaces is only supported for a single loop\n";

--- a/src/gsIO/gsXmlUtils.hpp
+++ b/src/gsIO/gsXmlUtils.hpp
@@ -297,8 +297,8 @@ public:
         return m;
     }
 
-    static gsXmlNode * put (const gsMesh<T> & obj,
-                            gsXmlTree & data )
+    static gsXmlNode * put (const gsMesh<T> &,
+                            gsXmlTree & )
     {
         return NULL;
     }
@@ -951,8 +951,8 @@ public:
         return NULL;
     }
     
-    static gsXmlNode * put (const gsPde<T> & obj,
-                            gsXmlTree & data )
+    static gsXmlNode * put (const gsPde<T> &,
+                            gsXmlTree & )
     {
         return NULL;
     }
@@ -1301,8 +1301,8 @@ public:
         return cf ;
     }
 
-    static gsXmlNode * put (const gsCurveFitting<T> & obj,
-                            gsXmlTree & data )
+    static gsXmlNode * put (const gsCurveFitting<T> &,
+                            gsXmlTree & )
     {
         return NULL;
     }
@@ -1377,8 +1377,8 @@ public:
         }
     }
     
-    static gsXmlNode * put (const gsPoissonPde<T> & obj,
-                            gsXmlTree & data )
+    static gsXmlNode * put (const gsPoissonPde<T> &,
+                            gsXmlTree & )
     {
         return NULL;
     }

--- a/src/gsMatrix/Adjugate.h
+++ b/src/gsMatrix/Adjugate.h
@@ -51,7 +51,7 @@ struct compute_adjugate
 template<typename MatrixType, typename ResultType>
 struct compute_adjugate<MatrixType, ResultType, 1>
 {
-    static inline void run(const MatrixType& matrix, ResultType& result)
+    static inline void run(const MatrixType& , ResultType& result)
     {
         result.coeffRef(0,0) = typename ResultType::Scalar(1);
     }

--- a/src/gsMatrix/gsSparseMatrix.h
+++ b/src/gsMatrix/gsSparseMatrix.h
@@ -221,7 +221,7 @@ public:
 
     // Avoid default keyword for MSVC<2013
     // https://msdn.microsoft.com/en-us/library/hh567368.aspx
-    gsSparseMatrix(const gsSparseMatrix& other)
+    gsSparseMatrix(const gsSparseMatrix& other) : Base(other)
     { Base::operator=(other); }
     gsSparseMatrix& operator= (const gsSparseMatrix & other)
     { Base::operator=(other); return *this; }

--- a/src/gsMatrix/gsSparseVector.h
+++ b/src/gsMatrix/gsSparseVector.h
@@ -90,7 +90,7 @@ public:
     
     // Avoid default keyword for MSVC<2013 
     // https://msdn.microsoft.com/en-us/library/hh567368.aspx
-    gsSparseVector(const gsSparseVector& other)
+    gsSparseVector(const gsSparseVector& other) : Base(other)
     { Base::operator=(other); }
 
     gsSparseVector& operator= (const gsSparseVector & other)

--- a/src/gsModeling/gsCurveLoop.h
+++ b/src/gsModeling/gsCurveLoop.h
@@ -32,7 +32,8 @@ namespace gismo
     \ingroup Modeling
 */
 
-template<class T> class gsCurveLoop
+template<class T>
+class gsCurveLoop
 {
 
 public:

--- a/src/gsModeling/gsCurveLoop.h
+++ b/src/gsModeling/gsCurveLoop.h
@@ -226,15 +226,10 @@ private:
 
 }; // class gsCurveLoop
 
-
-//////////////////////////////////////////////////
-//////////////////////////////////////////////////
-
 template<class T>
-bool gsCurveLoop<T>::isInterior ( gsVector<T> const & p, const T& tol)
+bool gsCurveLoop<T>::isInterior ( gsVector<T> const &, const T&)
 {
-    // to do
-    return false;
+    GISMO_NO_IMPLEMENTATION
 }
 
 /// Print (as string) operator to be used by all derived classes

--- a/src/gsModeling/gsCurveLoop.hpp
+++ b/src/gsModeling/gsCurveLoop.hpp
@@ -23,7 +23,7 @@ namespace gismo
 {
   
 template<class T>
-gsCurveLoop<T>::gsCurveLoop(const std::vector<gsVector3d<T> *> points3D, const std::vector<bool> isConvex, T margin, gsVector3d<T> *outNormal)
+gsCurveLoop<T>::gsCurveLoop(const std::vector<gsVector3d<T> *> points3D, const std::vector<bool> , T margin, gsVector3d<T> *outNormal)
 {
     // attempt to choose a curve loop by using the plane of best fit
     gsVector3d<T> resultNormal = initFrom3DPlaneFit(points3D, margin);
@@ -623,6 +623,7 @@ void gsCurveLoop<T>::flip1(T minu, T maxu)
 template<class T>
 gsMatrix<T> gsCurveLoop<T>::splitCurve(std::size_t curveId, T lengthRatio)
 {
+    GISMO_UNUSED(lengthRatio);
     GISMO_ASSERT(lengthRatio>0 && lengthRatio<1, "the second parameter *lengthRatio* must be between 0 and 1");
     GISMO_ASSERT(curveId < m_curves.size(), "the first parameter *curveID* exceeds the number of curves of the loop");
     // the two vertices a and b of the curve curveId, counting counterclockwise from z+

--- a/src/gsModeling/gsModelingUtils.hpp
+++ b/src/gsModeling/gsModelingUtils.hpp
@@ -407,7 +407,6 @@ gsBSpline<T> gsInterpolate(gsKnotVector<T> & kv,const gsMatrix<T> & preImage,
     int dimPI = 1; // dimension of space of preImage, TODO: put dimPI, dimI to template<dimPI,...
     int dimI = 2;  // dimension of space of image
     GISMO_UNUSED(dimPI);
-    GISMO_UNUSED(dimI);
     int nip = image.cols(); // number of interpolating points
     int nn=normal.cols(); // number of prescribed normals
     gsMatrix<T> Nu, dNu, dNu_nm, NuApp;

--- a/src/gsModeling/gsPlanarDomain.h
+++ b/src/gsModeling/gsPlanarDomain.h
@@ -159,15 +159,10 @@ public:
         return m_loops[loopNumber]->curve(curveNumber);
     }
 
-    bool contains( gsVector<T> const & p, T tol) {
-        // is on boundary ?
-
-        // is inside ?
-        //      std::vector<T> ind = lineIntersections(0,p[0]);
-        //gsMatrix<T> ev;
-
-        return true;
-    };
+    bool contains( gsVector<T> const &, T)
+    {
+        GISMO_NO_IMPLEMENTATION
+    }
 
     gsMatrix<T> boundingBox() const
     {

--- a/src/gsModeling/gsSolid.h
+++ b/src/gsModeling/gsSolid.h
@@ -123,11 +123,7 @@ public:
 // Non-constant members
 public:
     /// add coords to gsHeVertex, not yet pointers to HEs
-    void addHeVertex(scalar_t const& x, scalar_t const& y, scalar_t const& z=0);  
-
-    /// todo: each element of holeV is the pointer to a list of vertices of outer boundary and holes
-    gsSolidHalfFaceHandle addFace(std::vector< std::vector<gsSolidHeVertexHandle>* > holeV)
-    { return NULL; }
+    void addHeVertex(scalar_t const& x, scalar_t const& y, scalar_t const& z=0);
 
     /// add one face as a trimmed surface, the order of the vertices
     /// in *V* must be either CCW or CW when viewing from infinity for
@@ -200,14 +196,12 @@ public:
 
     /// \brief Insert a new vertex to an edge of the volume.
     /// \param he       the half-edge into which to insert the vertex
-    /// \param option   choice of method of inserting the new vertex:
-    ///         option = 0 (default): new vertex = midpoint of the edge
     /// \note This insertion only affects the volume containing the HE.
-    void insertNewVertex(gsSolidHalfEdgeHandle he, int const & option=0);
+    void insertNewVertex(gsSolidHalfEdgeHandle he);
     	
     /// @brief If there are impeding edges that make the solid inseparatable along a given HE \a he, this routine
     /// will create a new vertex on each impeding edges.
-    void handleImpedingEdges(gsSolidHalfEdgeHandle he, int const & option=0);
+    void handleImpedingEdges(gsSolidHalfEdgeHandle he);
 
     //void addPatch(gsPatch<T> *f) { this->addFace(f) ;};
     //void addCurve(gsCurve<T> *f) { this->addEdge(f) ;};      

--- a/src/gsModeling/gsSolid.hpp
+++ b/src/gsModeling/gsSolid.hpp
@@ -556,6 +556,7 @@ gsVolumeBlock<T> *gsSolid<T>::newVolume(gsSolidHalfFaceHandle startingFace)
 template <class T>
 void gsSolid<T>::checkStructure(bool checkVerts) const
 {
+    GISMO_UNUSED(checkVerts);
     size_t numEdges = edge.size();
     for(size_t idxE = 0; idxE < numEdges; idxE++)
     {
@@ -863,7 +864,7 @@ std::vector<typename gsSolid<T>::gsSolidHalfEdgeHandle > gsSolid<T>::impedingEdg
 }
 
 template <class T>
-void gsSolid<T>::insertNewVertex(gsSolidHalfEdgeHandle he, int const & option)
+void gsSolid<T>::insertNewVertex(gsSolidHalfEdgeHandle he)
 {
     using std::size_t;
     checkStructure();
@@ -971,7 +972,7 @@ void gsSolid<T>::insertNewVertex(gsSolidHalfEdgeHandle he, int const & option)
 }
 
 template <class T>
-void gsSolid<T>::handleImpedingEdges(gsSolidHalfEdgeHandle he, int const & option)
+void gsSolid<T>::handleImpedingEdges(gsSolidHalfEdgeHandle he)
 {
     typename std::vector<gsSolidHalfEdgeHandle> iHe;
     iHe=this->impedingEdges(he);
@@ -980,7 +981,7 @@ void gsSolid<T>::handleImpedingEdges(gsSolidHalfEdgeHandle he, int const & optio
     {
         for (it=iHe.begin();it!=iHe.end();++it)
         {
-            this->insertNewVertex(*it,option);
+            this->insertNewVertex(*it);
         }
     }
     checkStructure();

--- a/src/gsModeling/gsSolidHeVertex.h
+++ b/src/gsModeling/gsSolidHeVertex.h
@@ -33,7 +33,7 @@ public:
     
 // Data members    
 public:
-    gsVector3d<T> coords;
+    GISMO_DEPRECATED gsVector3d<T> coords;
     // halfedge out of this vertex
     gsSolidHalfEdgeHandle hed;    
     

--- a/src/gsModeling/gsTrimSurface.h
+++ b/src/gsModeling/gsTrimSurface.h
@@ -294,6 +294,7 @@ public:
 
     void cleanEndpoints(T eps)
     {
+      GISMO_UNUSED(eps);
       gsMatrix<T> supp = this->m_surface->support();
       size_t n = domain().loop(0).curves().size();
       for(size_t i = 0; i < n; i++)

--- a/src/gsMpi/gsMpiComm.h
+++ b/src/gsMpi/gsMpiComm.h
@@ -154,7 +154,7 @@ public:
      * @param[in] tag Specifies the message ID
      */
     template<typename T>
-    static int send (T* in, int len, int dest, int tag = 0)
+    static int send (T*, int, int, int = 0)
     {
         return 0;
     }
@@ -185,7 +185,7 @@ public:
      * @param[in] tag Specifies the message ID
      */
     template<typename T>
-    static int recv (T* out, int len, int source, int tag = 0)
+    static int recv (T*, int, int, int = 0)
     {
         return 0;
     }
@@ -227,7 +227,7 @@ public:
      * task.  @param[in] root The root task that gathers the data.
      */
     template<typename T>
-    static int gather (T* in, T* out, int len, int root) // note out must have same size as in
+    static int gather (T* in, T* out, int len, int) // note out must have same size as in
     {
         // copy_n(in, len, out);
         for (int i=0; i<len; i++)

--- a/src/gsNurbs/gsBSpline.h
+++ b/src/gsNurbs/gsBSpline.h
@@ -161,30 +161,33 @@ public:
     /// Returns a reference to the knot vector
     KnotVectorType & knots(const int i = 0) 
     {
+        GISMO_UNUSED(i);
         GISMO_ASSERT( i==0, "Requested knots of invalid direction "<< i );
-        return this->basis().knots(); 
+        return this->basis().knots();
     }
 
     /// Returns a (const )reference to the knot vector
     const KnotVectorType & knots(const int i = 0) const 
-    { 
+    {
+        GISMO_UNUSED(i);
         GISMO_ASSERT( i==0, "Requested knots of invalid direction "<< i );
         return this->basis().knots(); 
     }
 
     /// Returns the degree of the B-spline
     int degree(int i = 0) const 
-    { 
+    {
+        GISMO_UNUSED(i);
         GISMO_ASSERT( i==0, "Requested knots of invalid direction "<< i );
         return this->basis().degree(); 
     }
     
     // compatible curves: same degree, same first/last p+1 knots
-    void isCompatible( gsGeometry<T> * other )
+    void isCompatible( gsGeometry<T> * )
     { GISMO_NO_IMPLEMENTATION }
     
     // compatible curves: same degree, same first/last p+1 knots
-    void makeCompatible( gsGeometry<T> * other )
+    void makeCompatible( gsGeometry<T> * )
     { GISMO_NO_IMPLEMENTATION }
 
 

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -155,6 +155,8 @@ void gsBSpline<T>::setFurthestCorner(gsMatrix<T> const &v)
 template <class T>
 void gsBSpline<T>::swapDirections(const unsigned i, const unsigned j)
 {
+    GISMO_UNUSED(i);
+    GISMO_UNUSED(j);
     GISMO_ASSERT( static_cast<int>(i) == 0 && static_cast<int>(j) == 0,
                   "Invalid basis components "<<i<<" and "<<j<<" requested" );
 }

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -163,6 +163,7 @@ void gsBSpline<T>::swapDirections(const unsigned i, const unsigned j)
 template<class T>
 void gsBSpline<T>::degreeElevate(int const i, int const dir)
 {
+    GISMO_UNUSED(dir);
     GISMO_ASSERT( (dir == -1) || (dir == 0),
                   "Invalid basis component "<< dir <<" requested for degree elevation" );
     

--- a/src/gsNurbs/gsBSplineBasis.h
+++ b/src/gsNurbs/gsBSplineBasis.h
@@ -306,7 +306,8 @@ public:
 
     // Look at gsBasis class for a description
     int degree(int i) const 
-    { 
+    {
+        GISMO_UNUSED(i);
         GISMO_ASSERT(i==0,"Asked for degree(i) in 1D basis.");
         return m_p; 
     }
@@ -459,7 +460,8 @@ public:
   
     /// Elevate the degree of the basis and preserve the smoothness
     void degreeElevate(int const & i = 1, int const dir = -1)
-    { 
+    {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT( dir == -1 || dir == 0, "Invalid direction");
         m_p+=i; m_knots.degreeElevate(i); 
     }
@@ -467,6 +469,7 @@ public:
     // Look at gsBasis for documentation
     void degreeReduce (int const & i = 1, int const dir = -1) 
     {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT( dir == -1 || dir == 0, "Invalid direction");
         GISMO_ASSERT( i<=m_p, "Cannot reduce degree to negative");
         m_p-=i; m_knots.degreeReduce(i);
@@ -476,6 +479,7 @@ public:
     // Look at gsBasis for documentation
     void degreeIncrease(int const & i = 1, int const dir = -1)
     {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT( dir == -1 || dir == 0, "Invalid direction");
         m_p+=i; m_knots.degreeIncrease(i);
     }
@@ -483,6 +487,7 @@ public:
     // Look at gsBasis for documentation
     void degreeDecrease(int const & i = 1, int const dir = -1)
     {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT( dir == -1 || dir == 0, "Invalid direction");
         m_p-=i; m_knots.degreeDecrease(i);
     }
@@ -545,6 +550,7 @@ public:
     // Compatible with tensor B-spline basis
     void setPeriodic(int dir)
     {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT(dir==0, "Invalid direction");
             _convertToPeriodic();
     }
@@ -604,6 +610,7 @@ public:
 
     gsMatrix<T> perCoefs(const gsMatrix<T>& coefs, int dir) const
     {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT(dir==0, "Error");
         return perCoefs(coefs);
     }

--- a/src/gsNurbs/gsBSplineBasis.hpp
+++ b/src/gsNurbs/gsBSplineBasis.hpp
@@ -182,7 +182,7 @@ gsMatrix<unsigned> gsTensorBSplineBasis<1,T>::boundaryOffset(boxSide const & s,
 }
 
 template <class T>
-gsConstantBasis<T> * gsTensorBSplineBasis<1,T>::boundaryBasis_impl(boxSide const & s) const
+gsConstantBasis<T> * gsTensorBSplineBasis<1,T>::boundaryBasis_impl(boxSide const &) const
 {
     return new gsConstantBasis<T>(1.0);
 }
@@ -1214,6 +1214,7 @@ void gsTensorBSplineBasis<1,T>::_stretchEndKnots()
 template <class T>
 gsBSplineBasis<T> & gsBSplineBasis<T>::component(unsigned i)
 {
+    GISMO_UNUSED(i);
     GISMO_ASSERT(i==0,"gsBSplineBasis has only one component");
     return const_cast<gsBSplineBasis&>(*this);
 }
@@ -1221,6 +1222,7 @@ gsBSplineBasis<T> & gsBSplineBasis<T>::component(unsigned i)
 template <class T>
 const gsBSplineBasis<T> & gsBSplineBasis<T>::component(unsigned i) const
 {
+    GISMO_UNUSED(i);
     GISMO_ASSERT(i==0,"gsBSplineBasis has only one component");
     return const_cast<gsBSplineBasis&>(*this);
 }

--- a/src/gsNurbs/gsKnotVector.hpp
+++ b/src/gsNurbs/gsKnotVector.hpp
@@ -44,7 +44,6 @@ public:
     {
         // TODO: make it unused when possible.
         int p = atoi(node->first_attribute("degree")->value() );
-        //GISMO_UNUSED(p);
 
         typename gsKnotVector<T>::knotContainer knotValues;
 

--- a/src/gsNurbs/gsNurbsCreator.hpp
+++ b/src/gsNurbs/gsNurbsCreator.hpp
@@ -665,7 +665,7 @@ gsNurbsCreator<T>::NurbsCurve2 (T const & r, T const & x, T const & y)
 
 
 template<class T> typename gsNurbsCreator<T>::NurbsPtr
-gsNurbsCreator<T>::NurbsBean(T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::NurbsBean(T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,12,3,1,2);
     gsMatrix<T> C(15,2);
@@ -695,7 +695,7 @@ gsNurbsCreator<T>::NurbsBean(T const & r, T const & x, T const & y)
 
 
 template<class T> typename gsNurbsCreator<T>::BSplinePtr
-gsNurbsCreator<T>::BSplineE (T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::BSplineE (T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,22,4,1,3);
     gsMatrix<T> C(26,2);
@@ -732,7 +732,7 @@ gsNurbsCreator<T>::BSplineE (T const & r, T const & x, T const & y)
 }
 
 template<class T> typename gsNurbsCreator<T>::NurbsPtr
-gsNurbsCreator<T>::NurbsAmoebaFull(T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::NurbsAmoebaFull(T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,19,3,1,2);
     gsMatrix<T> C(22,2);
@@ -904,7 +904,7 @@ gsNurbsCreator<T>::BSplineLShapeMultiPatch_p2()
 }
 
 template<class T> typename gsNurbsCreator<T>::BSplinePtr
-gsNurbsCreator<T>::BSplineAmoeba(T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::BSplineAmoeba(T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,19,3,1,2);
     gsMatrix<T> C(22,2);
@@ -943,7 +943,7 @@ gsNurbsCreator<T>::BSplineAmoeba(T const & r, T const & x, T const & y)
 }
 
 template<class T> typename gsNurbsCreator<T>::BSplinePtr
-gsNurbsCreator<T>::BSplineAmoebaBig(T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::BSplineAmoebaBig(T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,19,3,1,2);
     gsMatrix<T> C(22,2);
@@ -980,7 +980,7 @@ gsNurbsCreator<T>::BSplineAmoebaBig(T const & r, T const & x, T const & y)
 }
 
 template<class T> typename gsNurbsCreator<T>::BSplinePtr
-gsNurbsCreator<T>::BSplineAustria(T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::BSplineAustria(T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,31,3,1,2);
     gsMatrix<T> C(34,2);
@@ -1030,7 +1030,7 @@ gsNurbsCreator<T>::BSplineAustria(T const & r, T const & x, T const & y)
 
 
 template<class T> typename gsNurbsCreator<T>::BSplinePtr
-gsNurbsCreator<T>::BSplineFish(T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::BSplineFish(T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,13,3,1,2);
     gsMatrix<T> C(16,2);
@@ -1059,7 +1059,7 @@ gsNurbsCreator<T>::BSplineFish(T const & r, T const & x, T const & y)
 }
 
 template<class T> typename gsNurbsCreator<T>::BSplinePtr
-gsNurbsCreator<T>::BSplineAmoeba3degree(T const & r, T const & x, T const & y)
+gsNurbsCreator<T>::BSplineAmoeba3degree(T const &, T const & x, T const & y)
 {
     gsKnotVector<T> kv(0,1,18,4,1,3);
     gsMatrix<T> C(22,2);

--- a/src/gsNurbs/gsTensorBSplineBasis.hpp
+++ b/src/gsNurbs/gsTensorBSplineBasis.hpp
@@ -85,7 +85,7 @@ refine_withCoefs(gsMatrix<T> & coefs,const std::vector< std::vector<T> >& refine
 
 
 template<unsigned d, class T>
-void gsTensorBSplineBasis<d,T>::refine(gsMatrix<T> const & boxes, int refExt)
+void gsTensorBSplineBasis<d,T>::refine(gsMatrix<T> const & boxes, int)
 {
     // Note: refExt parameter is ignored
     GISMO_ASSERT( boxes.rows() == this->dim() , 

--- a/src/gsPde/gsPde.h
+++ b/src/gsPde/gsPde.h
@@ -155,7 +155,7 @@ public:
      * @param np the patch index
      * @return a pointer to an allocated gsPDE<T> object.
      */
-    virtual gsPde<T>* restrictToPatch(unsigned np) const{GISMO_NO_IMPLEMENTATION}
+    virtual gsPde<T>* restrictToPatch(unsigned) const{GISMO_NO_IMPLEMENTATION}
 
     /**
      * @brief getCoeffForIETI returns for a patch \a np the scaling coefficient in order to make
@@ -164,7 +164,7 @@ public:
      * @param np the patch under consideration
      * @return the scaling value for IETI
      */
-    virtual T getCoeffForIETI(unsigned np) const {GISMO_NO_IMPLEMENTATION}
+    virtual T getCoeffForIETI(unsigned) const {GISMO_NO_IMPLEMENTATION}
 
 protected:
     /// @brief Description of the unknown fields:

--- a/src/gsPde/gsPoissonPde.h
+++ b/src/gsPde/gsPoissonPde.h
@@ -43,7 +43,7 @@ public:
     gsPoissonPde(const gsMultiPatch<T>         &domain,
                  const gsBoundaryConditions<T> &bc,
                  const gsPiecewiseFunction<T>  &rhs,
-                 const gsFunction<T>           *sol = NULL)
+                 const gsFunction<T>           * = NULL)
     : gsPde<T>(domain,bc), m_rhs(rhs)
     {
         m_unknownDim.setOnes(1);
@@ -53,7 +53,7 @@ public:
     GISMO_DEPRECATED
     gsPoissonPde(const gsFunction<T>  &rhs,
                  int                   domdim,
-                 const gsFunction<T>  &sol)
+                 const gsFunction<T>  &)
     : m_compat_dim(domdim), m_rhs(rhs)
     {
         m_unknownDim.setOnes(1);

--- a/src/gsSolver/gsGMRes.hpp
+++ b/src/gsSolver/gsGMRes.hpp
@@ -80,9 +80,9 @@ void gsGMRes<T>::finalizeIteration( typename gsGMRes<T>::VectorType& x )
 }
 
 template<class T>
-bool gsGMRes<T>::step( typename gsGMRes<T>::VectorType& x )
+bool gsGMRes<T>::step( typename gsGMRes<T>::VectorType& )
 {
-    GISMO_UNUSED(x); // The iterate x is never updated! Use finalizeIteration to obtain x.
+    // The iterate x is never updated! Use finalizeIteration to obtain x.
     const index_t k = m_num_iter-1;
     H.setZero(k+2,k+1);
     h_tmp.setZero(k+2,1);

--- a/src/gsSolver/gsIterativeSolver.h
+++ b/src/gsSolver/gsIterativeSolver.h
@@ -203,7 +203,7 @@ public:
     }
 
     virtual bool step( VectorType& x ) = 0;                     ///< Perform one step, requires initIteration
-    virtual void finalizeIteration( VectorType& x ) {}          ///< Some post-processing might be required
+    virtual void finalizeIteration( VectorType& ) {}          ///< Some post-processing might be required
 
     /// Returns the size of the linear system
     index_t size() const                                       { return m_mat->rows(); }

--- a/src/gsSolver/gsLinearOperator.h
+++ b/src/gsSolver/gsLinearOperator.h
@@ -66,7 +66,7 @@ public:
 
     /// Set options based on a gsOptionList object
     // This implementation does not read any input
-    virtual void setOptions(const gsOptionList & opt)  {}
+    virtual void setOptions(const gsOptionList &)  {}
 
 }; // gsLinearOperator
 

--- a/src/gsSolver/gsMinimalResidual.hpp
+++ b/src/gsSolver/gsMinimalResidual.hpp
@@ -93,9 +93,8 @@ bool gsMinimalResidual<T>::step( typename gsMinimalResidual<T>::VectorType& x )
 }
 
 template<class T>
-void gsMinimalResidual<T>::finalizeIteration( typename gsMinimalResidual<T>::VectorType& x )
+void gsMinimalResidual<T>::finalizeIteration( typename gsMinimalResidual<T>::VectorType& )
 {
-    GISMO_UNUSED(x);
     // cleanup temporaries
     negResidual.clear();
     vPrev.clear(); v.clear(); vNew.clear();

--- a/src/gsTensor/gsTensorBasis.h
+++ b/src/gsTensor/gsTensorBasis.h
@@ -797,12 +797,13 @@ public:
     { return i; }
 
     /// \todo remove
-    inline unsigned index(unsigned i, unsigned j) const
+    inline unsigned index(unsigned , unsigned ) const
     { GISMO_ERROR("The basis is 1D"); }
 
     /// Returns the stride for dimension dir
     inline unsigned stride(int dir) const 
-    { 
+    {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT(dir==0,"Invalid direction");
         return 1; 
     }
@@ -830,12 +831,14 @@ public:
 
     Basis_t & component(unsigned i)
     {
+        GISMO_UNUSED(i);
         GISMO_ASSERT(i==0,"Invalid component requested");
         return *this; 
     }
 
     const Basis_t & component(unsigned i) const 
     {
+        GISMO_UNUSED(i);
         GISMO_ASSERT(i==0,"Invalid component requested");
         return *this; 
     }

--- a/src/gsTensor/gsTensorBasis.h
+++ b/src/gsTensor/gsTensorBasis.h
@@ -402,6 +402,7 @@ public:
     // Look at gsBasis class for documentation 
     virtual void degreeReduce(int const & i = 1, int const dir = -1)
     {
+        GISMO_UNUSED(dir);
         GISMO_ASSERT( static_cast<int>(dir) < this->dim(),
                       "Invalid basis component requested" );
         for (unsigned j = 0; j < d; ++j)
@@ -762,6 +763,7 @@ public:
     /// parameter component
     index_t size(int k) const 
     {
+        GISMO_UNUSED(k);
         GISMO_ASSERT(k==0, "Invalid direction");
         return this->size();
     }
@@ -780,6 +782,8 @@ public:
     
     void swapDirections(const unsigned i, const unsigned j)
     {
+        GISMO_UNUSED(i);
+        GISMO_UNUSED(j);
         GISMO_ASSERT( static_cast<int>(i) == 0 && static_cast<int>(j) == 0,
                       "Invalid basis components "<<i<<" and "<<j<<" requested" );
     }
@@ -787,6 +791,8 @@ public:
     /// Returns all the basis functions with tensor-numbering \a k in direction \a dir 
     gsMatrix<unsigned> coefSlice(int dir, int k) const
     {
+        GISMO_UNUSED(dir);
+        GISMO_UNUSED(k);
         GISMO_ASSERT(dir == 0, "Invalid direction");
         GISMO_ASSERT(k < this->size(), "Invalid index");
         // return 0 or size()-1
@@ -809,7 +815,7 @@ public:
     }
 
     /// Returns the components for a basis on the face \a s 
-    void getComponentsForSide(boxSide const & s, std::vector<gsBasis<T>*> & rr) const
+    void getComponentsForSide(boxSide const &, std::vector<gsBasis<T>*> & rr) const
     { rr.clear(); }
 
     /// Returns the global index of the basis function created by

--- a/src/gsUtils/gsFunctionWithDerivatives.h
+++ b/src/gsUtils/gsFunctionWithDerivatives.h
@@ -90,10 +90,9 @@ public:
         return *m_deriv2;
     }
 
-    const gsFunctionWithDerivatives & piece(const index_t k) const
+    const gsFunctionWithDerivatives & piece(const index_t) const
     {
         // same on all pieces
-        GISMO_UNUSED(k);
         return *this; 
     }
 


### PR DESCRIPTION
FIXED -Wunused_parameter Warnings
FIXED -Wextra Warnings
IMPROVED remove of gsFunctionSet::compute(const gsMapData<T> & in, gsFuncData<T> & out)
   use gsFunctionSet::compute(const gsMatrix<T> & in, gsFuncData<T> & out) instead
   by calling compute(gsMapData.points, gsFuncData)
IMPROVED remove of gsBulk::toMesh(gsMesh<T> &, int)
IMPROVED remove of gsVolume::toMesh(gsMesh<T>&, int)