### PR TITLE
Update gsJITConfigXml.cmake

### DIFF
--- a/cmake/gsJITConfigXml.cmake
+++ b/cmake/gsJITConfigXml.cmake
@@ -78,10 +78,12 @@ macro(gsJITConfigXml source_file target_file)
   string(REPLACE "-fvisibility-inlines-hidden" "" JIT_CXX_FLAGS ${JIT_CXX_FLAGS})
 
   # Set includes
-  string(REPLACE ";" " -I" JIT_INCLUDES "-I${GISMO_INCLUDE_DIRS} -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/src  -I${CMAKE_BINARY_DIR}")
+  string(REPLACE ";" " -I" JIT_INCLUDES "-I${GISMO_INCLUDE_DIRS} -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/src  -I${gismo_BINARY_DIR}")
 
   # Set (extra) library directories
-  string(REPLACE ";" " -L" JIT_LIBRARIES "-L${GISMO_LIBRARY_DIR}")
+  if(GISMO_LIBRARY_DIR)
+    string(REPLACE ";" " -L" JIT_LIBRARIES "-L${GISMO_LIBRARY_DIR}")
+  endif()
 
   foreach(lib ${GISMO_LIBRARIES} ${gismo_LINKER})
     if (NOT IS_ABSOLUTE ${lib})


### PR DESCRIPTION
1) Without this change <gsCore/gsConfig.h> cannot be found.
2) If GISMO_LIBRARY_DIR is empty then no '-L' should be generated.
