### PR TITLE
Update gsUnum.h

### DIFF
--- a/extensions/gsUnum/gsUnum.h
+++ b/extensions/gsUnum/gsUnum.h
@@ -1,6 +1,10 @@
 
 #pragma once
 
+#ifndef NDEBUG
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
+#endif
+
 #include <posit>
 
 typedef sw::unum::posit<32,2> posit_32_2;


### PR DESCRIPTION
Let the Unum library throw exceptions (in debug mode) when under/overflow and dividison-by-zero occurs.
