### PR TITLE
Update gsFdbb.cpp

### DIFF
--- a/extensions/gsFdbb/gsFdbb.cpp
+++ b/extensions/gsFdbb/gsFdbb.cpp
@@ -2,4 +2,6 @@
 #include <string>
 #include <iostream>
 
+#ifdef GISMO_BUILD_LIB
 #include <gsFdbb/gsFdbb.h>
+#endif


### PR DESCRIPTION
Fixed bug: double symbols when compiled in header-only mode.
