### PR TITLE
Update gsSparseSystem.h

### DIFF
--- a/src/gsAssembler/gsSparseSystem.h
+++ b/src/gsAssembler/gsSparseSystem.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-//#include <gsCore/gsRefVector.h>
+#include <gsCore/gsStdVectorRef.h>
 
 namespace gismo
 {


### PR DESCRIPTION
Bug fixed: undefined symbol when compiled in header-only mode.
