### PR TITLE
[NOT MERGE] Allow to get transfer matrices for patches and for globs

### DIFF
--- a/src/gsCore/gsMultiBasis.h
+++ b/src/gsCore/gsMultiBasis.h
@@ -659,6 +659,7 @@ public:
         typename gsBasis<T>::Ptr basis;
         gsSparseMatrix<T,RowMajor> transfer;
         gsSortedVector<unsigned> corners;
+        gsSortedVector<index_t> patches;
     };
 
     /// @brief Decomposes the whole basis into globs and gives the transfers
@@ -674,16 +675,18 @@ public:
     ///   the edges
     ///   the corners
     ///
-    /// The result of this algorithm is a vector of vector of pairs containing the
-    /// corresponding basis (as \a gsBasis<T>::Ptr) and the corresponding transfer
-    /// matrix. The outer vector has d+1 entries. Its i th entry is again a vector
-    /// collecting all globs with d-i dimensions.
+    /// The result of this algorithm is a vector of vector of a struct containing the
+    /// corresponding basis (as \a gsBasis<T>::Ptr), the corresponding transfer
+    /// matrix, the indices of the corresponding corners and the indices of the
+    /// corresponding patches. The outer vector has d+1 entries. Its i th entry is
+    /// again a vector collecting all globs with d-i dimensions.
     ///
     /// \param bc The boundary conditions to be used
     /// \param dirichletStrategy The Dirichlet strategy to be used
     /// \param iFaceStrategy The interface strategy to be used
     /// \param combineCorners If this is set to true, all corners are considered
-    ///             as one glob.
+    ///           as one glob. The combined glob does not contain information on corners
+    ///           or patches.
     std::vector< std::vector< glob > >
     getGlobs_withTransferMatrices(
         const gsBoundaryConditions<T>& bc,

--- a/src/gsCore/gsMultiBasis.h
+++ b/src/gsCore/gsMultiBasis.h
@@ -654,6 +654,11 @@ public:
         iFace::strategy iFaceStrategy = iFace::conforming
     ) const;
 
+    struct glob {
+        typename gsBasis<T>::Ptr basis;
+        gsSparseMatrix<T,RowMajor> transfer;
+    };
+
     /// @brief Decomposes the whole basis into globs and gives the transfers
     ///
     /// Globs are in 2 dimensions:
@@ -677,7 +682,7 @@ public:
     /// \param iFaceStrategy The interface strategy to be used
     /// \param combineCorners If this is set to true, all corners are considered
     ///             as one glob.
-    std::vector< std::vector< std::pair< typename gsBasis<T>::Ptr, gsSparseMatrix<T,RowMajor> > > >
+    std::vector< std::vector< glob > >
     getGlobs_withTransferMatrices(
         const gsBoundaryConditions<T>& bc,
         dirichlet::strategy dirichletStrategy = dirichlet::elimination,

--- a/src/gsCore/gsMultiBasis.h
+++ b/src/gsCore/gsMultiBasis.h
@@ -19,6 +19,7 @@
 #include <gsCore/gsBoxTopology.h>
 #include <gsPde/gsBoundaryConditions.h>
 #include <gsAssembler/gsAssemblerOptions.h>
+#include <gsUtils/gsSortedVector.h>
 
 
 namespace gismo
@@ -657,6 +658,7 @@ public:
     struct glob {
         typename gsBasis<T>::Ptr basis;
         gsSparseMatrix<T,RowMajor> transfer;
+        gsSortedVector<unsigned> corners;
     };
 
     /// @brief Decomposes the whole basis into globs and gives the transfers

--- a/src/gsCore/gsMultiBasis.hpp
+++ b/src/gsCore/gsMultiBasis.hpp
@@ -989,18 +989,6 @@ template<typename T>
 bool first_is_equal( const Glob<T>& a, const Glob<T>& b )
 { return a.indices[0]==b.indices[0]; }
 
-template<typename T>
-std::vector< std::vector< std::pair< typename gsBasis<T>::Ptr, gsSparseMatrix<T,RowMajor> > > > constructGlobs(
-                                    const gsMultiBasis<T>& mb,
-                                    const std::vector< gsVector<unsigned> >& locals,
-                                    index_t totalNumberDof,
-                                    bool combineCorners
-                                )
-{
-
-
-}
-
 } // anonymous namespace
 
 template<class T>

--- a/unittests/gsGlobs_test.cpp
+++ b/unittests/gsGlobs_test.cpp
@@ -37,26 +37,42 @@ SUITE(gsGlobs_test)
                 for (unsigned n=0; n<result[i][j].corners.size(); ++n )
                     gsInfo << "  " << result[i][j].corners[n];
                 gsInfo << "\n";
+                gsInfo << "Patches: ";
+                for (unsigned n=0; n<result[i][j].patches.size(); ++n )
+                    gsInfo << "  " << result[i][j].patches[n];
+                gsInfo << "\n";
                 gsInfo << "Transfer: " << result[i][j].transfer.transpose() << "\n";
             }
-        */
+        //*/
 
         CHECK(result.size() == 3);
 
         // Have 7 vertices with 1 dof each
         CHECK(result[0].size() == 8);
         for (unsigned i=0; i<8; ++i )
+        {
             CHECK( result[0][i].transfer.cols() == 1 && result[0][i].transfer.rows() == 40 );
+            CHECK( result[0][i].corners.size() == 1 );
+            CHECK( result[0][i].patches.size() > 0 && result[0][i].patches.size() < 4 );
+        }
 
         // Have 10 edges with 2 dofs each
         CHECK(result[1].size() == 10);
         for (unsigned i=0; i<10; ++i )
+        {
             CHECK( result[1][i].transfer.cols() == 2 && result[1][i].transfer.rows() == 40 );
+            CHECK( result[1][i].corners.size() == 2 );
+            CHECK( result[1][i].patches.size() > 0 && result[1][i].patches.size() < 3 );
+        }
 
         // Have 3 patches with 4 interior dofs each
         CHECK(result[2].size() == 3);
         for (unsigned i=0; i<3; ++i )
+        {
             CHECK( result[2][i].transfer.cols() == 4 && result[2][i].transfer.rows() == 40 );
+            CHECK( result[2][i].corners.size() == 4 );
+            CHECK( result[2][i].patches.size() == 1 );
+        }
 
     }
 

--- a/unittests/gsGlobs_test.cpp
+++ b/unittests/gsGlobs_test.cpp
@@ -1,0 +1,63 @@
+/** @file gsGlobs_test.cpp
+
+    @brief This tests gsMultiBasis::getGlobs_withTransferMatrices
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): S. Takacs
+ **/
+
+#include "gismo_unittest.h"
+
+SUITE(gsGlobs_test)
+{
+
+    TEST(test)
+    {
+        gsMultiPatch<> mp = gsNurbsCreator<>::BSplineLShapeMultiPatch_p2();
+        gsMultiBasis<> mb(mp);
+
+        mb.uniformRefine();
+        
+        gsBoundaryConditions<> bc;
+
+        std::vector< std::vector< gsMultiBasis<>::glob > > result = mb.getGlobs_withTransferMatrices(bc);
+        
+        /*
+        for (unsigned i=0; i<result.size(); ++i)
+            for (unsigned j=0; j<result[i].size(); ++j)
+            {
+                gsInfo << "Consider glob [" << i << "][" << j << "]:\n";
+                gsInfo << "Basis: " << result[i][j].basis.get() << "\n";
+                gsInfo << "Corners: ";
+                for (unsigned n=0; n<result[i][j].corners.size(); ++n )
+                    gsInfo << "  " << result[i][j].corners[n];
+                gsInfo << "\n";
+                gsInfo << "Transfer: " << result[i][j].transfer.transpose() << "\n";
+            }
+        */
+
+        CHECK(result.size() == 3);
+
+        // Have 7 vertices with 1 dof each
+        CHECK(result[0].size() == 8);
+        for (unsigned i=0; i<8; ++i )
+            CHECK( result[0][i].transfer.cols() == 1 && result[0][i].transfer.rows() == 40 );
+
+        // Have 10 edges with 2 dofs each
+        CHECK(result[1].size() == 10);
+        for (unsigned i=0; i<10; ++i )
+            CHECK( result[1][i].transfer.cols() == 2 && result[1][i].transfer.rows() == 40 );
+
+        // Have 3 patches with 4 interior dofs each
+        CHECK(result[2].size() == 3);
+        for (unsigned i=0; i<3; ++i )
+            CHECK( result[2][i].transfer.cols() == 4 && result[2][i].transfer.rows() == 40 );
+
+    }
+
+}


### PR DESCRIPTION
This allows to decompose the patches into globs and to obtain local bases.

This is needed for the robust multi-patch multigrid stuff.