### PR TITLE
gsPiecewiseFunction - add clear()

### DIFF
--- a/src/gsCore/gsPiecewiseFunction.h
+++ b/src/gsCore/gsPiecewiseFunction.h
@@ -144,8 +144,10 @@ public:
         return pwf.print(os);
     }
 
+    /// Clear (delete) all functions
     void clear()
     {
+        freeAll(m_funcs);
         m_funcs.clear();
     }
 

--- a/src/gsCore/gsPiecewiseFunction.h
+++ b/src/gsCore/gsPiecewiseFunction.h
@@ -144,6 +144,11 @@ public:
         return pwf.print(os);
     }
 
+    void clear()
+    {
+        m_funcs.clear();
+    }
+
 protected:
     
     FunctionContainer m_funcs;


### PR DESCRIPTION
Added a function to clear the container with gsFunction * pointers.
Functionality similar to gsMultiPatch::clear().
Necessary to for multipatch stress functions in gsElasticity/gsElasticityAssembler.hpp at line 114  - in gsElasticityAssembler::constructCauchyStresses 
