### PR TITLE
gsAssembler::updateSolution works for vector valued functions

### DIFF
--- a/src/gsAssembler/gsAssembler.h
+++ b/src/gsAssembler/gsAssembler.h
@@ -450,21 +450,23 @@ public: /* Element visitors */
     /// @brief Iterates over all elements of the domain and applies
     /// the \a ElementVisitor
     template<class ElementVisitor>
-    void push(ElementVisitor & visitor)
+    void push(const ElementVisitor & visitor)
     {
         for (index_t np = 0; np < m_pde_ptr->domain().nPatches(); ++np)
         {
+            ElementVisitor curVisitor = visitor;
             //Assemble (fill m_matrix and m_rhs) on patch np
-            apply(visitor, np);
+            apply(curVisitor, np);
         }
     }
 
     /// @brief Applies the \a BElementVisitor to the boundary condition \a BC
     template<class BElementVisitor>
-    void push( BElementVisitor & visitor, const boundary_condition<T> & BC)
+    void push(const BElementVisitor & visitor, const boundary_condition<T> & BC)
     {
+        BElementVisitor curVisitor = visitor;
         //Assemble (fill m_matrix and m_rhs) contribution from this BC
-        apply(visitor, BC.patch(), BC.side());
+        apply(curVisitor, BC.patch(), BC.side());
     }
 
     /// @brief Iterates over all elements of interfaces and

--- a/src/gsAssembler/gsAssembler.h
+++ b/src/gsAssembler/gsAssembler.h
@@ -450,7 +450,7 @@ public: /* Element visitors */
     /// @brief Iterates over all elements of the domain and applies
     /// the \a ElementVisitor
     template<class ElementVisitor>
-    void push(const ElementVisitor & visitor)
+    void push(ElementVisitor & visitor)
     {
         for (index_t np = 0; np < m_pde_ptr->domain().nPatches(); ++np)
         {

--- a/src/gsAssembler/gsAssembler.h
+++ b/src/gsAssembler/gsAssembler.h
@@ -454,9 +454,8 @@ public: /* Element visitors */
     {
         for (index_t np = 0; np < m_pde_ptr->domain().nPatches(); ++np)
         {
-            ElementVisitor curVisitor = visitor;
             //Assemble (fill m_matrix and m_rhs) on patch np
-            apply(curVisitor, np);
+            apply(visitor, np);
         }
     }
 

--- a/src/gsAssembler/gsAssembler.hpp
+++ b/src/gsAssembler/gsAssembler.hpp
@@ -655,6 +655,7 @@ void gsAssembler<T>::updateSolution(const gsMatrix<T>& solVector,
                                     gsMultiPatch<T>& result, T theta) const
 {
     // GISMO_ASSERT(m_dofs == m_rhs.rows(), "Something went wrong, assemble() not called?");
+    unsigned idx;
 
     for (index_t p = 0; p < m_pde_ptr->domain().nPatches(); ++p)
     {
@@ -670,7 +671,8 @@ void gsAssembler<T>::updateSolution(const gsMatrix<T>& solVector,
             {
                 if ( mapper.is_free(i, p) ) // DoF value is in the solVector
                 {
-                    coeffs(i,j) += theta* solVector( mapper.index(i, p), 0);
+                    m_system.mapToGlobalColIndex(i,p,idx,j);
+                    coeffs(i,j) += theta * solVector(idx,0);
                 }
             }
         }


### PR DESCRIPTION
Why copying the visitor? This may require a copy constructor
