### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The latest revision of the code can be obtained using subversion:
 
 ```svn co https://github.com/gismo/gismo/trunk gismo```
 
-or using git:
+or using git (via https):
 
-```git clone git@github.com:gismo/gismo.git```
+```git clone https://github.com/gismo/gismo.git```
 
 or as a zip file:
 


### PR DESCRIPTION
update clone entry, changed from ssh to https (as github recommends now)

This is, because ssh will need extra effort on new computers/for new users.
HTTPS works without extra effort.