### PR TITLE
Transposing PK_BSURF in gsWriteParasolid.

### DIFF
--- a/extensions/gsParasolid/gsWriteParasolid.hpp
+++ b/extensions/gsParasolid/gsWriteParasolid.hpp
@@ -312,6 +312,8 @@ bool createPK_BSURF(const gsTensorBSpline< 2, T> & bsp,
                     bool closed_u,
                     bool closed_v)
 {
+    // Gismo and Parasolid store the coefficients in different order.
+    // Therefore we create the BSURF with u and v swapped and then transpose it.
     for (index_t dim = 0; dim != 2; dim++)
     {
         const int deg = bsp.basis().degree(dim);
@@ -372,12 +374,12 @@ bool createPK_BSURF(const gsTensorBSpline< 2, T> & bsp,
 
     if (closed_u)
     {
-        sform.is_u_closed = PK_LOGICAL_true;
+        sform.is_v_closed = PK_LOGICAL_true;
     }
 
     if (closed_v)
     {
-        sform.is_v_closed = PK_LOGICAL_true;
+        sform.is_u_closed = PK_LOGICAL_true;
     }
 
     sform.self_intersecting = PK_self_intersect_unset_c;
@@ -386,6 +388,14 @@ bool createPK_BSURF(const gsTensorBSpline< 2, T> & bsp,
     // Create parasolid surface with the previous spline data
     PK_ERROR_code_t err = PK_BSURF_create(&sform, &bsurf);
     PARASOLID_ERROR(PK_BSURF_create, err);
+
+    // Transposition (new on 2019-02-26).
+    PK_BSURF_reparameterise_o_t options;
+    PK_BSURF_reparameterise_o_m(options);
+    options.transpose = PK_LOGICAL_true;
+
+    err = PK_BSURF_reparameterise(bsurf,&options);
+    PARASOLID_ERROR(PK_BSURF_reparameterise, err);
 
     return true;
 }


### PR DESCRIPTION
The function `createPK_BSURF` from extensions/gsParasolid/gsWriteParasolid swaps _u_- and _v_- directions (the 0-th parametric dimension of Gismo becomes _v_ and the 1-st becomes _u_ in Parasolid). This is caused by Parasolid and Gismo storing the control points in different order (row-wise vs. col-wise).

While the geometry remains unchanged, it is still a bug, as we have to transpose after each export. I have committed a simple solution: we create a `PK_BSURF` with the directions swapped and then transpose the geometry with `PK_BSURF_reparameterise`.

We are the sole users of the Parasolid interface, so I did not add any further tests to Gismo.