### PR TITLE
Fix gsElastity linker error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,10 @@ if(GISMO_BUILD_LIB)
   endif()
 endif()
 
+if(GISMO_ELASTICITY)
+  gismo_fetch_module(gsElasticity)
+endif()
+
 include(gsLibrary)
 
 ## #################################################################
@@ -387,10 +391,6 @@ endif()
 
 if(GISMO_MOTOR)
   gismo_fetch_module(motor)
-endif()
-
-if(GISMO_ELASTICITY)
-  gismo_fetch_module(gsElasticity)
 endif()
 
 if(GISMO_EXASTENCILS)


### PR DESCRIPTION
This fixes the linker error #292 where gsElasticity examples can't be compiled. I don't know why, but apparently https://github.com/gismo/gismo/blob/8f2e332e33249cf6275327f0bb97b64daffceff4/CMakeLists.txt#L393
has to come before https://github.com/gismo/gismo/blob/8f2e332e33249cf6275327f0bb97b64daffceff4/CMakeLists.txt#L313
as it used to be before the 8a6c6d0fbc02d733165e20a8bc0291f6f7da37b6. It probably has to be the same for the rest of the submodules, but I didn't touch it 
