### PR TITLE
Added thermal diffusivity coefficient to use with the heat equation

### DIFF
--- a/src/gsAssembler/gsPoissonAssembler.h
+++ b/src/gsAssembler/gsPoissonAssembler.h
@@ -51,8 +51,8 @@ public:
     gsPoissonAssembler( const gsPoissonPde<T>          & pde,
                         const gsMultiBasis<T>          & bases)
     {
-        Base::initialize(pde, bases, m_options);
         m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
+        Base::initialize(pde, bases, m_options);
     }
 
     
@@ -70,9 +70,9 @@ public:
     {
         m_options.setInt("DirichletStrategy", dirStrategy);
         m_options.setInt("InterfaceStrategy", intStrategy);
+        m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
 
         Base::initialize(pde, bases, m_options);
-        m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
     }
 
     /** @brief
@@ -96,10 +96,10 @@ public:
     {
         m_options.setInt("DirichletStrategy", dirStrategy);
         m_options.setInt("InterfaceStrategy", intStrategy);
+        m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
 
         typename gsPde<T>::Ptr pde( new gsPoissonPde<T>(patches,bconditions,rhs) );
         Base::initialize(pde, basis, m_options);
-        m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
     }
 
     virtual gsAssembler<T>* clone() const

--- a/src/gsAssembler/gsPoissonAssembler.h
+++ b/src/gsAssembler/gsPoissonAssembler.h
@@ -52,6 +52,7 @@ public:
                         const gsMultiBasis<T>          & bases)
     {
         Base::initialize(pde, bases, m_options);
+        m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
     }
 
     
@@ -71,6 +72,7 @@ public:
         m_options.setInt("InterfaceStrategy", intStrategy);
 
         Base::initialize(pde, bases, m_options);
+        m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
     }
 
     /** @brief
@@ -97,6 +99,7 @@ public:
 
         typename gsPde<T>::Ptr pde( new gsPoissonPde<T>(patches,bconditions,rhs) );
         Base::initialize(pde, basis, m_options);
+        m_options.addReal("ThermalDiff","Thermal diffusivity of the material",1.);
     }
 
     virtual gsAssembler<T>* clone() const

--- a/src/gsAssembler/gsVisitorPoisson.h
+++ b/src/gsAssembler/gsVisitorPoisson.h
@@ -45,6 +45,7 @@ public:
     {
         // Grab right-hand side for current patch
         rhs_ptr = &pde_ptr->rhs()->piece(patchIndex);
+        thermalDiff = options.getReal("ThermalDiff");
         
         // Setup Quadrature
         rule = gsQuadrature::get(basis, options); // harmless slicing occurs here
@@ -95,7 +96,7 @@ public:
             transformGradients(md, k, bGrads, physGrad);
             
             localRhs.noalias() += weight * ( bVals.col(k) * rhsVals.col(k).transpose() ) ;
-            localMat.noalias() += weight * (physGrad.transpose() * physGrad);
+            localMat.noalias() += thermalDiff * weight * (physGrad.transpose() * physGrad);
         }
     }
 
@@ -113,6 +114,7 @@ public:
 protected:
     // Pointer to the pde data
     const gsPoissonPde<T> * pde_ptr;
+    T thermalDiff;
     
 protected:
     // Basis values


### PR DESCRIPTION
The thermal diffusivity coefficient alpha is necessary for the heat equation:
u_t = alpha*Du + f

Unfortunately, it cannot be simply introduced after assembly of the stiffness matrix with gsPoissonAssembler if the elimination Dirichlet strategy is used.