### PR TITLE
add unsigned T abs_diff(T a, T b)

### DIFF
--- a/src/gsCore/gsMath.h
+++ b/src/gsCore/gsMath.h
@@ -326,7 +326,8 @@ template <typename T> int getSign(T val)
 template <typename T>
 inline typename util::make_unsigned<T>::type abs_diff(T a, T b)
 {
-    return a > b ? a - b : b - a;
+    typedef typename util::make_unsigned<T>::type unsignedT;
+    return a > b ? unsignedT(a) - unsignedT(b) : unsignedT(b) - unsignedT(a);
 }
 
 /// integer power

--- a/src/gsCore/gsMath.h
+++ b/src/gsCore/gsMath.h
@@ -324,7 +324,7 @@ template <typename T> int getSign(T val)
 /// Return smallest difference between two (integer) numbers as size_t
 /// especially the case abs_diff(INT32_MAX, INT32_MIN) := UINT32_MAX is correct
 template <typename T>
-inline typename std::make_unsigned<T>::type abs_diff(T a, T b)
+inline typename util::make_unsigned<T>::type abs_diff(T a, T b)
 {
     return a > b ? a - b : b - a;
 }

--- a/src/gsCore/gsMath.h
+++ b/src/gsCore/gsMath.h
@@ -321,6 +321,18 @@ template <typename T> int getSign(T val)
     return (T(0) < val) - (val < T(0));
 }
 
+/// Return smallest difference between two (integer) numbers as size_t
+/// especially the case abs_diff(INT32_MAX, INT32_MIN) := UINT32_MAX is correct
+template <typename T>
+inline size_t abs_diff(T a, T b)
+{
+    if (getSign(a) != getSign(b))
+    {
+        return (size_t) math::max(a, b) + -(math::min(a, b) + 1) + 1; // false for abs_diff(UINT32_MAX, UINT32_MAX)
+    }
+    return a > b ? a - b : b - a; // false for abs_diff(>=0,INT32_MIN)
+}
+
 /// integer power
 inline int ipow(int x, unsigned exp)
 {

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -138,7 +138,7 @@ template<typename T> struct is_integral: is_integral_base<typename remove_cv<T>:
 template<class T>
 struct make_unsigned;
 
-#define MAKE_UNSIGNED(signed_type)           \
+#define GISMO_MAKE_UNSIGNED(signed_type)           \
 template<>                                   \
 struct make_unsigned<signed_type> {          \
     typedef unsigned signed_type type;       \
@@ -148,11 +148,11 @@ struct make_unsigned<unsigned signed_type> { \
     typedef unsigned signed_type type;       \
 };
 
-MAKE_UNSIGNED(short)
-MAKE_UNSIGNED(int)
-MAKE_UNSIGNED(long)
-MAKE_UNSIGNED(long long)
-#undef MAKE_UNSIGNED
+GISMO_MAKE_UNSIGNED(short)
+GISMO_MAKE_UNSIGNED(int)
+GISMO_MAKE_UNSIGNED(long)
+GISMO_MAKE_UNSIGNED(long long)
+#undef GISMO_MAKE_UNSIGNED
 
 #endif
 

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -144,7 +144,7 @@ struct make_unsigned<signed_type> {          \
     typedef unsigned signed_type type;       \
 };                                           \
 template<>                                   \
-struct make_unsigned(unsigned signed_type) { \
+struct make_unsigned<unsigned signed_type> { \
     typedef unsigned signed_type type;       \
 };
 
@@ -152,6 +152,7 @@ MAKE_UNSIGNED(short)
 MAKE_UNSIGNED(int)
 MAKE_UNSIGNED(long)
 MAKE_UNSIGNED(long long)
+#undef MAKE_UNSIGNED
 
 #endif
 

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -51,6 +51,7 @@ using std::remove_const;
 using std::remove_cv;
 using std::remove_volatile;
 using std::true_type;
+using std::make_unsigned;
 
 #else
 
@@ -133,6 +134,24 @@ template< class T >
 struct remove_cv { typedef typename remove_volatile<typename remove_const<T>::type>::type type; };
 
 template<typename T> struct is_integral: is_integral_base<typename remove_cv<T>::type> {};
+
+template<class T>
+struct make_unsigned;
+
+#define MAKE_UNSIGNED(signed_type)           \
+template<>                                   \
+struct make_unsigned<signed_type> {          \
+    typedef unsigned signed_type type;       \
+};                                           \
+template<>                                   \
+struct make_unsigned(unsigned signed_type) { \
+    typedef unsigned signed_type type;       \
+};
+
+MAKE_UNSIGNED(short)
+MAKE_UNSIGNED(int)
+MAKE_UNSIGNED(long)
+MAKE_UNSIGNED(long long)
 
 #endif
 

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -16,6 +16,7 @@
 #include <gsCore/gsExport.h>
 #include <utility>
 #include <complex>
+#include <stdint.h>
 
 namespace gismo
 {
@@ -138,20 +139,20 @@ template<typename T> struct is_integral: is_integral_base<typename remove_cv<T>:
 template<class T>
 struct make_unsigned;
 
-#define GISMO_MAKE_UNSIGNED(signed_type)           \
-template<>                                   \
-struct make_unsigned<signed_type> {          \
-    typedef unsigned signed_type type;       \
-};                                           \
-template<>                                   \
-struct make_unsigned<unsigned signed_type> { \
-    typedef unsigned signed_type type;       \
+#define GISMO_MAKE_UNSIGNED(signed_type) \
+template<>                               \
+struct make_unsigned<signed_type> {      \
+    typedef u##signed_type type;         \
+};                                       \
+template<>                               \
+struct make_unsigned<u##signed_type> {   \
+    typedef u##signed_type type;         \
 };
 
-GISMO_MAKE_UNSIGNED(short)
-GISMO_MAKE_UNSIGNED(int)
-GISMO_MAKE_UNSIGNED(long)
-GISMO_MAKE_UNSIGNED(long long)
+GISMO_MAKE_UNSIGNED(int8_t)
+GISMO_MAKE_UNSIGNED(int16_t)
+GISMO_MAKE_UNSIGNED(int32_t)
+GISMO_MAKE_UNSIGNED(int64_t)
 #undef GISMO_MAKE_UNSIGNED
 
 #endif

--- a/unittests/gsMakeUnsigned.cpp
+++ b/unittests/gsMakeUnsigned.cpp
@@ -1,0 +1,240 @@
+/** @file gsBoxList.cpp
+
+    @brief Tests std::make_unsigned, which is part of CXX11 and
+    for CXX98 defined in gsTemplateTools.h.
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): J. Vogl
+**/
+
+#include "gismo_unittest.h"
+
+#include <stdint.h>
+
+SUITE(gsMakeUnsigned)
+{
+    TEST(int32_m1_1)
+    {
+        int i0 = -1;
+        int i1 = 1;
+        unsigned int exp = 2;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_min_max)
+    {
+        int i0 = INT32_MIN;
+        int i1 = INT32_MAX;
+        unsigned int exp = UINT32_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_min_m1)
+    {
+        int i0 = INT32_MIN;
+        int i1 = -1;
+        unsigned int exp = INT32_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_min_0)
+    {
+        int i0 = INT32_MIN;
+        int i1 = 0;
+        unsigned int exp = INT32_MAX + 1U;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_min_1)
+    {
+        int i0 = INT32_MIN;
+        int i1 = 1;
+        unsigned int exp = INT32_MAX + 2U;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_m1_max)
+    {
+        int i0 = -1;
+        int i1 = INT32_MAX;
+        unsigned int exp = INT32_MAX + 1U;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_0_max)
+    {
+        int i0 = 0;
+        int i1 = INT32_MAX;
+        unsigned int exp = INT32_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_1_max)
+    {
+        int i0 = 1;
+        int i1 = INT32_MAX;
+        unsigned int exp = INT32_MAX - 1;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(int32_max_max)
+    {
+        int i0 = INT32_MAX;
+        int i1 = INT32_MAX;
+        unsigned int exp = 0;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(uint32_0_imax)
+    {
+        unsigned int i0 = 0;
+        unsigned int i1 = INT32_MAX;
+        unsigned int exp = INT32_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(uint32_imax_imax)
+    {
+        unsigned int i0 = INT32_MAX;
+        unsigned int i1 = INT32_MAX;
+        unsigned int exp = 0;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_m1_1)
+    {
+        long long i0 = -1;
+        long long i1 = 1;
+        unsigned long long exp = 2;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_min_max)
+    {
+        long long i0 = INT64_MIN;
+        long long i1 = INT64_MAX;
+        unsigned long long exp = UINT64_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_min_m1)
+    {
+        long long i0 = INT64_MIN;
+        long long i1 = -1;
+        unsigned long long exp = INT64_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_min_0)
+    {
+        long long i0 = INT64_MIN;
+        long long i1 = 0;
+        unsigned long long exp = INT64_MAX + 1UL;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_min_1)
+    {
+        long long i0 = INT64_MIN;
+        long long i1 = 1;
+        unsigned long long exp = INT64_MAX + 2UL;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_m1_max)
+    {
+        long long i0 = -1;
+        long long i1 = INT64_MAX;
+        unsigned long long exp = INT64_MAX + 1UL;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_0_max)
+    {
+        long long i0 = 0;
+        long long i1 = INT64_MAX;
+        unsigned long long exp = INT64_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_1_max)
+    {
+        long long i0 = 1;
+        long long i1 = INT64_MAX;
+        unsigned long long exp = INT64_MAX - 1;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(INT64_max_max)
+    {
+        long long i0 = INT64_MAX;
+        long long i1 = INT64_MAX;
+        unsigned long long exp = 0;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(uINT64_0_imax)
+    {
+        unsigned long long i0 = 0;
+        unsigned long long i1 = INT64_MAX;
+        unsigned long long exp = INT64_MAX;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+
+    TEST(uINT64_imax_imax)
+    {
+        unsigned long long i0 = INT64_MAX;
+        unsigned long long i1 = INT64_MAX;
+        unsigned long long exp = 0;
+
+        CHECK(math::abs_diff(i0, i1) == exp);
+        CHECK(math::abs_diff(i1, i0) == exp);
+    }
+}


### PR DESCRIPTION
On some code (unsupported, like [gsIETIdG_experimental.cpp#L145](https://github.com/gismo/unsupported/blob/b36880528353bac9826de7892fe4338679e2032e/examples/gsIETIdG_experimental.cpp#L145)) there is abs(a - b) used to find out the distance of 2 indexes.
Since this will not work with size_t, and is buggy in special cases, it would make sense to add an error free implementation that works well with all integer types.
