### PR TITLE
use _MSVC_LANG, as MSVC doesn't set _cplusplus to correct value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ build/
 
 # QtCreator user file
 CMakeLists.txt.user
+
+# Visual Studio
+/CMakeSettings.json*
+/.vs
+/build*

--- a/external/Eigen/src/Core/util/Macros.h
+++ b/external/Eigen/src/Core/util/Macros.h
@@ -356,7 +356,7 @@
 #define EIGEN_MAX_CPP_VER 99
 #endif
 
-#if EIGEN_MAX_CPP_VER>=11 && (defined(__cplusplus) && (__cplusplus >= 201103L) || EIGEN_COMP_MSVC >= 1900)
+#if EIGEN_MAX_CPP_VER>=11 && (defined(__cplusplus) && (__cplusplus >= 201103L) || EIGEN_COMP_MSVC >= 1600)
 #define EIGEN_HAS_CXX11 1
 #else
 #define EIGEN_HAS_CXX11 0

--- a/external/Eigen/src/Core/util/Macros.h
+++ b/external/Eigen/src/Core/util/Macros.h
@@ -356,7 +356,7 @@
 #define EIGEN_MAX_CPP_VER 99
 #endif
 
-#if EIGEN_MAX_CPP_VER>=11 && (defined(__cplusplus) && (__cplusplus >= 201103L) || EIGEN_COMP_MSVC >= 1600)
+#if EIGEN_MAX_CPP_VER>=11 && (defined(__cplusplus) && (__cplusplus >= 201103L) || EIGEN_COMP_MSVC >= 1900)
 #define EIGEN_HAS_CXX11 1
 #else
 #define EIGEN_HAS_CXX11 0
@@ -368,7 +368,7 @@
 #if EIGEN_MAX_CPP_VER>=11 && \
     (__has_feature(cxx_rvalue_references) || \
     (defined(__cplusplus) && __cplusplus >= 201103L) || \
-    (EIGEN_COMP_MSVC >= 1600))
+    (EIGEN_COMP_MSVC >= 1900))
   #define EIGEN_HAS_RVALUE_REFERENCES 1
 #else
   #define EIGEN_HAS_RVALUE_REFERENCES 0

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -381,7 +381,7 @@ public:
     void setOptions(gsOptionList opt) { m_options = opt; } // gsOptionList opt
     // .swap(opt) todo
 
-#   if(__cplusplus >= 201103L || defined(__DOXYGEN__))
+#   if(__cplusplus >= 201103L || _MSVC_LANG >= 201103L || defined(__DOXYGEN__))
     /// Adds the expressions \a args to the system matrix/rhs
     ///
     /// The arguments are considered as integrals over the whole domain
@@ -503,7 +503,7 @@ private:
                                 const ifContainer & iFaces);
 
 // /*
-#if(__cplusplus >= 201103L) // c++11
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
     template <class op, class E1>
     void _apply(op _op, const expr::_expr<E1> & firstArg) {_op(firstArg);}
     template <class op, class E1, class... Rest>
@@ -793,7 +793,7 @@ template<class T> void gsExprAssembler<T>::resetDimensions()
 }
 
 template<class T>
-#if(__cplusplus >= 201103L || defined(__DOXYGEN__)) // c++11
+#if(__cplusplus >= 201103L || _MSVC_LANG >= 201103L || defined(__DOXYGEN__)) // c++11
 template<class... expr>
 void gsExprAssembler<T>::assemble(expr... args)
 #else
@@ -806,7 +806,7 @@ void gsExprAssembler<T>::assemble(expr... args)
 
     // initialize flags
     m_exprdata->initFlags(SAME_ELEMENT|NEED_ACTIVE, SAME_ELEMENT);
-#   if(__cplusplus >= 201103L)
+#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
     _apply(_setFlag, args...);
     //_apply(_printExpr, args...);
 #   else
@@ -839,7 +839,7 @@ void gsExprAssembler<T>::assemble(expr... args)
             //m_exprdata->precompute(QuRule, *domIt); // todo
 
             // Assemble contributions of the element
-#           if(__cplusplus >= 201103L)
+#           if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
             _apply(ee, args...);
 #           else
             ee(a1);ee(a2);ee(a3);ee(a4);ee(a5);
@@ -851,7 +851,7 @@ void gsExprAssembler<T>::assemble(expr... args)
 }
 
 template<class T>
-#if(__cplusplus >= 201103L) // c++11
+if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
 template<class... expr>
 void gsExprAssembler<T>::assemble(const bcRefList & BCs, expr... args)
 #else
@@ -861,7 +861,7 @@ void gsExprAssembler<T>::assemble(const bcRefList & BCs, const expr::_expr<E1> &
 {
     // initialize flags
     m_exprdata->initFlags(SAME_ELEMENT|NEED_ACTIVE, SAME_ELEMENT);
-#   if(__cplusplus >= 201103L)
+#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
     _apply(_setFlag, args...);
 #   else
     _setFlag(a1);
@@ -899,7 +899,7 @@ void gsExprAssembler<T>::assemble(const bcRefList & BCs, const expr::_expr<E1> &
             m_exprdata->precompute(it->patch());
 
             // Assemble contributions of the element
-#           if(__cplusplus >= 201103L)
+#           if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
             _apply(ee, args...);
 #           else
             ee(a1);

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -851,7 +851,7 @@ void gsExprAssembler<T>::assemble(expr... args)
 }
 
 template<class T>
-if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
 template<class... expr>
 void gsExprAssembler<T>::assemble(const bcRefList & BCs, expr... args)
 #else

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -381,7 +381,7 @@ public:
     void setOptions(gsOptionList opt) { m_options = opt; } // gsOptionList opt
     // .swap(opt) todo
 
-#   if(__cplusplus >= 201103L || _MSVC_LANG >= 201103L || defined(__DOXYGEN__))
+#   if(__cplusplus >= 201103L || _MSC_VER >= 1600 || defined(__DOXYGEN__))
     /// Adds the expressions \a args to the system matrix/rhs
     ///
     /// The arguments are considered as integrals over the whole domain
@@ -503,7 +503,7 @@ private:
                                 const ifContainer & iFaces);
 
 // /*
-#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
+#if __cplusplus >= 201103L || _MSC_VER >= 1600 // c++11
     template <class op, class E1>
     void _apply(op _op, const expr::_expr<E1> & firstArg) {_op(firstArg);}
     template <class op, class E1, class... Rest>
@@ -793,7 +793,7 @@ template<class T> void gsExprAssembler<T>::resetDimensions()
 }
 
 template<class T>
-#if(__cplusplus >= 201103L || _MSVC_LANG >= 201103L || defined(__DOXYGEN__)) // c++11
+#if(__cplusplus >= 201103L || _MSC_VER >= 1600 || defined(__DOXYGEN__)) // c++11
 template<class... expr>
 void gsExprAssembler<T>::assemble(expr... args)
 #else
@@ -806,7 +806,7 @@ void gsExprAssembler<T>::assemble(expr... args)
 
     // initialize flags
     m_exprdata->initFlags(SAME_ELEMENT|NEED_ACTIVE, SAME_ELEMENT);
-#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#   if __cplusplus >= 201103L || _MSC_VER >= 1600
     _apply(_setFlag, args...);
     //_apply(_printExpr, args...);
 #   else
@@ -839,7 +839,7 @@ void gsExprAssembler<T>::assemble(expr... args)
             //m_exprdata->precompute(QuRule, *domIt); // todo
 
             // Assemble contributions of the element
-#           if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#           if __cplusplus >= 201103L || _MSC_VER >= 1600
             _apply(ee, args...);
 #           else
             ee(a1);ee(a2);ee(a3);ee(a4);ee(a5);
@@ -851,7 +851,7 @@ void gsExprAssembler<T>::assemble(expr... args)
 }
 
 template<class T>
-#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
+#if __cplusplus >= 201103L || _MSC_VER >= 1600 // c++11
 template<class... expr>
 void gsExprAssembler<T>::assemble(const bcRefList & BCs, expr... args)
 #else
@@ -861,7 +861,7 @@ void gsExprAssembler<T>::assemble(const bcRefList & BCs, const expr::_expr<E1> &
 {
     // initialize flags
     m_exprdata->initFlags(SAME_ELEMENT|NEED_ACTIVE, SAME_ELEMENT);
-#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#   if __cplusplus >= 201103L || _MSC_VER >= 1600
     _apply(_setFlag, args...);
 #   else
     _setFlag(a1);
@@ -899,7 +899,7 @@ void gsExprAssembler<T>::assemble(const bcRefList & BCs, const expr::_expr<E1> &
             m_exprdata->precompute(it->patch());
 
             // Assemble contributions of the element
-#           if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#           if __cplusplus >= 201103L || _MSC_VER >= 1600
             _apply(ee, args...);
 #           else
             ee(a1);

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -69,12 +69,12 @@ template<class T> class gsExprHelper;
 namespace expr
 {
 
-#if(__cplusplus >= 201402L) // c++14
+#if __cplusplus >= 201402L || _MSVC_LANG >= 201402L // c++14
 #  define MatExprType  auto
 #  define AutoReturn_t auto
-//#elif(__cplusplus >= 201103L) // c++11
+//#elif __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
 //note: in c++11 auto-return requires -> decltype(.)
-#else // 199711L
+#else // 199711L, 201103L
 #  define MatExprType typename gsMatrix<Scalar>::constRef
 #  define AutoReturn_t typename util::conditional<ScalarValued,Scalar,MatExprType>::type
 #endif
@@ -2973,7 +2973,7 @@ operator-(typename E2::Scalar const& s, _expr<E2> const& v)
 
 
 //----------------------------------------------------------------------------------
-#if(__cplusplus >= 201402L)
+#if __cplusplus >= 201402L || _MSVC_LANG >= 201402L
 
 // Shortcuts for common quantities, for instance function
 // transformations by the geometry map \a G

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -72,7 +72,7 @@ namespace expr
 #if __cplusplus >= 201402L || _MSVC_LANG >= 201402L // c++14
 #  define MatExprType  auto
 #  define AutoReturn_t auto
-//#elif __cplusplus >= 201103L || _MSVC_LANG >= 201103L // c++11
+//#elif __cplusplus >= 201103L || _MSC_VER >= 1600 // c++11
 //note: in c++11 auto-return requires -> decltype(.)
 #else // 199711L, 201103L
 #  define MatExprType typename gsMatrix<Scalar>::constRef

--- a/src/gsCore/gsBoxTopology.cpp
+++ b/src/gsCore/gsBoxTopology.cpp
@@ -283,12 +283,12 @@ std::vector< std::vector<patchComponent> > gsBoxTopology::allComponents(bool com
     for (short_t i=dim; i>=0; --i)
     {
         if (!combineCorners || i>0)
-            for( /*typename*/ map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
+            for( map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
                 result.push_back( it->second );
         else
         {
             component_coll_t last;
-            for( /*typename*/ map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
+            for( map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
             {
                 const index_t nrcp = it->second.size();
                 for (index_t j=0; j<nrcp; ++j)

--- a/src/gsCore/gsBoxTopology.cpp
+++ b/src/gsCore/gsBoxTopology.cpp
@@ -283,12 +283,12 @@ std::vector< std::vector<patchComponent> > gsBoxTopology::allComponents(bool com
     for (short_t i=dim; i>=0; --i)
     {
         if (!combineCorners || i>0)
-            for( typename map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
+            for( /*typename*/ map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
                 result.push_back( it->second );
         else
         {
             component_coll_t last;
-            for( typename map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
+            for( /*typename*/ map_t::iterator it = comps[i].begin(); it != comps[i].end(); ++it )
             {
                 const index_t nrcp = it->second.size();
                 for (index_t j=0; j<nrcp; ++j)

--- a/src/gsCore/gsDebug.h
+++ b/src/gsCore/gsDebug.h
@@ -264,7 +264,7 @@ static const int  gismo_set_abort_behavior = _set_abort_behavior(
  */
 #ifndef GISMO_NO_STATIC_ASSERT
 
-  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || _MSVC_VER > 199711L
+  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || _MSVC_LANG > 199711L
 
     // Native static_assert is available
     #define GISMO_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);

--- a/src/gsCore/gsDebug.h
+++ b/src/gsCore/gsDebug.h
@@ -264,7 +264,7 @@ static const int  gismo_set_abort_behavior = _set_abort_behavior(
  */
 #ifndef GISMO_NO_STATIC_ASSERT
 
-  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || _MSVC_VER > 199711L)
+  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || _MSVC_VER > 199711L
 
     // Native static_assert is available
     #define GISMO_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);

--- a/src/gsCore/gsDebug.h
+++ b/src/gsCore/gsDebug.h
@@ -264,7 +264,7 @@ static const int  gismo_set_abort_behavior = _set_abort_behavior(
  */
 #ifndef GISMO_NO_STATIC_ASSERT
 
-  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || _MSVC_LANG > 199711L
+  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || _MSC_VER >= 1600
 
     // Native static_assert is available
     #define GISMO_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);

--- a/src/gsCore/gsDebug.h
+++ b/src/gsCore/gsDebug.h
@@ -264,7 +264,7 @@ static const int  gismo_set_abort_behavior = _set_abort_behavior(
  */
 #ifndef GISMO_NO_STATIC_ASSERT
 
-  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || (defined(_MSC_VER) && (_MSC_VER >= 1600))
+  #if defined(__GXX_EXPERIMENTAL_CXX0X__) || _MSVC_VER > 199711L)
 
     // Native static_assert is available
     #define GISMO_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);

--- a/src/gsCore/gsExport.h.in
+++ b/src/gsCore/gsExport.h.in
@@ -128,9 +128,12 @@
   Example:
   virtual void foo() GISMO_OVERRIDE;
 */
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1700   // all versions before MSVC 2012
 // MSVC2010 uses "sealed", later versions accept final as well
 #  define GISMO_FINAL sealed
+#  define GISMO_OVERRIDE override
+#elif _MSC_VER >= 1700   // MSVC 2012 upward
+#  define GISMO_FINAL final
 #  define GISMO_OVERRIDE override
 #elif defined(__clang__ ) && __has_feature(cxx_override_control)
 #  define GISMO_FINAL final

--- a/src/gsCore/gsJITCompiler.h
+++ b/src/gsCore/gsJITCompiler.h
@@ -88,7 +88,7 @@ struct gsJITCompilerConfig
         std::swap(temp , other.temp );
     }
             
-#   if __cplusplus >= 201103L
+#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
 
     /// Constructor (copy)
     gsJITCompilerConfig(gsJITCompilerConfig const& other)
@@ -604,7 +604,7 @@ public:
         return *this;
     }
 
-#   if __cplusplus >= 201103L
+#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
     /// Constructor (move)
     gsJITCompiler(gsJITCompiler && other)
     : //kernel(std::move(other.kernel)),
@@ -640,7 +640,7 @@ public:
     /// (determine filename from hash of kernel source code)
     gsDynamicLibrary build(bool force = false)
     {
-#       if __cplusplus >= 201103L
+#       if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
         size_t h = std::hash<std::string>()(getKernel().str());
         return build(std::to_string(h), force);
 #       else

--- a/src/gsCore/gsJITCompiler.h
+++ b/src/gsCore/gsJITCompiler.h
@@ -88,7 +88,7 @@ struct gsJITCompilerConfig
         std::swap(temp , other.temp );
     }
             
-#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#   if __cplusplus >= 201103L || _MSC_VER >= 1600
 
     /// Constructor (copy)
     gsJITCompilerConfig(gsJITCompilerConfig const& other)
@@ -625,7 +625,7 @@ public:
         return *this;
     }
 
-#   if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#   if __cplusplus >= 201103L || _MSC_VER >= 1600
     /// Constructor (move)
     gsJITCompiler(gsJITCompiler && other)
     : //kernel(std::move(other.kernel)),
@@ -661,7 +661,7 @@ public:
     /// (determine filename from hash of kernel source code)
     gsDynamicLibrary build(bool force = false)
     {
-#       if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#       if __cplusplus >= 201103L || _MSC_VER >= 1600
         size_t h = std::hash<std::string>()(getKernel().str());
         return build(std::to_string(h), force);
 #       else

--- a/src/gsCore/gsMemory.h
+++ b/src/gsCore/gsMemory.h
@@ -69,7 +69,7 @@ usage:
 memory::unique_ptr<int> B;
 \endcode
 */
-#if __cplusplus >= 201103 || _MSVC_LANG >= 201103
+#if __cplusplus >= 201103 || _MSC_VER >= 1600
 using std::unique_ptr;
 using std::nullptr_t;
 #else
@@ -234,7 +234,7 @@ inline std::vector<T*> release(std::vector< unique_ptr<T> >& cont)
 
 } // namespace memory
 
-#if __cplusplus >= 201103 || _MSVC_LANG >= 201103
+#if __cplusplus >= 201103 || _MSC_VER >= 1600
 /** 
     Alias for std::move, to be used instead of writing std::move for
     keeping backward c++98 compatibility
@@ -398,7 +398,7 @@ inline void copy(T begin, T end, U* result)
 
 } // namespace gismo
 
-#if __cplusplus < 201103L && _MSVC_LANG < 201103L
+#if __cplusplus < 201103L && _MSC_VER < 1600
 // Define nullptr for compatibility with newer C++
 static const gismo::memory::nullptr_t nullptr ={};
 #endif

--- a/src/gsCore/gsMemory.h
+++ b/src/gsCore/gsMemory.h
@@ -69,7 +69,7 @@ usage:
 memory::unique_ptr<int> B;
 \endcode
 */
-#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1600)
+#if __cplusplus >= 201103 || _MSVC_LANG >= 201103
 using std::unique_ptr;
 using std::nullptr_t;
 #else
@@ -234,7 +234,7 @@ inline std::vector<T*> release(std::vector< unique_ptr<T> >& cont)
 
 } // namespace memory
 
-#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER >= 1600)
+#if __cplusplus >= 201103 || _MSVC_LANG >= 201103
 /** 
     Alias for std::move, to be used instead of writing std::move for
     keeping backward c++98 compatibility
@@ -398,7 +398,7 @@ inline void copy(T begin, T end, U* result)
 
 } // namespace gismo
 
-#if (__cplusplus < 201103) && (!defined(_MSC_VER) || _MSC_VER < 1600)
+#if __cplusplus < 201103L && _MSVC_LANG < 201103L
 // Define nullptr for compatibility with newer C++
 static const gismo::memory::nullptr_t nullptr ={};
 #endif

--- a/src/gsCore/gsMemory.h
+++ b/src/gsCore/gsMemory.h
@@ -234,7 +234,7 @@ inline std::vector<T*> release(std::vector< unique_ptr<T> >& cont)
 
 } // namespace memory
 
-#if __cplusplus >= 201103 || _MSC_VER >= 1600
+#if __cplusplus >= 201103 || _MSC_VER >= 1900
 /** 
     Alias for std::move, to be used instead of writing std::move for
     keeping backward c++98 compatibility
@@ -253,7 +253,7 @@ auto give(T&& t) -> decltype(std::move(std::forward<T>(t)))
 #else
 /**
     Alias for std::move, to be used instead of std::move for backward
-    c++98 compatibility
+    c++98 compatibility and MSVC before 2015
 
     Based on swapping and copy elision.
 */

--- a/src/gsCore/gsMemory.h
+++ b/src/gsCore/gsMemory.h
@@ -14,7 +14,6 @@
 #pragma once
 
 #include <gsCore/gsTemplateTools.h>
-#include <type_traits>
 
 #ifdef __MINGW32__
 //#include <malloc/malloc.h> //xcode

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -22,7 +22,7 @@ namespace gismo
 
 namespace util {
 
-#if __cplusplus >= 201103 || _MSVC_LANG >= 201103 // (defined(_MSC_VER) && _MSC_VER > 1700) // MSVC 2012
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // (defined(_MSC_VER) && _MSC_VER > 1700) // MSVC 2012
 //see also http://lists.boost.org/Archives/boost/2009/04/151209.php
 template <typename T> struct has_move_constructor
 {

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -22,7 +22,7 @@ namespace gismo
 
 namespace util {
 
-#if __cplusplus >= 201103 || (defined(_MSC_VER) && _MSC_VER > 1700)
+#if __cplusplus >= 201103 || _MSVC_LANG >= 201103 // (defined(_MSC_VER) && _MSC_VER > 1700) // MSVC 2012
 //see also http://lists.boost.org/Archives/boost/2009/04/151209.php
 template <typename T> struct has_move_constructor
 {

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -22,7 +22,7 @@ namespace gismo
 
 namespace util {
 
-#if __cplusplus >= 201103L || _MSC_VER >= 1600
+#if __cplusplus >= 201103L
 //see also http://lists.boost.org/Archives/boost/2009/04/151209.php
 // has_move_constructor is not working with MSVC up to VS2019
 template <typename T> struct has_move_constructor

--- a/src/gsCore/gsTemplateTools.h
+++ b/src/gsCore/gsTemplateTools.h
@@ -22,8 +22,9 @@ namespace gismo
 
 namespace util {
 
-#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L // (defined(_MSC_VER) && _MSC_VER > 1700) // MSVC 2012
+#if __cplusplus >= 201103L || _MSC_VER >= 1600
 //see also http://lists.boost.org/Archives/boost/2009/04/151209.php
+// has_move_constructor is not working with MSVC up to VS2019
 template <typename T> struct has_move_constructor
 {
     typedef char yes[1];
@@ -38,6 +39,9 @@ template <typename T> struct has_move_constructor
     template <typename> static yes& test(...);
     enum { value = (sizeof(test<T>(0)) == sizeof(yes)) };
 };
+#endif
+
+#if __cplusplus >= 201103L || _MSC_VER >= 1600
 
 using std::conditional;
 using std::enable_if;

--- a/src/gsIO/gsCmdLine.cpp
+++ b/src/gsIO/gsCmdLine.cpp
@@ -426,8 +426,12 @@ void gsCmdLine::printVersion()
     gsInfo << "               version "<< GISMO_VERSION<<"\n";
     gsInfo << "Compiled by ";
 //https://sourceforge.net/p/predef/wiki/Compilers, see also boost/predef.h
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1600
+    gsInfo << "MSVC "<<_MSC_FULL_VER <<" ("<<"199711L" <<", ";
+#elsif _MSC_VER >= 1900
     gsInfo << "MSVC "<<_MSC_FULL_VER <<" ("<<_MSVC_LANG <<", ";
+#elsif _MSC_VER >= 1600
+    gsInfo << "MSVC "<<_MSC_FULL_VER <<" ("<<"201103L" <<", ";
 #elif defined(__clang__ )
     gsInfo << "Clang "<<__clang_version__<<" ("<<__cplusplus <<", ";
 #elif defined(_INTEL_COMPILER)

--- a/src/gsIO/gsCmdLine.cpp
+++ b/src/gsIO/gsCmdLine.cpp
@@ -427,7 +427,7 @@ void gsCmdLine::printVersion()
     gsInfo << "Compiled by ";
 //https://sourceforge.net/p/predef/wiki/Compilers, see also boost/predef.h
 #if defined(_MSC_VER)
-    gsInfo << "MSVC "<<_MSC_FULL_VER <<" ("<<__cplusplus <<", ";
+    gsInfo << "MSVC "<<_MSC_FULL_VER <<" ("<<_MSVC_LANG <<", ";
 #elif defined(__clang__ )
     gsInfo << "Clang "<<__clang_version__<<" ("<<__cplusplus <<", ";
 #elif defined(_INTEL_COMPILER)

--- a/src/gsIO/gsFileManager.cpp
+++ b/src/gsIO/gsFileManager.cpp
@@ -23,11 +23,7 @@
 #include <windows.h>
 #include <direct.h>
 #include <ShlObj.h>
-#ifdef __MINGW32__
-//#include <sys/stat.h>
-#endif
 #else
-//#include <sys/stat.h>
 #include <dlfcn.h>
 #include <unistd.h>
 #include <pwd.h>

--- a/src/gsIO/gsFileManager.cpp
+++ b/src/gsIO/gsFileManager.cpp
@@ -222,7 +222,13 @@ inline bool _addSearchPaths(const std::string& in, std::vector<std::string>& out
             if (*p.rbegin() != '/')
                 p.push_back('/');
 #endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+            // with VS2013, a path must not end with pathseperator
+            if(_dirExistsWithoutSearching(gsFileManager::getCanonicRepresentation(p + "..")))
+#else
             if (_dirExistsWithoutSearching(p))
+#endif // defined(_MSC_VER) && _MSC_VER < 1900
                 out.push_back(p);
             else
                 ok = false;

--- a/src/gsIO/gsFileManager.cpp
+++ b/src/gsIO/gsFileManager.cpp
@@ -17,16 +17,17 @@
 #include <gsCore/gsConfig.h>
 #include <gsUtils/gsUtils.h>
 #include <cstdlib>
+#include <sys/stat.h>
 
 #if defined _WIN32
 #include <windows.h>
 #include <direct.h>
 #include <ShlObj.h>
 #ifdef __MINGW32__
-#include <sys/stat.h>
+//#include <sys/stat.h>
 #endif
 #else
-#include <sys/stat.h>
+//#include <sys/stat.h>
 #include <dlfcn.h>
 #include <unistd.h>
 #include <pwd.h>

--- a/src/gsModeling/gsParametrization.hpp
+++ b/src/gsModeling/gsParametrization.hpp
@@ -537,7 +537,7 @@ gsParametrization<T>::LocalParametrization::LocalParametrization(const gsHalfEdg
                 length = (*meshInfo.getVertex(indices.front()) - *meshInfo.getVertex(m_vertexIndex)).norm();
                 //length =  (meshInfo.getVertex(indices.front()) - meshInfo.getVertex(m_vertexIndex) ).norm();
                 nextAngle = angles.front()*thetaInv * 2 * EIGEN_PI;
-                nextVector = ((Eigen::Rotation2D<T>(nextAngle) * actualVector).normalized()*length) + p;
+                nextVector = (Eigen::Rotation2D<T>(nextAngle).operator*(actualVector).normalized()*length) + p;
                 nextPoint = Point2D(nextVector[0], nextVector[1], indices.front());
                 points.push_back(nextPoint);
                 actualVector = nextPoint - p;

--- a/src/gsUtils/gsStopwatch.h
+++ b/src/gsUtils/gsStopwatch.h
@@ -16,7 +16,7 @@
 #include <ostream>
 
 // includes for wall clocks
-#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#if __cplusplus >= 201103L || _MSC_VER >= 1600
 #  include <chrono>
 #elif defined(__linux__)
 #  include <sys/time.h>
@@ -101,7 +101,7 @@ private:
  * SYSTEM-SPECIFIC WALL CLOCKS
  */
 
-#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L   // C++11 //
+#if __cplusplus >= 201103L || _MSC_VER >= 1600   // C++11 //
 // highest-resolution wall clock time
 struct CXX11WallClock
 {

--- a/src/gsUtils/gsStopwatch.h
+++ b/src/gsUtils/gsStopwatch.h
@@ -16,7 +16,7 @@
 #include <ostream>
 
 // includes for wall clocks
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
 #  include <chrono>
 #elif defined(__linux__)
 #  include <sys/time.h>
@@ -101,7 +101,7 @@ private:
  * SYSTEM-SPECIFIC WALL CLOCKS
  */
 
-#if __cplusplus >= 201103L                                          // C++11 //
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L   // C++11 //
 // highest-resolution wall clock time
 struct CXX11WallClock
 {

--- a/src/gsUtils/gsUtils.h
+++ b/src/gsUtils/gsUtils.h
@@ -38,7 +38,7 @@ namespace gismo
 namespace util
 {
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
 template <class C, size_t N> // we catch up char arrays
 std::string to_string(C (& value)[N])
 {
@@ -82,7 +82,7 @@ inline bool ends_with( const std::string & haystack, const std::string & needle 
     return std::equal(needle.rbegin(), needle.rend(), haystack.rbegin());
 }
 
-#if __cplusplus > 199711L || (defined(_MSC_VER) && _MSC_VER >= 1600)
+#if __cplusplus > 199711L || _MSVC_LANG > 199711L
 using std::iota;
 using std::stod;
 using std::stoi;
@@ -252,9 +252,9 @@ public:
         std::free(dm);
         return res;
 #endif
-#else
+#else   // not __GNUC__
         return typeid(T).name();
-#endif
+#endif  // __GNUC__
     }
 };
 
@@ -268,7 +268,7 @@ size_t hash_range(T const * start, const T * const end)
     return seed;
 }
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 using std::size;
 #else
 template <class T, size_t N>
@@ -296,7 +296,7 @@ inline bool operator>= (const T& a, const T& b) { return !(a<b);  }
 // This macro deletes the operators ==, !=, <, >, <= and >=
 // for operations that involve the types S and T (in either
 // order)
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
 #define GISMO_DELETE_COMPARISON_OPERATORS( S, T )         \
 inline bool operator== (const S& a, const T& b) = delete; \
 inline bool operator!= (const S& a, const T& b) = delete; \

--- a/src/gsUtils/gsUtils.h
+++ b/src/gsUtils/gsUtils.h
@@ -187,7 +187,7 @@ inline std::string tokenize(const std::string& str,
                             const std::string& delim,
                             const size_t token)
 {
-    size_t token_end = -1;
+    size_t token_end = std::string::npos;
     size_t token_begin = 0;
     size_t token_count = 0;
     bool catched = false;

--- a/src/gsUtils/gsUtils.h
+++ b/src/gsUtils/gsUtils.h
@@ -38,7 +38,7 @@ namespace gismo
 namespace util
 {
 
-#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#if __cplusplus >= 201103L || _MSC_VER >= 1600
 template <class C, size_t N> // we catch up char arrays
 std::string to_string(C (& value)[N])
 {
@@ -82,7 +82,7 @@ inline bool ends_with( const std::string & haystack, const std::string & needle 
     return std::equal(needle.rbegin(), needle.rend(), haystack.rbegin());
 }
 
-#if __cplusplus > 199711L || _MSVC_LANG > 199711L
+#if __cplusplus > 199711L || _MSC_VER >= 1600
 using std::iota;
 using std::stod;
 using std::stoi;
@@ -296,7 +296,7 @@ inline bool operator>= (const T& a, const T& b) { return !(a<b);  }
 // This macro deletes the operators ==, !=, <, >, <= and >=
 // for operations that involve the types S and T (in either
 // order)
-#if __cplusplus >= 201103L || _MSVC_LANG >= 201103L
+#if __cplusplus >= 201103L || _MSC_VER >= 1600
 #define GISMO_DELETE_COMPARISON_OPERATORS( S, T )         \
 inline bool operator== (const S& a, const T& b) = delete; \
 inline bool operator!= (const S& a, const T& b) = delete; \

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -12,14 +12,14 @@
 */
 
 #include "gismo_unittest.h"
-#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
+#if (__cplusplus >= 201103L || _MSC_VER >= 1600)
 #include <type_traits>
 #endif
 
 SUITE(gsMoveSemantics_test)
 {
 
-#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L) && EIGEN_HAS_RVALUE_REFERENCES
+#if (__cplusplus >= 201103L || _MSC_VER >= 1600) && EIGEN_HAS_RVALUE_REFERENCES
 
 #ifndef _MSC_VER // util::has_move_constructor doesn't work with MSVC
 TEST(gsMatrix_mc) { CHECK(util::has_move_constructor<gismo::gsMatrix<> >::value); }
@@ -45,9 +45,9 @@ TEST(gsTensorBSplineBasis_std_mc) { CHECK(std::is_move_constructible<gismo::gsTe
 TEST(gsTensorBSpline_std_mc) { CHECK(std::is_move_constructible<gismo::gsTensorBSpline<2> >::value); }
 
 // T needs to be a complete type.
-TEST(gsMatrix_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsMatrix<> >::value); }
-TEST(gsVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsVector<> >::value); }
-TEST(gsKnotVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsKnotVector<> >::value); }
+TEST(gsMatrix_nothrow_mc) { CHECK(std::is_nothrow_move_constructible<gismo::gsMatrix<> >::value); }
+TEST(gsVector_nothrow_mc) { CHECK(std::is_nothrow_move_constructible<gismo::gsVector<> >::value); }
+TEST(gsKnotVector_nothrow_mc) { CHECK(std::is_nothrow_move_constructible<gismo::gsKnotVector<> >::value); }
 #endif
 
 

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -16,7 +16,7 @@
 SUITE(gsMoveSemantics_test)
 {
 
-#if (__cplusplus >=201103 || _MSVC_LANG >=201103) && EIGEN_HAS_RVALUE_REFERENCES
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L) && EIGEN_HAS_RVALUE_REFERENCES
 TEST(gsMatrix_mc) { CHECK(util::has_move_constructor<gismo::gsMatrix<> >::value); }
 TEST(gsVector_mc) { CHECK(util::has_move_constructor<gismo::gsVector<> >::value); }
 TEST(gsSparseMatrix_mc) { CHECK(util::has_move_constructor<gismo::gsSparseMatrix<> >::value); }

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -61,28 +61,42 @@ TEST(gsMatrix_swap)
     gsMatrix<> c = a;                   // make a deep copy
     gsMatrix<> d = b;                   // make a deep copy
 
-    size_t adda = (size_t) &a.at(0);    // gdb p a.m_storage.m_data
-    size_t addb = (size_t) &b.at(0);    // gdb p b.m_storage.m_data
+    size_t add_a = (size_t) &a;         // gdb p &a
+    size_t add_b = (size_t) &b;         // gdb p &b
+    size_t add_m_a = (size_t) &a.at(0); // gdb p a.m_storage.m_data
+    size_t add_m_b = (size_t) &b.at(0); // gdb p b.m_storage.m_data
 
+    // assert c is deep copy
     CHECK(a == c);                      // same values
     CHECK(!(b == c));
     CHECK(&a != &c);                    // copy
     CHECK(&a.at(0) != &c.at(0));        // deep copy
 
+    // assert d is deep copy
     CHECK(!(a == d));
     CHECK(b == d);                      // same values
     CHECK(&b != &d);                    // copy
     CHECK(&b.at(0) != &d.at(0));        // deep copy
 
-    a = give(b);                        // give swaps with flat copies
+    a = give(b);                        // give swaps with flat copies under C++11
 
-    CHECK(b == c);                      // same values
-    CHECK(!(b == d));
-    CHECK((size_t) &b.at(0) == adda);   // flat copy
-
+    // a
+    CHECK((size_t) &a == add_a);
+    CHECK((size_t) &a != add_b);
     CHECK(!(a == c));
     CHECK(a == d);                      // same values
-    CHECK((size_t) &a.at(0) == addb);   // flat copy
+    CHECK((size_t) &a.at(0) == add_m_b);// flat copy
+
+    // b
+    CHECK((size_t) &b != add_a);
+    CHECK((size_t) &b == add_b);
+#if __cplusplus >= 201103L || _MSC_VER >= 1600
+    CHECK(b == c);                      // same values
+    CHECK(!(b == d));
+    CHECK((size_t) &b.at(0) == add_m_a);// flat copy
+#else
+    CHECK(0 == b.size());
+#endif
 }
 
 TEST(gsMatrix_ms)

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -50,7 +50,40 @@ TEST(gsVector_nothrow_mc) { CHECK(std::is_nothrow_move_constructible<gismo::gsVe
 TEST(gsKnotVector_nothrow_mc) { CHECK(std::is_nothrow_move_constructible<gismo::gsKnotVector<> >::value); }
 #endif
 
+TEST(gsMatrix_swap)
+{
+    gsMatrix<> a(2, 2);
+    gsMatrix<> b(2, 2);
 
+    a << 1, 2, 3, 4;
+    b << 5, 6, 7, 8;
+
+    gsMatrix<> c = a;                   // make a deep copy
+    gsMatrix<> d = b;                   // make a deep copy
+
+    size_t adda = (size_t) &a.at(0);    // gdb p a.m_storage.m_data
+    size_t addb = (size_t) &b.at(0);    // gdb p b.m_storage.m_data
+
+    CHECK(a == c);                      // same values
+    CHECK(!(b == c));
+    CHECK(&a != &c);                    // copy
+    CHECK(&a.at(0) != &c.at(0));        // deep copy
+
+    CHECK(!(a == d));
+    CHECK(b == d);                      // same values
+    CHECK(&b != &d);                    // copy
+    CHECK(&b.at(0) != &d.at(0));        // deep copy
+
+    a = give(b);                        // give swaps with flat copies
+
+    CHECK(b == c);                      // same values
+    CHECK(!(b == d));
+    CHECK((size_t) &b.at(0) == adda);   // flat copy
+
+    CHECK(!(a == c));
+    CHECK(a == d);                      // same values
+    CHECK((size_t) &a.at(0) == addb);   // flat copy
+}
 
 TEST(gsMatrix_ms)
 {

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -97,7 +97,7 @@ TEST(gsMatrix_swap)
     CHECK(b == c);                      // same values
     CHECK(!(b == d));
     CHECK((size_t) &b.at(0) == add_m_a);// flat copy
-	CHECK(0 != b.size());
+    CHECK(0 != b.size());
 #else
     CHECK(0 == b.size());
 #endif
@@ -107,22 +107,22 @@ TEST(gsMatrix_swap)
 TEST(gsMatrix_ms)
 {
     gsMatrix<> b(2,2);
-	b << 1, 2, 3, 4;
-	CHECK_EQUAL(1, b.at(0));
-	CHECK_EQUAL(3, b.at(1));
-	CHECK_EQUAL(2, b.at(2));
-	CHECK_EQUAL(4, b.at(3));
-	size_t add_m_b = (size_t)& b.at(0);
+    b << 1, 2, 3, 4;
+    CHECK_EQUAL(1, b.at(0));
+    CHECK_EQUAL(3, b.at(1));
+    CHECK_EQUAL(2, b.at(2));
+    CHECK_EQUAL(4, b.at(3));
+    size_t add_m_b = (size_t)& b.at(0);
 
     gsMatrix<> a(give(b));
     CHECK(0 == b.size());
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-	CHECK((size_t)& a.at(0) == add_m_b);	// flat copy, move worked
+    CHECK((size_t)& a.at(0) == add_m_b);	// flat copy, move worked
 #endif
-	CHECK_EQUAL(1, a.at(0));
-	CHECK_EQUAL(3, a.at(1));
-	CHECK_EQUAL(2, a.at(2));
-	CHECK_EQUAL(4, a.at(3));
+    CHECK_EQUAL(1, a.at(0));
+    CHECK_EQUAL(3, a.at(1));
+    CHECK_EQUAL(2, a.at(2));
+    CHECK_EQUAL(4, a.at(3));
     /*
       gsMatrix<> c(2,2);
       c = give(b);

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -85,6 +85,7 @@ TEST(gsMatrix_swap)
     CHECK((size_t) &a != add_b);
     CHECK(!(a == c));
     CHECK(a == d);                      // same values
+    CHECK((size_t) &a.at(0) != add_m_a);// a isn't a any more
     CHECK((size_t) &a.at(0) == add_m_b);// flat copy
 
     // b
@@ -97,6 +98,7 @@ TEST(gsMatrix_swap)
 #else
     CHECK(0 == b.size());
 #endif
+    CHECK((size_t) &b.at(0) != add_m_b);// b isn't b any more
 }
 
 TEST(gsMatrix_ms)

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -16,7 +16,7 @@
 SUITE(gsMoveSemantics_test)
 {
 
-#if __cplusplus >=201103 && EIGEN_HAS_RVALUE_REFERENCES
+#if (__cplusplus >=201103 || _MSVC_LANG >=201103) && EIGEN_HAS_RVALUE_REFERENCES
 TEST(gsMatrix_mc) { CHECK(util::has_move_constructor<gismo::gsMatrix<> >::value); }
 TEST(gsVector_mc) { CHECK(util::has_move_constructor<gismo::gsVector<> >::value); }
 TEST(gsSparseMatrix_mc) { CHECK(util::has_move_constructor<gismo::gsSparseMatrix<> >::value); }

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -20,6 +20,8 @@ SUITE(gsMoveSemantics_test)
 {
 
 #if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L) && EIGEN_HAS_RVALUE_REFERENCES
+
+#ifndef _MSC_VER // util::has_move_constructor doesn't work with MSVC
 TEST(gsMatrix_mc) { CHECK(util::has_move_constructor<gismo::gsMatrix<> >::value); }
 TEST(gsVector_mc) { CHECK(util::has_move_constructor<gismo::gsVector<> >::value); }
 TEST(gsSparseMatrix_mc) { CHECK(util::has_move_constructor<gismo::gsSparseMatrix<> >::value); }
@@ -29,36 +31,23 @@ TEST(gsBSplineBasis_mc) { CHECK(util::has_move_constructor<gismo::gsBSplineBasis
 TEST(gsBSpline_mc) { CHECK(util::has_move_constructor<gismo::gsBSpline<> >::value); }
 TEST(gsTensorBSplineBasis_mc) { CHECK(util::has_move_constructor<gismo::gsTensorBSplineBasis<2> >::value); }
 TEST(gsTensorBSpline_mc) { CHECK(util::has_move_constructor<gismo::gsTensorBSpline<2> >::value); }
+#endif
 
-TEST(gsMatrix_mc2) { CHECK(std::is_move_constructible<gismo::gsMatrix<> >::value); }
-TEST(gsVector_mc2) { CHECK(std::is_move_constructible<gismo::gsVector<> >::value); }
-TEST(gsSparseMatrix_mc2) { CHECK(std::is_move_constructible<gismo::gsSparseMatrix<> >::value); }
-TEST(gsSparseVector_mc2) { CHECK(std::is_move_constructible<gismo::gsSparseVector<> >::value); }
-TEST(gsKnotVector_mc2) { CHECK(std::is_move_constructible<gismo::gsKnotVector<> >::value); }
-TEST(gsBSplineBasis_mc2) { CHECK(std::is_move_constructible<gismo::gsBSplineBasis<> >::value); }
-TEST(gsBSpline_mc2) { CHECK(std::is_move_constructible<gismo::gsBSpline<> >::value); }
-TEST(gsTensorBSplineBasis_mc2) { CHECK(std::is_move_constructible<gismo::gsTensorBSplineBasis<2> >::value); }
-TEST(gsTensorBSpline_mc2) { CHECK(std::is_move_constructible<gismo::gsTensorBSpline<2> >::value); }
+// std::is_move_constructible satisfy also copy constructors with const T&
+TEST(gsMatrix_std_mc) { CHECK(std::is_move_constructible<gismo::gsMatrix<> >::value); }
+TEST(gsVector_std_mc) { CHECK(std::is_move_constructible<gismo::gsVector<> >::value); }
+TEST(gsSparseMatrix_std_mc) { CHECK(std::is_move_constructible<gismo::gsSparseMatrix<> >::value); }
+TEST(gsSparseVector_std_mc) { CHECK(std::is_move_constructible<gismo::gsSparseVector<> >::value); }
+TEST(gsKnotVector_std_mc) { CHECK(std::is_move_constructible<gismo::gsKnotVector<> >::value); }
+TEST(gsBSplineBasis_std_mc) { CHECK(std::is_move_constructible<gismo::gsBSplineBasis<> >::value); }
+TEST(gsBSpline_std_mc) { CHECK(std::is_move_constructible<gismo::gsBSpline<> >::value); }
+TEST(gsTensorBSplineBasis_std_mc) { CHECK(std::is_move_constructible<gismo::gsTensorBSplineBasis<2> >::value); }
+TEST(gsTensorBSpline_std_mc) { CHECK(std::is_move_constructible<gismo::gsTensorBSpline<2> >::value); }
 
-TEST(gsMatrix_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsMatrix<> >::value); }
-TEST(gsVector_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsVector<> >::value); }
-TEST(gsSparseMatrix_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsSparseMatrix<> >::value); }
-TEST(gsSparseVector_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsSparseVector<> >::value); }
-TEST(gsKnotVector_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsKnotVector<> >::value); }
-TEST(gsBSplineBasis_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsBSplineBasis<> >::value); }
-TEST(gsBSpline_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsBSpline<> >::value); }
-TEST(gsTensorBSplineBasis_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsTensorBSplineBasis<2> >::value); }
-TEST(gsTensorBSpline_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsTensorBSpline<2> >::value); }
-
+// T needs to be a complete type.
 TEST(gsMatrix_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsMatrix<> >::value); }
 TEST(gsVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsVector<> >::value); }
-TEST(gsSparseMatrix_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsSparseMatrix<> >::value); }
-TEST(gsSparseVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsSparseVector<> >::value); }
 TEST(gsKnotVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsKnotVector<> >::value); }
-TEST(gsBSplineBasis_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsBSplineBasis<> >::value); }
-TEST(gsBSpline_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsBSpline<> >::value); }
-TEST(gsTensorBSplineBasis_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsTensorBSplineBasis<2> >::value); }
-TEST(gsTensorBSpline_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsTensorBSpline<2> >::value); }
 #endif
 
 

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -86,15 +86,18 @@ TEST(gsMatrix_swap)
     CHECK(!(a == c));
     CHECK(a == d);                      // same values
     CHECK((size_t) &a.at(0) != add_m_a);// a isn't a any more
-    CHECK((size_t) &a.at(0) == add_m_b);// flat copy
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+    CHECK((size_t) &a.at(0) == add_m_b);// flat copy, move worked
+#endif
 
     // b
     CHECK((size_t) &b != add_a);
     CHECK((size_t) &b == add_b);
-#if __cplusplus >= 201103L || _MSC_VER >= 1600
+#if __cplusplus >= 201103L || _MSC_VER >= 1900
     CHECK(b == c);                      // same values
     CHECK(!(b == d));
     CHECK((size_t) &b.at(0) == add_m_a);// flat copy
+	CHECK(0 != b.size());
 #else
     CHECK(0 == b.size());
 #endif
@@ -104,8 +107,22 @@ TEST(gsMatrix_swap)
 TEST(gsMatrix_ms)
 {
     gsMatrix<> b(2,2);
-    gsMatrix<> a = give(b);
+	b << 1, 2, 3, 4;
+	CHECK_EQUAL(1, b.at(0));
+	CHECK_EQUAL(3, b.at(1));
+	CHECK_EQUAL(2, b.at(2));
+	CHECK_EQUAL(4, b.at(3));
+	size_t add_m_b = (size_t)& b.at(0);
+
+    gsMatrix<> a(give(b));
     CHECK(0 == b.size());
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+	CHECK((size_t)& a.at(0) == add_m_b);	// flat copy, move worked
+#endif
+	CHECK_EQUAL(1, a.at(0));
+	CHECK_EQUAL(3, a.at(1));
+	CHECK_EQUAL(2, a.at(2));
+	CHECK_EQUAL(4, a.at(3));
     /*
       gsMatrix<> c(2,2);
       c = give(b);

--- a/unittests/gsMoveSemantics_test.cpp
+++ b/unittests/gsMoveSemantics_test.cpp
@@ -12,6 +12,9 @@
 */
 
 #include "gismo_unittest.h"
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
+#include <type_traits>
+#endif
 
 SUITE(gsMoveSemantics_test)
 {
@@ -26,7 +29,39 @@ TEST(gsBSplineBasis_mc) { CHECK(util::has_move_constructor<gismo::gsBSplineBasis
 TEST(gsBSpline_mc) { CHECK(util::has_move_constructor<gismo::gsBSpline<> >::value); }
 TEST(gsTensorBSplineBasis_mc) { CHECK(util::has_move_constructor<gismo::gsTensorBSplineBasis<2> >::value); }
 TEST(gsTensorBSpline_mc) { CHECK(util::has_move_constructor<gismo::gsTensorBSpline<2> >::value); }
+
+TEST(gsMatrix_mc2) { CHECK(std::is_move_constructible<gismo::gsMatrix<> >::value); }
+TEST(gsVector_mc2) { CHECK(std::is_move_constructible<gismo::gsVector<> >::value); }
+TEST(gsSparseMatrix_mc2) { CHECK(std::is_move_constructible<gismo::gsSparseMatrix<> >::value); }
+TEST(gsSparseVector_mc2) { CHECK(std::is_move_constructible<gismo::gsSparseVector<> >::value); }
+TEST(gsKnotVector_mc2) { CHECK(std::is_move_constructible<gismo::gsKnotVector<> >::value); }
+TEST(gsBSplineBasis_mc2) { CHECK(std::is_move_constructible<gismo::gsBSplineBasis<> >::value); }
+TEST(gsBSpline_mc2) { CHECK(std::is_move_constructible<gismo::gsBSpline<> >::value); }
+TEST(gsTensorBSplineBasis_mc2) { CHECK(std::is_move_constructible<gismo::gsTensorBSplineBasis<2> >::value); }
+TEST(gsTensorBSpline_mc2) { CHECK(std::is_move_constructible<gismo::gsTensorBSpline<2> >::value); }
+
+TEST(gsMatrix_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsMatrix<> >::value); }
+TEST(gsVector_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsVector<> >::value); }
+TEST(gsSparseMatrix_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsSparseMatrix<> >::value); }
+TEST(gsSparseVector_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsSparseVector<> >::value); }
+TEST(gsKnotVector_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsKnotVector<> >::value); }
+TEST(gsBSplineBasis_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsBSplineBasis<> >::value); }
+TEST(gsBSpline_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsBSpline<> >::value); }
+TEST(gsTensorBSplineBasis_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsTensorBSplineBasis<2> >::value); }
+TEST(gsTensorBSpline_mc3) { CHECK(std::is_trivially_move_constructible<gismo::gsTensorBSpline<2> >::value); }
+
+TEST(gsMatrix_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsMatrix<> >::value); }
+TEST(gsVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsVector<> >::value); }
+TEST(gsSparseMatrix_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsSparseMatrix<> >::value); }
+TEST(gsSparseVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsSparseVector<> >::value); }
+TEST(gsKnotVector_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsKnotVector<> >::value); }
+TEST(gsBSplineBasis_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsBSplineBasis<> >::value); }
+TEST(gsBSpline_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsBSpline<> >::value); }
+TEST(gsTensorBSplineBasis_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsTensorBSplineBasis<2> >::value); }
+TEST(gsTensorBSpline_mc4) { CHECK(std::is_nothrow_move_constructible<gismo::gsTensorBSpline<2> >::value); }
 #endif
+
+
 
 TEST(gsMatrix_ms)
 {

--- a/unittests/gsUtils_test.cpp
+++ b/unittests/gsUtils_test.cpp
@@ -123,7 +123,12 @@ TEST(stod)
 
     CHECK_THROW(util::stod("a0.5"), std::invalid_argument);
     CHECK_EQUAL(0.4, util::stod("0.4a"));
-    CHECK_EQUAL(-255.99609375, util::stod("-0xFF.FF"));
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+	CHECK_EQUAL(-255.99609375, util::stod("-0xFF.FF"));
+    CHECK_EQUAL(-255.99609375, util::stod("-0XFF.FF"));
+	CHECK_EQUAL(-255.99609375, util::stod("-0xff.ff"));
+	CHECK_EQUAL(-255.99609375, util::stod("-0Xff.ff"));
+#endif
 }
 
 TEST(string_replace)

--- a/unittests/gsUtils_test.cpp
+++ b/unittests/gsUtils_test.cpp
@@ -124,10 +124,10 @@ TEST(stod)
     CHECK_THROW(util::stod("a0.5"), std::invalid_argument);
     CHECK_EQUAL(0.4, util::stod("0.4a"));
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-	CHECK_EQUAL(-255.99609375, util::stod("-0xFF.FF"));
+    CHECK_EQUAL(-255.99609375, util::stod("-0xFF.FF"));
     CHECK_EQUAL(-255.99609375, util::stod("-0XFF.FF"));
-	CHECK_EQUAL(-255.99609375, util::stod("-0xff.ff"));
-	CHECK_EQUAL(-255.99609375, util::stod("-0Xff.ff"));
+    CHECK_EQUAL(-255.99609375, util::stod("-0xff.ff"));
+    CHECK_EQUAL(-255.99609375, util::stod("-0Xff.ff"));
 #endif
 }
 


### PR DESCRIPTION
see https://github.com/gismo/internal/issues/10

fixes for:
* [x] VS2013
* [ ] VS2012
* [ ] VS2010