### PR TITLE
Issue #337: exporting a PK_SHEET from extensions/gsParasolid

### DIFF
--- a/extensions/gsParasolid/gsWriteParasolid.cpp
+++ b/extensions/gsParasolid/gsWriteParasolid.cpp
@@ -60,6 +60,10 @@ gsWriteParasolid<real_t>
 ( const gsTHBSpline<2, real_t>& thb,const std::vector<real_t>&par_boxes, std::string const & filename);
 
 TEMPLATE_INST bool
+gsWritePK_SHEET<real_t>
+( const gsTensorBSpline<2, real_t>& tp, std::string const & filename);
+
+TEMPLATE_INST bool
 getTrimCurvesAndBoundingBoxes<real_t>
 ( const gsTHBSpline<2, real_t>& surface,
   const std::vector<real_t>& par_boxes,

--- a/extensions/gsParasolid/gsWriteParasolid.h
+++ b/extensions/gsParasolid/gsWriteParasolid.h
@@ -70,6 +70,11 @@ namespace extensions {
     template<class T>
     bool gsWriteParasolid( const gsTHBSpline<2, T>& thb, const std::vector<T>&par_boxes, std::string const & filename );
 
+    /// Converts \a tp into a PK_SHEET and writes it to filename.xmt_txt.
+    template<class T>
+    bool gsWritePK_SHEET(const gsTensorBSpline<2, T>& tp, const std::string& filename);
+
+
     /// Translates a gsTensorBSpline to a PK_BSURF_t
     /// \param[in] bsp B-spline surface
     /// \param[out] bsurf Parasolid spline surface

--- a/extensions/gsParasolid/gsWriteParasolid.hpp
+++ b/extensions/gsParasolid/gsWriteParasolid.hpp
@@ -280,6 +280,45 @@ bool gsWriteParasolid( const gsTHBSpline<2, T>& thb,const std::vector<T>& par_bo
     return err;
 }
 
+template<class T>
+bool gsWritePK_SHEET(const gsTensorBSpline<2, T>& tp, const std::string& filename)
+{
+    gsPKSession::start();
+    PK_LOGICAL_t checks(0);
+    PK_SESSION_set_check_continuity(checks);
+    PK_SESSION_set_check_self_int(checks);
+
+    PK_ERROR_code_t err;
+
+    PK_BSURF_t bsurf;
+    createPK_BSURF<T>(tp, bsurf, false, false);
+
+    PK_UVBOX_t uv_box;
+    uv_box.param[0] = 0;
+    uv_box.param[1] = 0;
+    uv_box.param[2] = 1;
+    uv_box.param[3] = 1;
+    PK_BODY_t body;
+    err = PK_SURF_make_sheet_body(bsurf, uv_box, &body);
+    PARASOLID_ERROR(PK_SURF_make_sheet_body, err);
+
+    // PK_ASSEMBLY_t assembly;
+    // PK_ASSEMBLY_create_empty(&assembly);
+    // err = PK_PART_add_geoms(assembly, 1, &bsurf);
+    // PARASOLID_ERROR(PK_PART_add_geoms, err);
+
+    PK_PART_transmit_o_t transmit_options;
+    PK_PART_transmit_o_m(transmit_options);
+    transmit_options.transmit_format = PK_transmit_format_text_c;
+
+    err = PK_PART_transmit(1, &body, filename.c_str(), &transmit_options);
+    PARASOLID_ERROR(PK_PART_transmit, err);
+
+    gsPKSession::stop();
+
+    return err;
+}
+
 
 template<class T>
 bool createPK_GEOM( const gsGeometry<T> & ggeo,


### PR DESCRIPTION
This is the branch corresponding to issue #337 (sorry for the wrong number).

New functionality for gsParasolid: convert a gsTensorBSpline<2> into a PK_SHEET and export it.


Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
