### PR TITLE
Dof mapper handles vector variables

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -20,91 +20,6 @@
 namespace gismo
 {
 
-/*
-  Internal function which accumulates the local element matrices to
-  the global sparse matrix and right-hand side
- */
-template<class T, bool left, bool right>
-void gsAccumulateLocalToGlobal(
-    gsSparseMatrix<T> & matrix_out,
-    gsMatrix<T> & rhs_out,
-    const gsMatrix<T> & localMat,
-    const gsMatrix<T> & localRhs,
-    const expr::gsFeSpace<T> & v, //rowvar
-    const expr::gsFeSpace<T> & u, //colvar
-    const index_t patchInd)
-{
-    const index_t cd            = u.dim();
-    const index_t rd            = v.dim();
-    const gsDofMapper  & colMap = u.mapper();
-    const gsDofMapper  & rowMap = v.mapper();
-    gsMatrix<unsigned> & colInd0 = const_cast<gsMatrix<unsigned>&>(u.data().actives);
-    gsMatrix<unsigned> & rowInd0 = const_cast<gsMatrix<unsigned>&>(v.data().actives);
-    const gsMatrix<T>  & fixedDofs = u.fixedPart();
-
-    gsMatrix<unsigned> rowInd, colInd;
-    //if (&colMap==&rowMap) && (&rowInd==&colInd)
-    if (left)
-        colMap.localToGlobal(colInd0, patchInd, colInd);
-    rowMap.localToGlobal(rowInd0, patchInd, rowInd);
-
-    //gsDebugVar( localMat.dim() );
-    // colMap.print();
-    // rowMap.print();
-
-    //GISMO_STATIC_ASSERT(left || right, "Nothing to do.");
-    GISMO_ASSERT( !left || colMap.boundarySize()==fixedDofs.rows(),
-                  "Invalid values for fixed part");
-
-    for (index_t r = 0; r != rd; ++r)
-    {
-        const index_t rls = r * rowInd.rows();     //local stride
-        const index_t rgs = r * rowMap.freeSize(); //global stride
-
-        for (index_t i = 0; i != rowInd.rows(); ++i) // **
-        {
-            const int ii = rgs + rowInd.at(i); // N_i
-
-            if ( rowMap.is_free_index(rowInd.at(i)) )
-            {
-                if (right)
-                {
-                    rhs_out.row(ii) += localRhs.row(rls+i);
-                }
-
-                if (left)
-                    for (index_t c = 0; c != cd; ++c)
-                    {
-                        const index_t cls = c * colInd.rows();     //local stride
-                        const index_t cgs = c * colMap.freeSize(); //global stride
-
-                        for (index_t j = 0; j != colInd.rows(); ++j)
-                        {
-                            if ( 0 == localMat(rls+i,cls+j) ) continue;
-
-                            const int jj = cgs + colInd.at(j); // N_j
-
-                            if ( colMap.is_free_index(colInd.at(j)) )
-                            {
-                                // If matrix is symmetric, we could
-                                // store only lower triangular part
-                                //if ( (!symm) || jj <= ii )
-                                matrix_out.coeffRef(ii, jj) += localMat(rls+i,cls+j);
-                            }
-                            else // colMap.is_boundary_index(jj) )
-                            {
-                                // Symmetric treatment of eliminated BCs
-                                // GISMO_ASSERT(1==rhs_out.cols(), "-");
-                                rhs_out.at(ii) -= localMat(rls+i,cls+j) *
-                                    fixedDofs(colMap.global_to_bindex(colInd.at(j)), c);
-                            }
-                        }
-                    }
-            }
-        }
-    }
-}
-
 /**
    Assembler class for generating matrices and right-hand sides based
    on isogeometric expressions
@@ -172,7 +87,7 @@ public:
         GISMO_ASSERT( m_vcol.back()->mapper().isFinalized(),
                       "gsExprAssembler::numDofs() says: initSystem() has not been called.");
         return m_vcol.back()->mapper().firstIndex() +
-            m_vcol.back()->dim() * m_vcol.back()->mapper().freeSize();
+	  m_vcol.back()->mapper().freeSize();
     }
 
     /// Returns the number of test functions (after initialization)
@@ -181,7 +96,7 @@ public:
         GISMO_ASSERT( m_vrow.back()->mapper().isFinalized(),
                       "initSystem() has not been called.");
         return m_vrow.back()->mapper().firstIndex() +
-            m_vrow.back()->dim() * m_vrow.back()->mapper().freeSize();
+	  m_vrow.back()->mapper().freeSize();
     }
 
     /// Returns the number of blocks in the matrix, corresponding to
@@ -509,7 +424,6 @@ private:
                                 space rvar, space cvar,
                                 const ifContainer & iFaces);
 
-// /*
 #if __cplusplus >= 201103L || _MSC_VER >= 1600 // c++11
     template <class op, class E1>
     void _apply(op _op, const expr::_expr<E1> & firstArg) {_op(firstArg);}
@@ -576,45 +490,30 @@ private:
             const index_t rd            = v.dim();
             const gsDofMapper  & colMap = static_cast<const expr::gsFeSpace<T>&>(u).mapper();
             const gsDofMapper  & rowMap = static_cast<const expr::gsFeSpace<T>&>(v).mapper();
-            gsMatrix<unsigned> & colInd0 = const_cast<gsMatrix<unsigned>&>(u.data().actives);
-            gsMatrix<unsigned> & rowInd0 = const_cast<gsMatrix<unsigned>&>(v.data().actives);
+            const gsMatrix<unsigned> & colInd0 = u.data().actives;
+            const gsMatrix<unsigned> & rowInd0 = v.data().actives;
             const gsMatrix<T>  & fixedDofs = static_cast<const expr::gsFeSpace<T>&>(u).fixedPart();
-
-            gsMatrix<unsigned> rowInd, colInd;
-            rowMap.localToGlobal(rowInd0, patchInd, rowInd);
-            if (isMatrix)
-            {
-                //if (&rowInd0!=&colInd0)
-	        colMap.localToGlobal(colInd0, patchInd, colInd);
-	        GISMO_ASSERT( colMap.boundarySize()==fixedDofs.rows(),
-			      "Invalid values for fixed part");
-            }
 
             for (index_t r = 0; r != rd; ++r)
             {
-                const index_t rls = r * rowInd.rows();     //local stride
-                const index_t rgs = r * rowMap.freeSize(); //global stride
-
-                for (index_t i = 0; i != rowInd.rows(); ++i)
+                const index_t rls = r * rowInd0.rows();     //local stride
+                for (index_t i = 0; i != rowInd0.rows(); ++i)
                 {
-                    const index_t ii = rgs + rowInd.at(i); // N_i
-
-                    if ( rowMap.is_free_index(rowInd.at(i)) )
+		  const index_t ii = rowMap.index(rowInd0.at(i),patchInd,r); // N_i
+                    if ( rowMap.is_free_index(ii) )
                     {
                         for (index_t c = 0; c != cd; ++c)
                         {
                             if (isMatrix)
                             {
-                                const index_t cls = c * colInd.rows();     //local stride
-                                const index_t cgs = c * colMap.freeSize(); //global stride
+                                const index_t cls = c * colInd0.rows();     //local stride
 
-                                for (index_t j = 0; j != colInd.rows(); ++j)
+                                for (index_t j = 0; j != colInd0.rows(); ++j)
                                 {
                                     if ( 0 == localMat(rls+i,cls+j) ) continue;
 
-                                    const index_t jj = cgs + colInd.at(j); // N_j
-
-                                    if ( colMap.is_free_index(colInd.at(j)) )
+                                    const index_t jj = colMap.index(colInd0.at(j),patchInd,c); // N_j
+                                    if ( colMap.is_free_index(jj) )
                                     {
                                         // If matrix is symmetric, we could
                                         // store only lower triangular part
@@ -626,7 +525,7 @@ private:
                                         // Symmetric treatment of eliminated BCs
                                         // GISMO_ASSERT(1==m_rhs.cols(), "-");
                                         m_rhs.at(ii) -= localMat(rls+i,cls+j) *
-                                            fixedDofs(colMap.global_to_bindex(colInd.at(j)), c);
+                                            fixedDofs(colMap.global_to_bindex(jj), c);
                                     }
                                 }
                             }
@@ -639,7 +538,6 @@ private:
         }//push
 
     };
-//*/
 
 }; // gsExprAssembler
 
@@ -934,10 +832,9 @@ void gsExprAssembler<T>::assembleLhsRhsBc_impl(const expr::_expr<E1> & exprLhs,
     if (left ) exprLhs.setFlag();
     if (right) exprRhs.setFlag();
 
-    // Local matrix and local rhs
-    gsMatrix<T> localMat, localRhs;
     gsVector<T> quWeights;// quadrature weights
     gsQuadRule<T>  QuRule;
+    _eval ee(m_matrix, m_rhs, quWeights);
 
     for (typename bcContainer::const_iterator it = BCs.begin(); it!= BCs.end(); ++it)
     {
@@ -963,17 +860,8 @@ void gsExprAssembler<T>::assembleLhsRhsBc_impl(const expr::_expr<E1> & exprLhs,
             // Perform required pre-computations on the quadrature nodes
             m_exprdata->precompute(it->patch());
 
-            if (left)  localMat = quWeights[0] * exprLhs.eval(0);
-            if (right) localRhs = quWeights[0] * exprRhs.eval(0);
-            for (index_t k = 1; k != quWeights.rows(); ++k)
-            {
-                if (left ) localMat += quWeights[k] * exprLhs.eval(k);
-                if (right) localRhs += quWeights[k] * exprRhs.eval(k);
-            }
-
-            // Add contributions to the system matrix and right-hand side
-            gsAccumulateLocalToGlobal<T,left,right>(m_matrix, m_rhs,
-                                  localMat, localRhs, rvar, cvar, it->patch() );
+	    ee(exprLhs);
+	    ee(exprRhs);
         }
     }
 
@@ -1000,12 +888,11 @@ void gsExprAssembler<T>::assembleInterface_impl(const expr::_expr<E1> & exprLhs,
     //m_exprdata->parse(exprLhs,exprRhs);
     //m_exprdata->parse(exprRhs);
 
-    // Local matrix
-    gsMatrix<T> localMat, localRhs;
     gsVector<T> quWeights;// quadrature weights
     gsQuadRule<T>  QuRule;
+    _eval ee(m_matrix, m_rhs, quWeights);
 
-    gsMatrix<T> tmp;
+    //gsMatrix<T> tmp;
 
     for (gsBoxTopology::const_iiterator it = iFaces.begin();
          it != iFaces.end(); ++it )
@@ -1041,17 +928,8 @@ void gsExprAssembler<T>::assembleInterface_impl(const expr::_expr<E1> & exprLhs,
 //            m_exprdata->points().swap(tmp);
 //            m_exprdata->precompute(patch2);
 
-            if (left ) localMat = quWeights[0] * exprLhs.eval(0);
-            if (right) localRhs = quWeights[0] * exprRhs.eval(0);
-            for (index_t k = 1; k != quWeights.rows(); ++k)
-            {
-                if (left ) localMat += quWeights[k] * exprLhs.eval(k);
-                if (right) localRhs += quWeights[k] * exprRhs.eval(k);
-            }
-
-            // Add contributions to the system matrix and right-hand side
-            gsAccumulateLocalToGlobal<T,left,right>(m_matrix, m_rhs,
-                                          localMat, localRhs, rvar, cvar, patch1);
+	    ee(exprLhs);
+	    ee(exprRhs);
         }
     }
 
@@ -1149,8 +1027,7 @@ void gsExprAssembler<T>::computeDirichletDofsIntpl2(const expr::gsFeSpace<T> & u
         // Save corresponding boundary dofs
         for (index_t l=0; l!= boundary.size(); ++l)
         {
-            const int ii = mapper.bindex( boundary.at(l) , it->patch() );
-
+	    const int ii = mapper.bindex( boundary.at(l) , it->patch());
             fixedDofs.row(ii) = dVals.row(l);
         }
     }

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -203,6 +203,13 @@ public:
     /// @brief Writes the resulting matrix in \a out. The internal matrix is moved.
     void matrix_into(gsSparseMatrix<T> & out) { out = give(m_matrix); }
 
+    EIGEN_STRONG_INLINE gsSparseMatrix<T> giveMatrix()
+    {
+         gsSparseMatrix<T> rvo;
+         rvo.swap(m_matrix);
+          return rvo;
+    }
+
     /// @brief Returns the right-hand side vector(s)
     const gsMatrix<T> & rhs() const { return m_rhs; }
 
@@ -578,11 +585,10 @@ private:
             if (isMatrix)
             {
                 //if (&rowInd0!=&colInd0)
-                colMap.localToGlobal(colInd0, patchInd, colInd);
+	        colMap.localToGlobal(colInd0, patchInd, colInd);
+	        GISMO_ASSERT( colMap.boundarySize()==fixedDofs.rows(),
+			      "Invalid values for fixed part");
             }
-
-            GISMO_ASSERT( colMap.boundarySize()==fixedDofs.rows(),
-                          "Invalid values for fixed part");
 
             for (index_t r = 0; r != rd; ++r)
             {
@@ -772,12 +778,12 @@ template<class T> void gsExprAssembler<T>::resetDimensions()
 {
     for (size_t i = 0; i!=m_vcol.size(); ++i)
     {
-        GISMO_ASSERT(NULL!=m_vcol[i], "Not set.");
+        GISMO_ASSERT(NULL!=m_vcol[i], "The assembler spaces where not set.");
         m_vcol[i]->reset();
 
         if ( m_vcol[i] != m_vrow[i] )
         {
-            GISMO_ASSERT(NULL!=m_vrow[i], "Not set.");
+            GISMO_ASSERT(NULL!=m_vrow[i], "The assembler spaces where not set.");
             m_vrow[i]->reset();
         }
     }

--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -77,9 +77,15 @@ void gsDofMapper::localToGlobal2(const gsMatrix<unsigned>& locals,
 gsVector<index_t> gsDofMapper::asVector(index_t comp) const
 {
   gsVector<index_t> v(m_dofs[comp].size());
-  index_t c = 0;
     for(size_t j = 0; j!= m_dofs[comp].size(); ++j)
-      v[c++] = m_dofs[comp][j]+m_shift;
+      {
+	const index_t l = m_dofs[comp][j];
+	v[j] = 
+	  (l<m_numFreeDofs[comp+1]+m_numElimDofs[comp] ?
+	   l + m_shift - m_numElimDofs[comp]        :
+	   l + m_shift - m_numFreeDofs[comp+1] + m_numFreeDofs.back()
+	   );
+      }
     return v;
 }
 
@@ -221,13 +227,6 @@ void gsDofMapper::finalize()
 
     for (size_t c = 0; c!=m_dofs.size(); ++c)
       {
-	gsInfo<<"---- Component "<< c <<" : "<< -m_curElimId-1<< "----\n";
-
-	gsDebugVar(m_numFreeDofs[c+1]);
-	gsDebugVar(m_numCpldDofs[c+1]);
-	gsDebugVar(m_numElimDofs[c+1]);
-	gsInfo<<"---- Finalize \n";
-
 	finalizeComp(c);
 	
 	//off-set
@@ -325,6 +324,10 @@ std::ostream& gsDofMapper::print( std::ostream& os ) const
     os<<" coupled: "<< this->coupledSize() <<"\n";
     os<<" tagged: "<< this->taggedSize() <<"\n";
     os<<" elim: "<< this->boundarySize() <<"\n";
+    os<<" m_numFreeDofs: "<< gsAsConstVector<index_t>(m_numFreeDofs).transpose() <<"\n";
+    os<<" m_numElimDofs: "<< gsAsConstVector<index_t>(m_numElimDofs).transpose() <<"\n";
+    os<<" m_numCpldDofs: "<< gsAsConstVector<index_t>(m_numCpldDofs).transpose() <<"\n";
+    
     return os;
 }
 

--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -83,7 +83,7 @@ gsVector<index_t> gsDofMapper::asVector(index_t comp) const
     return v;
 }
 
-  void gsDofMapper::colapseDofs(index_t k, const gsMatrix<unsigned> & b,index_t comp)
+void gsDofMapper::colapseDofs(index_t k, const gsMatrix<unsigned> & b,index_t comp)
 {
     const index_t last = b.size()-1;
     for ( index_t l=0; l!=last; ++l)
@@ -239,12 +239,7 @@ void gsDofMapper::finalizeComp(const index_t comp)
     // For assigning coupling and eliminated dofs to continuous
     // indices (-1 = unassigned)
     std::vector<index_t> couplingDofs(m_numCpldDofs[comp+1] -1, -1);
-
-    std::vector<index_t> elimDofs(
-    //std::count_if(dofs.begin(), dofs.end(),std::bind2nd(std::less<index_t>(),0) ),
-    -m_curElimId - 1 - m_numElimDofs[comp]
- -1);
-    //std::vector<index_t> elimDofs    (-m_curElimId - 1, -1);
+    std::vector<index_t> elimDofs(-m_curElimId - 1 - m_numElimDofs[comp], -1);
 
     // Free dofs start at "0"
     index_t curFreeDof = m_numFreeDofs[comp]+m_numElimDofs[comp]; //= 0;
@@ -306,7 +301,7 @@ void gsDofMapper::finalizeComp(const index_t comp)
 std::ostream& gsDofMapper::print( std::ostream& os ) const
 {
   os<<" Dofs: "<< this->size() 
-    <<", components: "<< m_dofs.size()<<"\n";
+    <<"\n components: "<< m_dofs.size()<<"\n";
     os<<" free: "<< this->freeSize() <<"\n";
     os<<" coupled: "<< this->coupledSize() <<"\n";
     os<<" tagged: "<< this->taggedSize() <<"\n";
@@ -451,7 +446,6 @@ gsDofMapper::inverseOnPatch(const index_t k) const
     GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
     GISMO_ASSERT(static_cast<size_t>(k)<numPatches(), "Invalid patch index "<< k <<" >= "<< numPatches() );
 
-    const index_t sz = patchSize(k);
     std::map<index_t,index_t> inv;
     //inv.reserve(patchSize(k));
     typedef std::vector<index_t>::const_iterator citer;

--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -59,7 +59,7 @@ void gsDofMapper::localToGlobal(const gsMatrix<unsigned>& locals,
     for (index_t i = 0; i != numActive; ++i)
     {
       const index_t ii = index(locals(i,0), patchIndex, comp);
-        if ( ii<m_numElimDofs[comp] + m_numFreeDofs[comp] + m_shift )//is_free_index
+        if ( ii< m_numFreeDofs[comp+1] + m_numElimDofs[comp] + m_shift )//is_free_index
         {
             globals(numFree  , 0) = i ;
             globals(numFree++, 1) = ii;
@@ -340,7 +340,7 @@ std::ostream& gsDofMapper::print( std::ostream& os ) const
     for(index_t i=0; i<(index_t)dofs.size();++i)
     {
         const index_t idx = dofs[i];
-        if(is_free_index(idx))
+        if(idx<m_numFreeDofs[comp+1] + m_numElimDofs[comp] + m_shift)//is_free_index(idx)
         {
             m_dofs[comp][i] = permutation[idx];
             //fill  bookkeeping for tagged dofs

--- a/src/gsCore/gsDofMapper.cpp
+++ b/src/gsCore/gsDofMapper.cpp
@@ -83,15 +83,6 @@ gsVector<index_t> gsDofMapper::asVector() const
     return v;
 }
 
-gsVector<index_t> gsDofMapper::inverseAsVector() const
-{
-    GISMO_ASSERT(isPermutation(), "This dofMapper is not 1-1");
-    gsVector<index_t> v(size());
-    for(index_t i = 0; i!= v.size(); ++i)
-        v[m_dofs[i]] = i;
-    return v;
-}
-
 void gsDofMapper::colapseDofs(index_t k, const gsMatrix<unsigned> & b )
 {
     const index_t last = b.size()-1;
@@ -410,6 +401,31 @@ void gsDofMapper::preImage(const index_t gl,
             result.push_back( std::make_pair(patch, cur - m_offset[patch] - m_shift) );
         }
     }
+}
+
+gsVector<index_t> gsDofMapper::inverseAsVector() const
+{
+    GISMO_ASSERT(isPermutation(), "This dofMapper is not 1-1");
+    gsVector<index_t> v(size());
+    for(index_t i = 0; i!= v.size(); ++i)
+        v[m_dofs[i]] = i;
+    return v;
+}
+
+std::map<index_t,index_t> 
+gsDofMapper::inverseOnPatch(const index_t k) const
+{
+    GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
+    GISMO_ASSERT(static_cast<size_t>(k)<numPatches(), "Invalid patch index "<< k <<" >= "<< numPatches() );
+
+    const index_t sz = patchSize(k);
+    std::map<index_t,index_t> inv;
+    //inv.reserve(patchSize(k));
+    typedef std::vector<index_t>::const_iterator citer;
+    citer it = m_dofs.begin()+m_offset[k];
+    for(index_t i = 0;i!=sz;++i,++it)
+      inv[*it]=i;
+    return inv;
 }
 
 bool gsDofMapper::indexOnPatch(const index_t gl, const index_t k) const

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -328,7 +328,13 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
 	//if in_place
         //return MAPPER_PATCH_DOF(i,k,c)+m_shift;
 	// else (elim)
-        return MAPPER_PATCH_DOF(i,k,c)+m_shift - m_numElimDofs[c];
+
+	const index_t l = MAPPER_PATCH_DOF(i,k,c);
+
+	if (l<m_numFreeDofs[c+1]+m_numElimDofs[c]) 
+	  return l + m_shift - m_numElimDofs[c];
+	else // bindex(i,k,c) + m_numFreeDofs.back()
+	  return l + m_shift - m_numFreeDofs[c+1] + m_numFreeDofs.back();
     }
 
     /// @brief Returns the boundary index of local dof \a i of patch \a k.
@@ -341,7 +347,8 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
         //return MAPPER_PATCH_DOF(i,k,c) - m_numFreeDofs[c+1]
         //    - m_numElimDofs[c] + m_bshift;
 	//elim
-        return MAPPER_PATCH_DOF(i,k,c) - m_numFreeDofs[c+1] + m_bshift;
+        return MAPPER_PATCH_DOF(i,k,c) - m_numFreeDofs[c+1]
+	  - m_numElimDofs[c] + m_bshift;
     }
 
     /// @brief Returns the coupled dof index
@@ -366,11 +373,10 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     inline index_t global_to_bindex(index_t gl) const
     {
         GISMO_ASSERT( is_boundary_index( gl ),
-                      "global_to_bindex(): specified dof is not on the boundary");
-	const index_t c = componentOf(gl);
+                      "global_to_bindex(): dof "<<gl<<" is not on the boundary");
 	//inplace
-	//return gl - m_shift - m_numFreeDofs[c+1] - m_numElimDofs[c] + m_bshift;
-	  return gl - m_shift - m_numFreeDofs[c+1] + m_bshift;
+	//return gl - m_shift - m_numFreeDofs[c+1] + m_bshift - m_numElimDofs[c];
+	return gl - m_shift - m_numFreeDofs.back() + m_bshift;
     }
 
     /// Returns true if global dof \a gl is not eliminated.

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -259,7 +259,7 @@ public:
 
     ///\brief Returns the smallest value of the indices
     index_t firstIndex(index_t comp = 0) const
-    { return m_numFreeDofs[comp]+ m_numElimDofs[c] + m_shift; }
+    { return m_numFreeDofs[comp]+ m_numElimDofs[comp] + m_shift; }
 
     ///\brief Returns one past the biggest value of the indices
     index_t lastIndex() const { return m_shift + freeSize(); }
@@ -303,7 +303,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
         return MAPPER_PATCH_DOF(i,k,c);
     }
 
- index_t componentOf(index_t gl) 
+ index_t componentOf(index_t gl) const
  {
    index_t c = 1; // could do some binary search
    while (gl >= m_numFreeDofs[c]+m_numElimDofs[c]) { ++c; }
@@ -362,7 +362,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     /// Returns true if global dof \a gl is not eliminated.
     inline bool is_free_index(index_t gl) const
     {
-      const index_t c = conponentOf(gl);
+      const index_t c = componentOf(gl);
       return gl < m_numElimDofs[c] + m_numFreeDofs[c] + m_shift; 
     }
 
@@ -375,7 +375,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     { return !is_free_index(gl); }
 
     /// Returns true if local dof \a i of patch \a k is eliminated.
-    inline bool is_boundary(index_t i, index_t k = 0, , index_t c = 0) const
+    inline bool is_boundary(index_t i, index_t k = 0, index_t c = 0) const
     {return is_boundary_index( index(i, k, c) );}
 
     /// Returns true if local dof \a i of patch \a k is coupled.
@@ -388,7 +388,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
       const index_t gc = componentOf(gl);
       const index_t vv = m_numFreeDofs[gc+1]+m_numElimDofs[gc] + m_shift;
       return  (gl < vv && // is a free dof and
-	(gl + m_numCpldDofs[gc+1] + 1 > vv);   // is not standard dof
+	      (gl + m_numCpldDofs[gc+1] + 1 > vv) );  // is not standard dof
     }
 
     /// Returns true if local dof \a i of patch \a k is tagged.
@@ -419,7 +419,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     /// Returns the number of free (not eliminated) dofs.
     inline index_t freeSize() const
     {
-      return m_numFreeDofs[m_dofs.size()];
+      return m_numFreeDofs.back();
     }
 
     inline index_t freeSize(index_t comp) const
@@ -430,8 +430,6 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     /// Returns the number of coupled (not eliminated) dofs.
     index_t coupledSize() const;
 
-    index_t coupledSizeUpto(index_t comp) const;
-
     /// Returns the number of tagged (not eliminated) dofs.
     index_t taggedSize() const;
 
@@ -439,7 +437,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     inline index_t boundarySize() const
     {
         GISMO_ENSURE(m_curElimId==0, "finalize() was not called on gsDofMapper");
-        return m_numElimDofs[m_dofs.size()];
+        return m_numElimDofs.back();
     }
 
     index_t boundarySizeWithDuplicates() const;

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -88,7 +88,7 @@ public:
         int unk = 0
         ) : m_shift(0), m_bshift(0)
     {
-        init(bases, dirichlet, unk);
+      init(bases, dirichlet, unk); //obsolete, one component
     }
 
     /**
@@ -98,13 +98,12 @@ public:
      * @param bases
      */
     template<class T>
-    gsDofMapper(
-        const gsMultiBasis<T>         &bases
-        ) : m_shift(0), m_bshift(0)
+    gsDofMapper(const gsMultiBasis<T> & bases, index_t nComp = 1) 
+      : m_shift(0), m_bshift(0)
     {
-        init(bases);
+      init(bases, nComp);
     }
-
+    
     /**
      * @brief construct a dof mapper that identifies the degrees
      * of freedom for a vector of multibasis
@@ -121,35 +120,33 @@ public:
 
 
     /**
-     * @brief construct a dof mapper that manages the the degrees
+     * @brief construct a dof mapper that manages the degrees
      * of freedom in a gsBasis
      *
      * @param basis
      */
     template<class T>
-    gsDofMapper(
-        const gsBasis<T>               &basis
-         ) : m_shift(0), m_bshift(0)
+    gsDofMapper(const gsBasis<T> & basis, index_t nComp = 1) 
+      : m_shift(0), m_bshift(0)
     {
-        initSingle(basis);
+      initSingle(basis, nComp);
     }
 
     /**
-     * @brief construct a dof mapper with a given number of dofs per patch
+     * @brief construct a dof mapper with a given number of dofs per
+     * patch
      *
      * @param patchDofSizes
      */
-    gsDofMapper(
-        const gsVector<index_t>        &patchDofSizes
-         ) : m_shift(0), m_bshift(0)
+    gsDofMapper(const gsVector<index_t> &patchDofSizes, index_t nComp = 1) 
+      : m_shift(0), m_bshift(0)
     {
-        initPatchDofs(patchDofSizes);
+        initPatchDofs(patchDofSizes, nComp);
     }
-
 
     /// Initialize by a gsMultiBasis
     template <typename T>
-    void init( const gsMultiBasis<T> & bases);
+    void init(const gsMultiBasis<T> & bases, index_t nComp = 1);
 
     /// Initialize by a vector of gsMultiBasis.
     template <typename T>
@@ -158,9 +155,8 @@ public:
     /// Initialize by gsMultiBasis, boundary conditions and the index
     /// of the unknown to be eliminated
     template<class T>
-    void init(
-        const gsMultiBasis<T>         &basis,
-        const gsBoundaryConditions<T> &dirichlet, int unk = 0 );
+    void init(const gsMultiBasis<T>         &basis,
+	      const gsBoundaryConditions<T> &dirichlet, int unk = 0);
 
     void swap(gsDofMapper & other)
     {
@@ -180,7 +176,7 @@ private:
 
     /// Initialize by a single basis patch
     template <typename T>
-    void initSingle( const gsBasis<T> & basis);
+    void initSingle( const gsBasis<T> & basis, index_t nComp = 1);
 
     /// Initialize by vector of DoF indices and dimension
     void initPatchDofs(const gsVector<index_t> & patchDofSizes,
@@ -189,48 +185,51 @@ private:
 public:
 
     /// Returns a vector taking flat local indices to global
-    gsVector<index_t> asVector() const;
+    gsVector<index_t> asVector(index_t comp = 0) const;
 
     /** \brief Returns a vector taking global indices to flat local
 
         Assumes that the mapper is a permutation
     */
-    gsVector<index_t> inverseAsVector() const;
+    gsVector<index_t> inverseAsVector(index_t comp = 0) const;
 
     /// Called to initialize the gsDofMapper with matching interfaces
     /// after m_bases have already been set
     void setMatchingInterfaces(const gsBoxTopology & mp);
 
     /** \brief Calls matchDof() for all dofs on the given patch side
-     * \a i ps. Thus, the whole set of dofs collapses to a single global dof
+     * \a i ps. Thus, the whole set of dofs collapses to a single
+     * global dof
      *
      */
-void colapseDofs(index_t k, const gsMatrix<unsigned> & b, index_t comp = 0);
+    void colapseDofs(index_t k, const gsMatrix<unsigned> & b, index_t comp = 0);
 
     /// \brief Couples dof \a i of patch \a u with dof \a j of patch
-    /// \a v such that they refer to the same global dof at component \a comp.
-void matchDof( index_t u, index_t i, index_t v, index_t j, index_t comp = 0);
+    /// \a v such that they refer to the same global dof at component
+    /// \a comp.
+    void matchDof( index_t u, index_t i, index_t v, index_t j, index_t comp = 0);
 
     /// \brief Couples dofs \a b1 of patch \a u with dofs \a b2 of patch
     /// \a v one by one such that they refer to the same global dof.
     void matchDofs(index_t u, const gsMatrix<unsigned> & b1,
-                   index_t v, const gsMatrix<unsigned> & b2);
+                   index_t v, const gsMatrix<unsigned> & b2,
+		   index_t comp = 0);
 
     /// Mark the local dof \a i of patch \a k as coupled.
-    void markCoupled( index_t i, index_t k );
+    void markCoupled(index_t i, index_t k, index_t comp = 0);
 
     /// Mark a local dof \a i of patch \a k as tagged
-    void markTagged( index_t i, index_t k );
+    void markTagged(index_t i, index_t k, index_t comp = 0);
 
     /// Mark all coupled dofs as tagged
     void markCoupledAsTagged();
 
     /// Mark the local dofs \a boundaryDofs of patch \a k as eliminated.
     // to do: put k at the end
-    void markBoundary( index_t k, const gsMatrix<unsigned> & boundaryDofs );
+    void markBoundary(index_t k, const gsMatrix<unsigned> & boundaryDofs, index_t comp = 0);
 
     /// Mark the local dof \a i of patch \a k as eliminated.
-    void eliminateDof( index_t i, index_t k, index_t comp = 0 );
+    void eliminateDof(index_t i, index_t k, index_t comp = 0);
 
     /// \brief Must be called after all boundaries and interfaces have
     /// been marked to set up the dof numbering.
@@ -245,7 +244,7 @@ void matchDof( index_t u, index_t i, index_t v, index_t j, index_t comp = 0);
     /// \brief Print summary
     std::ostream& print( std::ostream& os = gsInfo ) const;
 
-    ///\brief Set this mapping to beh the identity
+    ///\brief Set this mapping to be the identity
     void setIdentity(index_t nPatches, size_t nDofs, size_t nComp = 1);
 
     ///\brief Set the shift amount for the global numbering
@@ -260,7 +259,7 @@ void matchDof( index_t u, index_t i, index_t v, index_t j, index_t comp = 0);
 
     ///\brief Returns the smallest value of the indices
     index_t firstIndex(index_t comp = 0) const
-    { return comp*m_dofs.front().size() + m_shift; }
+    { return m_numFreeDofs[comp]+ m_numElimDofs[c] + m_shift; }
 
     ///\brief Returns one past the biggest value of the indices
     index_t lastIndex() const { return m_shift + freeSize(); }
@@ -276,7 +275,8 @@ void matchDof( index_t u, index_t i, index_t v, index_t j, index_t comp = 0);
      */
     void localToGlobal(const gsMatrix<unsigned>& locals,
                        index_t patchIndex,
-                       gsMatrix<unsigned>& globals) const;
+                       gsMatrix<unsigned>& globals, 
+		       index_t comp = 0) const;
 
     /** \brief Computes the global indices of the input local indices
      *
@@ -288,7 +288,8 @@ void matchDof( index_t u, index_t i, index_t v, index_t j, index_t comp = 0);
     void localToGlobal(const gsMatrix<unsigned>& locals,
                        index_t patchIndex,
                        gsMatrix<unsigned>& globals,
-                       index_t & numFree) const;
+                       index_t & numFree, 
+		       index_t comp = 0) const;
 
     /** \brief Returns the index associated to local dof \a i of patch \a k without shifts.
      *
@@ -296,11 +297,18 @@ void matchDof( index_t u, index_t i, index_t v, index_t j, index_t comp = 0);
      * marked and finalize() has been called.
      */
 
-inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
+inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
         return MAPPER_PATCH_DOF(i,k,c);
     }
+
+ index_t componentOf(index_t gl) 
+ {
+   index_t c = 1; // could do some binary search
+   while (gl >= m_numFreeDofs[c]+m_numElimDofs[c]) { ++c; }
+   return c-1;
+ }
 
     /** \brief Returns the global dof index associated to local dof \a i of patch \a k.
      *
@@ -308,7 +316,7 @@ inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
      * marked and finalize() has been called.
      */
 
-    inline index_t index( index_t i, index_t k = 0, index_t c = 0 ) const
+    inline index_t index(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
         return MAPPER_PATCH_DOF(i,k,c)+m_shift;
@@ -317,25 +325,25 @@ inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
     /// @brief Returns the boundary index of local dof \a i of patch \a k.
     ///
     /// Produces undefined results if local dof (i,k) does not lie on the boundary.
-    inline index_t bindex( index_t i, index_t k = 0, index_t c = 0 ) const
+    inline index_t bindex(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
-        return MAPPER_PATCH_DOF(i,k,c) - freeSizeUpto(c)
-            - ( 0!=c ? boundarySizeUpto(c-1): 0) + m_bshift;
-
+        return MAPPER_PATCH_DOF(i,k,c) - m_numFreeDofs[c]
+            - m_numElimDofs[c] + m_bshift;
     }
 
     /// @brief Returns the coupled dof index
-    inline index_t cindex( index_t i, index_t k = 0, index_t c = 0 ) const
+    inline index_t cindex(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
         //return MAPPER_PATCH_DOF(i,k,c) - ( m_numFreeDofs - m_numCpldDofs ) ;
-        return MAPPER_PATCH_DOF(i,k,c) - ( freeSizeUpto(c) - coupledSizeUpto(c) )
-            - ( 0!=c ? boundarySizeupto(c-1): 0);
+        return MAPPER_PATCH_DOF(i,k,c) - 
+	  ( m_numFreeDofs[c] - m_numCpldDofs[c] )
+	  - m_numElimDofs[c];
     }
 
     /// @brief Returns the tagged dof index
-    inline index_t tindex( index_t i, index_t k = 0, index_t c = 0 ) const
+    inline index_t tindex(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
         return std::distance(m_tagged.begin(),std::lower_bound(m_tagged.begin(),m_tagged.end(),MAPPER_PATCH_DOF(i,k,c)));
@@ -344,48 +352,53 @@ inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
     /// @brief Returns the boundary index of global dof \a gl.
     ///
     /// Produces undefined results if dof \a gl does not lie on the boundary.
-    inline index_t global_to_bindex( index_t gl ) const
+    inline index_t global_to_bindex(index_t gl) const
     {
         GISMO_ASSERT( is_boundary_index( gl ),
                       "global_to_bindex(): specified dof is not on the boundary");
-        return gl - m_shift - freeSize() + m_bshift;
+        return gl - m_shift - m_numFreeDofs[componentOf(gl)] + m_bshift;
     }
 
     /// Returns true if global dof \a gl is not eliminated.
-    inline bool is_free_index( index_t gl ) const
-    { return gl < freeSize() + m_shift; }
+    inline bool is_free_index(index_t gl) const
+    {
+      const index_t c = conponentOf(gl);
+      return gl < m_numElimDofs[c] + m_numFreeDofs[c] + m_shift; 
+    }
 
     /// Returns true if local dof \a i of patch \a k is not eliminated.
-    inline bool is_free( index_t i, index_t k = 0 ) const
-    { return is_free_index( index(i, k) ); }
+    inline bool is_free( index_t i, index_t k = 0, index_t c = 0) const
+    { return is_free_index( index(i, k, c) ); }
 
     /// Returns true if global dof \a gl is eliminated
     inline bool is_boundary_index( index_t gl ) const
-    { return gl >= freeSize() + m_shift; }
+    { return !is_free_index(gl); }
 
     /// Returns true if local dof \a i of patch \a k is eliminated.
-    inline bool is_boundary( index_t i, index_t k = 0 ) const
-    {return is_boundary_index( index(i, k) );}
+    inline bool is_boundary(index_t i, index_t k = 0, , index_t c = 0) const
+    {return is_boundary_index( index(i, k, c) );}
 
     /// Returns true if local dof \a i of patch \a k is coupled.
-    inline bool is_coupled( index_t i, index_t k = 0 ) const
-    { return  is_coupled_index( index(i, k) ); }
+    inline bool is_coupled( index_t i, index_t k = 0, index_t c = 0) const
+    { return  is_coupled_index( index(i, k, c) ); }
 
     /// Returns true if \a gl is a coupled dof.
-    inline bool is_coupled_index( index_t gl) const
+    inline bool is_coupled_index(index_t gl) const
     {
-	   return  (gl < m_numFreeDofs + m_shift                    ) && // is a free dof and
-                    (gl + m_numCpldDofs + 1 > m_numFreeDofs + m_shift);   // is not standard dof
+      const index_t gc = componentOf(gl);
+      const index_t vv = m_numFreeDofs[gc+1]+m_numElimDofs[gc] + m_shift;
+      return  (gl < vv && // is a free dof and
+	(gl + m_numCpldDofs[gc+1] + 1 > vv);   // is not standard dof
     }
 
     /// Returns true if local dof \a i of patch \a k is tagged.
-    inline bool is_tagged( index_t i, index_t k = 0 ) const
-    { return  is_tagged_index( index(i, k) ); }
+    inline bool is_tagged(index_t i, index_t k = 0, index_t c = 0) const
+    { return  is_tagged_index( index(i, k, c) ); }
 
     /// Returns true if \a gl is a tagged dof.
-    inline bool is_tagged_index( index_t gl) const
+    inline bool is_tagged_index(index_t gl) const
     {
-          return std::binary_search(m_tagged.begin(),m_tagged.end(),gl);
+        return std::binary_search(m_tagged.begin(),m_tagged.end(),gl);
     }
 
     /// Returns the total number of dofs (free and eliminated).
@@ -399,22 +412,19 @@ inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
     inline index_t size(index_t comp) const
     {
         GISMO_ENSURE(m_curElimId==0, "finalize() was not called on gsDofMapper");
-        return m_numFreeDofs[comp] + m_numElimDofs[comp];
-    }
-
-    /// Returns the number of free (not eliminated) dofs.
-    inline index_t freeSizeUpto(index_t comp) const
-    {
-        GISMO_ENSURE(m_curElimId==0, "finalize() was not called on gsDofMapper");
-        return std::accumulate(m_numFreeDofs.begin(), m_numFreeDofs.begin()+comp, 0);
-        //return m_numFreeDofs;
+        return m_numFreeDofs[comp+1]-m_numFreeDofs[comp] 
+	  + m_numElimDofs[comp+1]-m_numElimDofs[comp];
     }
 
     /// Returns the number of free (not eliminated) dofs.
     inline index_t freeSize() const
     {
-        return freeSizeUpto(m_dofs.size());
-        //return m_numFreeDofs;
+      return m_numFreeDofs[m_dofs.size()];
+    }
+
+    inline index_t freeSize(index_t comp) const
+    {
+      return m_numFreeDofs[comp+1]-m_numFreeDofs[comp];
     }
 
     /// Returns the number of coupled (not eliminated) dofs.
@@ -429,33 +439,23 @@ inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
     inline index_t boundarySize() const
     {
         GISMO_ENSURE(m_curElimId==0, "finalize() was not called on gsDofMapper");
-        return boundarySizeUpto(m_dofs.size());
-    }
-
-    /// Returns the number of eliminated dofs.
-    inline index_t boundarySizeUpto(index_t comp) const
-    {
-        GISMO_ENSURE(m_curElimId==0, "finalize() was not called on gsDofMapper");
-        return std::accumulate(m_numElimDofs.begin(), m_numElimDofs.begin()+comp, 0);
+        return m_numElimDofs[m_dofs.size()];
     }
 
     index_t boundarySizeWithDuplicates() const;
 
     /// Returns the offset corresponding to patch \a k
-    size_t offset(int k) const
-    {return m_offset[k];}
+    size_t offset(int k) const {return m_offset[k];}
 
     /// Returns the number of patches present underneath the mapper
-    size_t numPatches() const
-    {return m_offset.size();}
+    size_t numPatches() const {return m_offset.size();}
 
     /// \brief Returns the total number of patch-local degrees of
     /// freedom that are being mapped
     size_t mapSize() const
     {return m_dofs.size() * m_dofs.front().size();}
 
-    size_t componentsSize() const
-    {return m_dofs.size();}
+    size_t componentsSize() const {return m_dofs.size();}
 
     /// \brief Returns the total number of patch-local DoFs on
     /// patch \a k that are being mapped
@@ -477,8 +477,8 @@ inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
     /// assuming that the map is invertible on that patch
     std::map<index_t,index_t> inverseOnPatch(const index_t k) const;
 
-    /// \brief For \a gl being a global index, this function returns true
-    /// whenever \a gl corresponds to patch \a k
+    /// \brief For \a gl being a global index, this function returns
+    /// true whenever \a gl corresponds to patch \a k
     bool indexOnPatch(const index_t gl, const index_t k) const;
 
     /// \brief For \a n being an index which is already offsetted, it
@@ -491,10 +491,12 @@ inline index_t freeIndex( index_t i, index_t k = 0, index_t c = 0 ) const
     }
 private:
 
+    void finalizeComp(const index_t comp);
+
     // replace all references to oldIdx by newIdx
     inline void replaceDofGlobally(index_t oldIdx, index_t newIdx);
 
-void mergeDofsGlobally(index_t dof1, index_t dof2, index_t comp = 0);
+    void mergeDofsGlobally(index_t dof1, index_t dof2);
 
 // Data members
 private:
@@ -509,33 +511,31 @@ private:
     // group of the dof. Dofs with the same id will get the same dof index in the
     // final numbering stage in finalize().
 
-    // Representation as a single vector plus offsets for patch-local
-    // indices
+    // Representation of each component as a single vector plus
+    // offsets for patch-local indices
     std::vector<std::vector<index_t> >  m_dofs;
-    //    std::vector<index_t>     m_dofs;
-    std::vector<size_t> m_offset;
-    // Representation as vector of vectors, m_patchDofs[k][i]
-    // corresponds to patch k patch-local basis index i
-    // std::vector< std::vector<index_t> > m_patchDofs;
 
-    // Shifting of the global index (zero by default)
+    /// Offsets
+    std::vector<size_t> m_offset;
+
+    /// Shifting of the global index (zero by default)
     index_t m_shift;
 
-    // Shifting of the boundary index (zero by default)
+    /// Shifting of the boundary index (zero by default)
     index_t m_bshift;
 
-    //index_t m_numFreeDofs;
-    //index_t m_numElimDofs;
-    //index_t m_numCpldDofs;
+    /// Offsets of free dofs, nComp+1
     std::vector<index_t> m_numFreeDofs;
+    /// Offsets of eliminated dofs, nComp+1
     std::vector<index_t> m_numElimDofs;
+    /// Offsets of coupled dofs, nComp+1
     std::vector<index_t> m_numCpldDofs;
 
     // used during setup: running id for current eliminated dof
     // After finalize() is called m_curElimId takes the value zero.
     index_t m_curElimId;
 
-    //stores the tagged indices
+    /// Stores the tagged indices
     std::vector<index_t> m_tagged;
 
 }; // class gsDofMapper

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -257,7 +257,7 @@ public:
     /// markCoupledAsTagged() and then use the corresponding functions for tagged dofs.
     void permuteFreeDofs(const gsVector<index_t>& permutation, index_t comp = 0);
 
-    ///\brief Returns the smallest value of the indices
+    ///\brief Returns the smallest value of the indices for \a comp
     index_t firstIndex(index_t comp = 0) const
     { return m_numFreeDofs[comp]+ m_numElimDofs[comp] + m_shift; }
 
@@ -328,7 +328,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     inline index_t bindex(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
-        return MAPPER_PATCH_DOF(i,k,c) - m_numFreeDofs[c]
+        return MAPPER_PATCH_DOF(i,k,c) - m_numFreeDofs[c+1]
             - m_numElimDofs[c] + m_bshift;
     }
 
@@ -337,9 +337,8 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT(m_curElimId==0, "finalize() was not called on gsDofMapper");
         //return MAPPER_PATCH_DOF(i,k,c) - ( m_numFreeDofs - m_numCpldDofs ) ;
-        return MAPPER_PATCH_DOF(i,k,c) - 
-	  ( m_numFreeDofs[c] - m_numCpldDofs[c] )
-	  - m_numElimDofs[c];
+        return MAPPER_PATCH_DOF(i,k,c) - m_numFreeDofs[c+1] 
+	          + m_numCpldDofs[c+1] - m_numElimDofs[c];
     }
 
     /// @brief Returns the tagged dof index
@@ -356,14 +355,15 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     {
         GISMO_ASSERT( is_boundary_index( gl ),
                       "global_to_bindex(): specified dof is not on the boundary");
-        return gl - m_shift - m_numFreeDofs[componentOf(gl)] + m_bshift;
+	const index_t c = componentOf(gl);
+        return gl - m_shift - m_numFreeDofs[c+1] - m_numElimDofs[c] + m_bshift;
     }
 
     /// Returns true if global dof \a gl is not eliminated.
     inline bool is_free_index(index_t gl) const
     {
       const index_t c = componentOf(gl);
-      return gl < m_numElimDofs[c] + m_numFreeDofs[c] + m_shift; 
+      return gl < m_numFreeDofs[c+1] + m_numElimDofs[c] +  m_shift; 
     }
 
     /// Returns true if local dof \a i of patch \a k is not eliminated.
@@ -436,7 +436,7 @@ inline index_t freeIndex(index_t i, index_t k = 0, index_t c = 0) const
     /// Returns the number of eliminated dofs.
     inline index_t boundarySize() const
     {
-        GISMO_ENSURE(m_curElimId==0, "finalize() was not called on gsDofMapper");
+      GISMO_ENSURE(m_curElimId==0, "finalize() was not called on gsDofMapper");
         return m_numElimDofs.back();
     }
 

--- a/src/gsCore/gsDofMapper.h
+++ b/src/gsCore/gsDofMapper.h
@@ -440,6 +440,10 @@ public:
     /// map to \a gl
     void preImage(index_t gl, std::vector<std::pair<index_t,index_t> > & result) const;
 
+    /// \brief Produces the inverse of the mapping on patch \a k
+    /// assuming that the map is invertible on that patch
+    std::map<index_t,index_t> inverseOnPatch(const index_t k) const;
+
     /// \brief For \a gl being a global index, this function returns true
     /// whenever \a gl corresponds to patch \a k
     bool indexOnPatch(const index_t gl, const index_t k) const;

--- a/src/gsCore/gsDofMapper.hpp
+++ b/src/gsCore/gsDofMapper.hpp
@@ -34,18 +34,18 @@ void gsDofMapper::init( const gsMultiBasis<T> & bases, index_t nComp)
 
     m_numFreeDofs.assign(1+nComp,m_offset.back() + bases.back().size()); m_numFreeDofs.front()=0;
 
-    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs.back().size(), 0));
+    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs.back(), 0));
 }
 
 template<class T>
 void gsDofMapper::init( std::vector<const gsMultiBasis<T> *> const & bases)
 {
+    const index_t numComp = bases.size();
     m_curElimId   = -1;
-    m_numCpldDofs =  1;
+    m_numCpldDofs.assign(numComp+1,1); m_numCpldDofs.front()=0;
     m_offset.clear();
 
     const size_t nPatches = bases[0]->nBases();
-    const index_t numComp = bases.size();
 
     //Checking if bases are same size in for components.
     std::vector<index_t> offsets(nPatches);
@@ -83,8 +83,8 @@ void gsDofMapper::init( std::vector<const gsMultiBasis<T> *> const & bases)
       m_numFreeDofs.assign(numComp, (m_offset.back() + bases[0]->back().size())*nPatches); m_numFreeDofs.front()=0;
     }
 
-    m_numElimDofs.assign(nComp+1,0);
-    m_dofs.resize(numComp, std::vector<index_t>(m_numFreeDofs.back().size(), 0));
+    m_numElimDofs.assign(numComp+1,0);
+    m_dofs.resize(numComp, std::vector<index_t>(m_numFreeDofs.back(), 0));
 }
 
 template<class T>
@@ -129,7 +129,7 @@ void gsDofMapper::initSingle( const gsBasis<T> & basis, index_t nComp)
     m_numCpldDofs.assign(nComp+1,1); m_numCpldDofs.front()=0;
     m_numElimDofs.assign(nComp+1,0);
     m_offset.resize(1,0);
-    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs.back().size(), 0));
+    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs.back(), 0));
 }
 
 }//namespace gismo

--- a/src/gsCore/gsDofMapper.hpp
+++ b/src/gsCore/gsDofMapper.hpp
@@ -20,7 +20,8 @@ template<class T>
 void gsDofMapper::init( const gsMultiBasis<T> & bases, index_t nComp)
 {
     m_curElimId   = -1;
-    m_numCpldDofs.resize(nComp, 1);
+    m_numCpldDofs.assign(nComp+1, 1); m_numCpldDofs.front()=0;
+    m_numElimDofs.assign(nComp+1,0);
     m_offset.clear();
 
     const size_t nPatches = bases.nBases();
@@ -29,13 +30,11 @@ void gsDofMapper::init( const gsMultiBasis<T> & bases, index_t nComp)
     m_offset.reserve( nPatches );
     m_offset.push_back(0);
     for (size_t k = 1; k < nPatches; ++k)
-    {
         m_offset.push_back( m_offset.back() + bases[k-1].size() );
-    }
 
-    m_numFreeDofs.resize(nComp,m_offset.back() + bases.back().size());
+    m_numFreeDofs.assign(1+nComp,m_offset.back() + bases.back().size()); m_numFreeDofs.front()=0;
 
-    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs, 0));
+    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs.back().size(), 0));
 }
 
 template<class T>
@@ -62,38 +61,37 @@ void gsDofMapper::init( std::vector<const gsMultiBasis<T> *> const & bases)
             offsets[k] =  bases[comp]->basis(k).size();
         }
     }
+
     // Initialize offsets and dof holder
     m_offset.reserve( nPatches );
     m_offset.push_back(0);
     for (size_t k = 1; k < nPatches; ++k)
-    {
         m_offset.push_back( m_offset.back() + bases[0]->basis(k-1).size() );
-    }
 
     if (nPatches == 1)
     {
         index_t dofsPatches = 0;
         for (index_t comp = 0; comp < numComp; ++comp)
-        {
             dofsPatches += bases[comp]->back().size();
-        }
-        m_numFreeDofs = m_offset.back() + dofsPatches;
+        m_numFreeDofs.assign(numComp+1,m_offset.back() + dofsPatches);
+	m_numFreeDofs.front()=0;
     }
     //Assuming each component are of same size;
     //i.e. bases[comp]->back().size() are equal for all comp
     else
     {
-        m_numFreeDofs = (m_offset.back() + bases[0]->back().size())*nPatches;
+      m_numFreeDofs.assign(numComp, (m_offset.back() + bases[0]->back().size())*nPatches); m_numFreeDofs.front()=0;
     }
 
-    m_dofs.resize( m_numFreeDofs, 0);
+    m_numElimDofs.assign(nComp+1,0);
+    m_dofs.resize(numComp, std::vector<index_t>(m_numFreeDofs.back().size(), 0));
 }
 
 template<class T>
 void gsDofMapper::init(const gsMultiBasis<T>         &basis,
                        const gsBoundaryConditions<T> &bc, int unk)
 {
-    init(basis);
+    init(basis, 1); //one component
 
     /// \todo move this code to gsMultiBasis::getMapper
     for (typename gsBoundaryConditions<T>::const_iterator
@@ -124,15 +122,15 @@ void gsDofMapper::init(const gsMultiBasis<T>         &basis,
 }
 
 template<class T>
-void gsDofMapper::initSingle( const gsBasis<T> & basis)
+void gsDofMapper::initSingle( const gsBasis<T> & basis, index_t nComp)
 {
     m_curElimId   = -1;
-    m_numCpldDofs =  1;
-
+    m_numFreeDofs.assign(nComp+1,basis.size()); m_numFreeDofs.front()=0;
+    m_numCpldDofs.assign(nComp+1,1); m_numCpldDofs.front()=0;
+    m_numElimDofs.assign(nComp+1,0);
     m_offset.resize(1,0);
-    m_numFreeDofs = basis.size();
-    m_dofs.resize( m_numFreeDofs, 0);
+    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs.back().size(), 0));
 }
 
-}
+}//namespace gismo
 

--- a/src/gsCore/gsDofMapper.hpp
+++ b/src/gsCore/gsDofMapper.hpp
@@ -17,10 +17,10 @@ namespace gismo
 {
 
 template<class T>
-void gsDofMapper::init( const gsMultiBasis<T> & bases)
+void gsDofMapper::init( const gsMultiBasis<T> & bases, index_t nComp)
 {
     m_curElimId   = -1;
-    m_numCpldDofs =  1;
+    m_numCpldDofs.resize(nComp, 1);
     m_offset.clear();
 
     const size_t nPatches = bases.nBases();
@@ -33,9 +33,9 @@ void gsDofMapper::init( const gsMultiBasis<T> & bases)
         m_offset.push_back( m_offset.back() + bases[k-1].size() );
     }
 
-    m_numFreeDofs = m_offset.back() + bases.back().size();
+    m_numFreeDofs.resize(nComp,m_offset.back() + bases.back().size());
 
-    m_dofs.resize( m_numFreeDofs, 0);
+    m_dofs.resize(nComp, std::vector<index_t>(m_numFreeDofs, 0));
 }
 
 template<class T>

--- a/src/gsCore/gsDofMapper_.cpp
+++ b/src/gsCore/gsDofMapper_.cpp
@@ -20,7 +20,7 @@
 namespace gismo {
 
     TEMPLATE_INST void gsDofMapper::init(
-         const gsMultiBasis<real_t> & bases);
+         const gsMultiBasis<real_t> & bases, index_t nComp);
 
     TEMPLATE_INST void gsDofMapper::init(
             std::vector<const gsMultiBasis<real_t> *> const & bases);
@@ -31,7 +31,7 @@ namespace gismo {
         );
 
     TEMPLATE_INST void gsDofMapper::initSingle(
-        const gsBasis<real_t> & bases);
+        const gsBasis<real_t> & bases, index_t nComp);
 }
 
 


### PR DESCRIPTION
The interface is extended by an arguement for the component, eg.

gsDofMapper::index(local-dof, patch, component)

There is no change in the behaviour when 1 component is used.

Restrictions:
1. The basis must be of equal size for all components.
2. DoFs on different components cannot be merged.
