### PR TITLE
Least squares fitting with linear constraints.

### DIFF
--- a/examples/constrained_fitting.cpp
+++ b/examples/constrained_fitting.cpp
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
 	{
 	    gsFileData<> fd_out;
 	    fd_out << *fitting.result() ;
-	    fd_out.dump("fitting_out" + std::to_string(i));
+	    fd_out.dump("fitting_out" + util::to_string(i));
 	}
 
         if ( fitting.maxPointError() < tolerance )

--- a/examples/constrained_fitting.cpp
+++ b/examples/constrained_fitting.cpp
@@ -1,0 +1,118 @@
+/** @file constrained_fitting.cpp
+
+    @brief Demonstration of a least-squares fitting (see
+    fitting_example.cpp) with constraints. In this case, the values
+    for v=0 and v=1 are prescribed by the user and only the remaining
+    DOFs are computed by the LS. Cf. Prautzch, Boehm, Paluszny: Bezier
+    and B-spline techniques, Section 4.7.
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): D. Mokris
+*/
+
+#include <gismo.h>
+
+using namespace gismo;
+
+int main(int argc, char *argv[])
+{
+    // The following parameters are hard-wired but could easily be
+    // made available through the command line analogously to
+    // fitting_example.cpp.
+    int iter = 5;
+    real_t tolerance = 1e-5;
+    real_t threshold = 1e-5;
+    real_t v_min = -1;
+    real_t v_max = 1;
+    index_t num_int_knots = 0;
+    index_t bound_mult = 4;
+    real_t lambda = 1e-6;
+    index_t extension = 2;
+    real_t refPercent = 0.1;
+    bool save = true;
+
+    std::string uvxyz_file = "fitting/deepdrawingC.xml";
+
+    // Read the fitting points and their parameters.
+    gsFileData<> fd_in(uvxyz_file);
+    gsMatrix<> uv, xyz;
+    fd_in.getId<gsMatrix<> >(0, uv );
+    fd_in.getId<gsMatrix<> >(1, xyz);
+
+    // Design the curves prescribing the values along v=0 and v=1.
+    gsMatrix<real_t> coefs0(5, 3);
+    coefs0 << -50, -50, 25,
+	-25, -50, 25,
+	0, -50, 25,
+	25, -50, 25,
+	50, -50, 25;
+    gsBSpline<> v0(-1, 1, 1, 3, coefs0);
+
+    gsMatrix<real_t> coefs1(5, 3);
+    coefs1 << -50, 50, 25,
+	-25, 50, 25,
+	0, 50, 25,
+	25, 50, 25,
+	50, 50, 25;
+    gsBSpline<> v1(-1, 1, 1, 3, coefs1);
+
+    // Find an appropriate basis. One could also modify the code by using
+    // further parameters from fitting_example.cpp.
+    // Note: u_knots are the knots in the u-direction, i.e., of the curve with v=0.
+    gsKnotVector<> u_knots (v0.knots());
+    GISMO_ASSERT(u_knots == v1.knots(), "The knot vectors in the v-direction differ.");
+    gsKnotVector<real_t> v_knots(v_min, v_max, num_int_knots, bound_mult);
+    gsTensorBSplineBasis<2> basis0(u_knots, v_knots);
+    gsTHBSplineBasis<2> basis(basis0);
+
+    // Extension, refin and lambda could also easily changed.
+    std::vector<unsigned> ext;
+    ext.push_back(extension);
+    ext.push_back(extension);
+    gsHFitting<2, real_t> fitting(uv, xyz, basis, refPercent, ext, lambda);
+
+    // Prescribe the curves with v=0 and v=1.
+    std::vector<gsBSpline<real_t> > prescribedCurves;
+    prescribedCurves.push_back(v0);
+    prescribedCurves.push_back(v1);
+    std::vector<boxSide>     prescribedSides;
+    prescribedSides.push_back(boxSide(3));
+    prescribedSides.push_back(boxSide(4));
+    fitting.setConstraints(prescribedSides, prescribedCurves);
+
+    gsStopwatch time;
+    for(int i = 0; i <= iter; i++)
+    {
+        gsInfo<<"----------------\n";
+        gsInfo<<"Iteration "<<i<<".."<<"\n";
+
+        time.restart();
+        fitting.nextIteration(tolerance, threshold, prescribedSides);
+        time.stop();
+        gsInfo<<"Fitting time: "<< time <<"\n";
+        gsInfo<<"Fitted with "<< fitting.result()->basis() <<"\n";
+        gsInfo<<"Min distance : "<< fitting.minPointError() <<" / ";
+        gsInfo<<"Max distance : "<< fitting.maxPointError() <<"\n";
+
+	if(save)
+	{
+	    gsFileData<> fd_out;
+	    fd_out << *fitting.result() ;
+	    fd_out.dump("fitting_out" + std::to_string(i));
+	}
+
+        if ( fitting.maxPointError() < tolerance )
+        {
+            gsInfo<<"Error tolerance achieved after "<<i<<" iterations.\n";
+            break;
+        }
+    }
+
+    return 0;
+
+}

--- a/src/gsHSplines/gsHFitting.h
+++ b/src/gsHSplines/gsHFitting.h
@@ -103,6 +103,13 @@ public:
      */
     bool nextIteration(T tolerance, T err_threshold);
 
+    /**
+     * @brief Like \a nextIteration without \a fixedSides but keeping the values
+     * on these sides unchanged throughout the fit.
+     */
+    bool nextIteration(T tolerance, T err_threshold,
+		       const std::vector<boxSide>& fixedSides);
+
     /// Return the refinement percentage
     T getRefPercentage() const
     {
@@ -135,6 +142,16 @@ public:
     /// Returns boxes which define refinment area.
     std::vector<unsigned> getBoxes(const std::vector<T>& errors,
                                    const T threshold);
+
+    /// Sets constraints in such a way that the previous values at \a
+    /// fixedSides of the geometry remain intact.
+    void setConstraints(const std::vector<boxSide>& fixedSides);
+
+    /// Set constraints in such a way that the resulting geometry on
+    /// each of \a fixedSides will coincide with the corresponding
+    /// curve in \a fixedCurves.
+    void setConstraints(const std::vector<boxSide>& fixedSides,
+			const std::vector<gsBSpline<T> >& fixedCurves);
 
 protected:
     /// Appends a box around parameter to the boxes only if the box is not
@@ -179,10 +196,77 @@ protected:
     using gsFitting<T>::m_min_error;
 };
 
+template<short_t d, class T>
+void gsHFitting<d, T>::setConstraints(const std::vector<boxSide>& fixedSides)
+{
+    if(fixedSides.size() == 0)
+	return;
 
+    std::vector<index_t> indices;
+    std::vector<gsMatrix<T> > coefs;
+
+    for(std::vector<boxSide>::const_iterator it=fixedSides.begin(); it!=fixedSides.end(); ++it)
+    {
+	gsMatrix<unsigned> ind = this->m_basis->boundary(*it);
+	for(index_t r=0; r<ind.rows(); r++)
+	{
+	    index_t fix = ind(r,0);
+	    // If it is a new constraint, add it.
+	    if(std::find(indices.begin(), indices.end(), fix) == indices.end())
+	    {
+		indices.push_back(fix);
+		coefs.push_back(this->m_result->coef(fix));
+	    }
+	}
+    }
+
+    gsFitting<T>::setConstraints(indices, coefs);
+}
+
+template<short_t d, class T>
+void gsHFitting<d, T>::setConstraints(const std::vector<boxSide>& fixedSides,
+				      const std::vector<gsBSpline<T> >& fixedCurves)
+{
+    if(fixedSides.size() == 0)
+	return;
+
+    GISMO_ASSERT(fixedCurves.size() == fixedSides.size(),
+		 "fixedCurves and fixedSides are of different sizes.");
+
+    std::vector<index_t> indices;
+    std::vector<gsMatrix<T> > coefs;
+    for(size_t s=0; s<fixedSides.size(); s++)
+    {
+	gsMatrix<T> coefsThisSide = fixedCurves[s].coefs();
+	gsMatrix<unsigned> indicesThisSide = m_basis->boundaryOffset(fixedSides[s],0);
+	GISMO_ASSERT(coefsThisSide.rows() == indicesThisSide.rows(),
+		     "Coef number mismatch between prescribed curve and basis side.");
+
+	for(index_t r=0; r<indicesThisSide.rows(); r++)
+	{
+	    index_t fix = indicesThisSide(r,0);
+	    // If it is a new constraint, add it.
+	    if(std::find(indices.begin(), indices.end(), fix) == indices.end())
+	    {
+		indices.push_back(fix);
+		coefs.push_back(coefsThisSide.row(r));
+	    }
+	}
+    }
+
+    gsFitting<T>::setConstraints(indices, coefs);
+}
 
 template<short_t d, class T>
 bool gsHFitting<d, T>::nextIteration(T tolerance, T err_threshold)
+{
+    std::vector<boxSide> dummy;
+    return nextIteration(tolerance, err_threshold, dummy);
+}
+
+template<short_t d, class T>
+bool gsHFitting<d, T>::nextIteration(T tolerance, T err_threshold,
+				     const std::vector<boxSide>& fixedSides)
 {
     // INVARIANT
     // look at iterativeRefine
@@ -201,6 +285,13 @@ bool gsHFitting<d, T>::nextIteration(T tolerance, T err_threshold)
 
             gsHTensorBasis<d, T>* basis = static_cast<gsHTensorBasis<d,T> *> (this->m_basis);
             basis->refineElements(boxes);
+
+	    // If there are any fixed sides, prescribe the coefs in the finer basis.
+	    if(m_result != NULL && fixedSides.size() > 0)
+	    {
+		m_result->refineElements(boxes);
+		setConstraints(fixedSides);
+	    }
 
             gsDebug << "inserted " << boxes.size() / (2 * d + 1) << " boxes.\n";
         }

--- a/src/gsModeling/gsFitting.h
+++ b/src/gsModeling/gsFitting.h
@@ -9,7 +9,7 @@
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-    Author(s): M. Kapl, G. Kiss, A. Mantzaflaris
+    Author(s): M. Kapl, G. Kiss, A. Mantzaflaris, D. Mokris
 */
 
 #pragma once
@@ -22,8 +22,7 @@ namespace gismo
 
 /**
   @brief 
-   Class for performing a least squares fit to get a open/closed
-   B-Spline curve for some given data
+   Class for performing a least squares fit of a parametrized point cloud with a gsGeometry.
     
    \ingroup Modeling
 **/
@@ -112,6 +111,26 @@ public:
     /// returns the points
     gsMatrix<T> returnPoints() const {return m_points;}
 
+    /// Sets constraints that the coefficients of the resulting
+    /// geometry have to conform to. More precisely, denoting the
+    /// coefficient vector by \a x, it enforces
+    ///  \a lhs * \a x = \a rhs.
+    void setConstraints(const gsSparseMatrix<T>& lhs, const gsMatrix<T>& rhs)
+    {
+	m_constraintsLHS = lhs;
+	m_constraintsRHS = rhs;
+    }
+
+    /// Sets constraints on that the coefficients of the resulting geometry have to conform to.
+    /// \param indices indices (in the coefficient vector) of the prescribed coefficients.
+    /// \param coefs prescribed coefficients.
+    void setConstraints(const std::vector<index_t>& indices,
+			const std::vector<gsMatrix<T> >& coefs);
+
+private:
+    /// Extends the system of equations by taking constraints into account.
+    void extendSystem(gsSparseMatrix<T>& A_mat, gsMatrix<T>& m_B);
+
 protected:
 
     /// the parameter values of the point cloud
@@ -134,6 +153,18 @@ protected:
 
     /// Minimum point-wise error
     T m_min_error;
+
+    /// Left hand-side of the constraints that the coefficients of the
+    /// resulting geometry have to conform to.
+    /// This corresponds to matrix D in Prautzch, Boehm, Paluszny:
+    /// Bezier and B-spline techniques, Section 4.7.
+    gsSparseMatrix<T> m_constraintsLHS;
+
+    /// Right hand-side of the constraints that the coefficients of the
+    /// resulting geometry have to conform to.
+    /// This corresponds to vector q in Prautzch, Boehm, Paluszny:
+    /// Bezier and B-spline techniques, Section 4.7.
+    gsMatrix<T>       m_constraintsRHS;
 
 private:
     //void applySmoothing(T lambda, gsMatrix<T> & A_mat);

--- a/src/gsModeling/gsFitting.hpp
+++ b/src/gsModeling/gsFitting.hpp
@@ -360,9 +360,9 @@ void gsFitting<T>::setConstraints(const std::vector<index_t>& indices,
     index_t duplicates = 0;
     for(size_t r=0; r<indices.size(); r++)
     {
-	index_t fix = indices[r];
-	lhs(r-duplicates, fix) = 1;
-	rhs.row(r-duplicates) = coefs[r];
+        index_t fix = indices[r];
+        lhs(r-duplicates, fix) = 1;
+        rhs.row(r-duplicates) = coefs[r];
     }
 
     setConstraints(lhs, rhs);

--- a/src/gsModeling/gsFitting.hpp
+++ b/src/gsModeling/gsFitting.hpp
@@ -9,7 +9,7 @@
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-    Author(s): M. Kapl, G. Kiss, A. Mantzaflaris
+    Author(s): M. Kapl, G. Kiss, A. Mantzaflaris, D. Mokris
 
 */
 
@@ -53,7 +53,7 @@ void gsFitting<T>::compute(T lambda)
 
     //left side matrix
     //gsMatrix<T> A_mat(num_basis,num_basis);
-    gsSparseMatrix<T> A_mat(num_basis, num_basis);
+    gsSparseMatrix<T> A_mat(num_basis + m_constraintsLHS.rows(), num_basis + m_constraintsLHS.rows());
     //gsMatrix<T>A_mat(num_basis,num_basis);
     //To optimize sparse matrix an estimation of nonzero elements per
     //column can be given here
@@ -61,10 +61,11 @@ void gsFitting<T>::compute(T lambda)
     for (int i = 0; i < m_basis->dim(); ++i) // to do: improve
         // nonZerosPerCol *= m_basis->degree(i) + 1;
         nonZerosPerCol *= ( 2 * m_basis->degree(i) + 1 ) * 4;
+    // TODO: improve by taking constraints nonzeros into account.
     A_mat.reservePerColumn( nonZerosPerCol );
 
     //right side vector (more dimensional!)
-    gsMatrix<T> m_B(num_basis, dimension);
+    gsMatrix<T> m_B(num_basis + m_constraintsRHS.rows(), dimension);
     m_B.setZero(); // enusure that all entries are zero in the beginning
 
     // building the matrix A and the vector b of the system of linear
@@ -76,6 +77,9 @@ void gsFitting<T>::compute(T lambda)
     //test degree >=3
     if(lambda > 0)
       applySmoothing(lambda, A_mat);
+
+    if(m_constraintsLHS.rows() > 0)
+	extendSystem(A_mat, m_B);
 
     //Solving the system of linear equations A*x=b (works directly for a right side which has a dimension with higher than 1)
 
@@ -94,6 +98,10 @@ void gsFitting<T>::compute(T lambda)
     // Solves for many right hand side  columns
     gsMatrix<T> x;
     x = solver.solve(m_B); //toDense()
+
+    // If there were constraints, we obtained too many coefficients.
+    x.conservativeResize(num_basis, Eigen::NoChange);
+
     //gsMatrix<T> x (m_B.rows(), m_B.cols());
     //x=A_mat.fullPivHouseholderQr().solve( m_B);
     // Solves for many right hand side  columns
@@ -131,6 +139,29 @@ void gsFitting<T>::assembleSystem(gsSparseMatrix<T>& A_mat,
             for (index_t j = 0; j != numActive; ++j)
                 A_mat(ii, actives.at(j)) += value.at(i) * value.at(j);
         }
+    }
+}
+
+template <class T>
+void gsFitting<T>::extendSystem(gsSparseMatrix<T>& A_mat,
+				gsMatrix<T>& m_B)
+{
+    index_t basisSize = m_basis->size();
+
+    // Idea: maybe we can resize here instead of doing it in compute().
+
+    // This way does not work, as these block operations are read-only for sparse matrices.
+    /*A_mat.topRightCorner(m_constraintsLHS.cols(), m_constraintsLHS.rows()) = m_constraintsLHS.transpose();
+      A_mat.bottomLeftCorner(m_constraintsLHS.rows(), m_constraintsLHS.cols()) = m_constraintsLHS;*/
+    m_B.bottomRows(m_constraintsRHS.rows()) = m_constraintsRHS;
+
+    for (index_t k=0; k<m_constraintsLHS.outerSize(); ++k)
+    {
+	for (typename gsSparseMatrix<T>::InnerIterator it(m_constraintsLHS,k); it; ++it)
+	{
+	    A_mat(basisSize + it.row(), it.col()) = it.value();
+	    A_mat(it.col(), basisSize + it.row()) = it.value();
+	}
     }
 }
 
@@ -312,5 +343,30 @@ void gsFitting<T>::get_Error(std::vector<T>& errors, int type) const
         }
     }
 }
+
+template<class T>
+void gsFitting<T>::setConstraints(const std::vector<index_t>& indices,
+				  const std::vector<gsMatrix<T> >& coefs)
+{
+    if(coefs.size() == 0)
+	return;
+
+    GISMO_ASSERT(indices.size() == coefs.size(),
+		 "Prescribed indices and coefs must have the same length.");
+
+    gsSparseMatrix<T> lhs(indices.size(), m_basis->size());
+    gsMatrix<T> rhs(indices.size(), coefs[0].cols());
+
+    index_t duplicates = 0;
+    for(size_t r=0; r<indices.size(); r++)
+    {
+	index_t fix = indices[r];
+	lhs(r-duplicates, fix) = 1;
+	rhs.row(r-duplicates) = coefs[r];
+    }
+
+    setConstraints(lhs, rhs);
+}
+
 
 } // namespace gismo


### PR DESCRIPTION
# Explanation
I have extended the least squares fitting algorithm to allow enforcing linear constraints on the coefficients.

## What is the algorithm?
It is described in Prautzsch, Boehm, Paluszny: Bezier and B-spline techniques, Section 4.7.

Instead of minimizing the L^2 error among all surfaces, it now minimizes the L^2 error among all surfaces satisfying the constraints. If no constraints are given, `gsFitting` works as before.

## What is the use of it?
For instance, in `gsHFitting` it is now possible to prescribe the values along some of the boundary sides. The new example `constrained_fitting` tries to show, how it can be used.

It is useful in practice if you want to fit a patch of data but the result has to be sewn to some prescribed form.

## Why in stable?
The functionality in `gsFitting` is rather general and can be used later on. The parts involving patch sides and boundary B-splines are in `gsHFitting`. If I started with an extra class (I tried it, actually), I end up with a lot of boilerplate code and things do not integrate so smoothly as here.

## the usual smallprint
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
  I tried above.
- [X] Have you documented any new codes using Doxygen comments?
  Yes.
- [X] Have you written new tests or examples for your changes?
  There is a new test `constrained_fitting`. I'm not sure though if it is exciting enough to be accepted into stable but at least it suggests, how the new functionality can be used.
-----
