### PR TITLE
Bugfix: a forgotten swap of parameters from issue #290

### DIFF
--- a/extensions/gsParasolid/gsWriteParasolid.hpp
+++ b/extensions/gsParasolid/gsWriteParasolid.hpp
@@ -850,7 +850,7 @@ bool exportTHBsurface( const gsTHBSpline<2, T>& surface,
         //std::cout << "bspline coef size: " << bspline.coefs().rows() << std::endl;
         makeValidGeometry(surface, bspline);
 
-        //gsWriteParaview(bspline,"paraviewtest" + std::to_string(box),1000,true,true);
+        //gsWriteParaview(bspline,"paraviewtest" + util::to_string(box),1000,true,true);
 
         PK_BSURF_t bsurf;
         createPK_BSURF<T>(bspline, bsurf); // swap

--- a/extensions/gsParasolid/gsWriteParasolid.hpp
+++ b/extensions/gsParasolid/gsWriteParasolid.hpp
@@ -8,7 +8,7 @@
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-    Author(s): A. Mantzaflaris
+    Author(s): A. Mantzaflaris, D. Mokris
 */
 
 #include <gsParasolid/gsFrustrum.h>
@@ -850,7 +850,7 @@ bool exportTHBsurface( const gsTHBSpline<2, T>& surface,
         //std::cout << "bspline coef size: " << bspline.coefs().rows() << std::endl;
         makeValidGeometry(surface, bspline);
 
-        //gsWriteParaview(bspline,"paraviewtest",1000,true,true);
+        //gsWriteParaview(bspline,"paraviewtest" + std::to_string(box),1000,true,true);
 
         PK_BSURF_t bsurf;
         createPK_BSURF<T>(bspline, bsurf); // swap
@@ -864,10 +864,10 @@ bool exportTHBsurface( const gsTHBSpline<2, T>& surface,
         {
             for (unsigned seg = 0; seg != polylines[loop].size(); seg++)
             {
-                real_t x1 = polylines[loop][seg][0];
-                real_t y1 = polylines[loop][seg][1];
-                real_t x2 = polylines[loop][seg][2];
-                real_t y2 = polylines[loop][seg][3];
+                real_t y1 = polylines[loop][seg][0];
+                real_t x1 = polylines[loop][seg][1];
+                real_t y2 = polylines[loop][seg][2];
+                real_t x2 = polylines[loop][seg][3];
 
                 PK_CURVE_t line;
                 PK_INTERVAL_t intervalDummy;
@@ -882,7 +882,7 @@ bool exportTHBsurface( const gsTHBSpline<2, T>& surface,
                                                       &options, &line, &intervalDummy);
                     PARASOLID_ERROR(PK_SURF_make_curve_isoparam, err);
 
-                    getInterval(false, y1, y2, x1, bspline, line, interval);
+                    getInterval(true, y1, y2, x1, bspline, line, interval);
                 }
                 else
                 {
@@ -890,7 +890,7 @@ bool exportTHBsurface( const gsTHBSpline<2, T>& surface,
                                                       &options, &line, &intervalDummy);
                     PARASOLID_ERROR(PK_SURF_make_curve_isoparam, err);
 
-                    getInterval(true, x1, x2,  y1, bspline, line, interval);
+                    getInterval(false, x1, x2,  y1, bspline, line, interval);
                 }
 
                 curves.push_back(line);
@@ -966,6 +966,16 @@ bool exportTHBsurface( const gsTHBSpline<2, T>& surface,
 //        PARASOLID_ERROR(PK_PART_transmit, err);
 
         // ----------------------------------------------------------------------
+
+	// Extra transposition (2019-11-14) to compensate for the transposition in createPK_BSURF.
+	// PK_BSURF_reparameterise_o_t rep_options;
+	// PK_BSURF_reparameterise_o_m(rep_options);
+	// rep_options.transpose = PK_LOGICAL_true;
+
+	// err = PK_BSURF_reparameterise(bsurf,&rep_options);
+	// PARASOLID_ERROR(PK_BSURF_reparameterise, err);
+	// End of the transposition.
+
 
         PK_SURF_trim_data_t trim_data;
         trim_data.n_spcurves = static_cast<int>(curves.size());


### PR DESCRIPTION
# Short explanation
When I was fixing the swapped _u_- and _v_-directions in Parasolid export (issue #290), I missed one of them. The current PR fixes the problem.

# Longer explanation
Parasolid and Gismo store coefficients in a different order. In the past, this meant that the Parasolid export was returning a geometrically correct surface but with _u_ and _v_ swapped. In issue #290, I fixed this for all our calls of the functions in `gsWriteParasolid.hpp`. However, I did not realize that there are functions in the file that call other functions from the _same_ file and did not fix the transposition for those. The current PR fixes this omission.

# Smallprint
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
  No, it is a bugfix.
- [ ] Have you written new tests or examples for your changes?
  No. We might consider adding some unittests in the future, though.
-----
