### PR TITLE
Update gsFileManager.cpp

### DIFF
--- a/src/gsIO/gsFileManager.cpp
+++ b/src/gsIO/gsFileManager.cpp
@@ -36,6 +36,10 @@
 #include <sys/syslimits.h>
 #endif
 
+#if defined __linux__
+#include <limits.h>
+#endif
+
 namespace gismo
 {
 


### PR DESCRIPTION
Not all Linux systems store PATH_MAX in <linux/limits.h>. Alpine Linux, for instance, uses the muse-lib and PATH_MAXis stored in <limits.h>.
