### PR TITLE
Fixed bug in CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.0
 
 jobs:
-  centos7_gcc_cxx98
+  centos7_gcc_cxx98:
     docker:
       - image: centos:7
     filters:
@@ -22,7 +22,7 @@ jobs:
           name: Build and test G+Smo on CentOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
 
-  centos8_gcc_cxx11
+  centos8_gcc_cxx11:
     docker:
       - image: centos:8
     filters:
@@ -43,7 +43,7 @@ jobs:
           name: Build and test G+Smo on CentOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
 
-  macos_xcode11_cxx98
+  macos_xcode11_cxx98:
     macos:
       xcode: "11.7.0"
     filters:
@@ -64,7 +64,7 @@ jobs:
           name: Build and test G+Smo on MacOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
 
-  macos_xcode12_cxx11
+  macos_xcode12_cxx11:
     macos:
       xcode: "12.1.0"
     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,49 @@ jobs:
           name: Build and test G+Smo on CentOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
 
-  macos_build: #OS SEED plan!
+  centos_build11:
+    docker:
+      - image: centos:7
+    filters:
+      branches:
+        - only: stable
+    working_directory: ~/gismo
+    environment:
+      MAKEFLAGS: -j4
+    steps:
+      - run:
+          name: Install dependencies
+          command: yum install -y git cmake make gcc-c++ #valgrind
+      - checkout
+      - run:
+          name: Configure G+Smo on CentOS
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [circleci98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=11 -DGISMO_WITH_ONURBS=ON
+      - run:
+          name: Build and test G+Smo on CentOS
+          command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
+
+  centos_build14:
+    docker:
+      - image: centos:7
+    filters:
+      branches:
+        - only: stable
+    working_directory: ~/gismo
+    environment:
+      MAKEFLAGS: -j4
+    steps:
+      - run:
+          name: Install dependencies
+          command: yum install -y git cmake make gcc-c++ #valgrind
+      - checkout
+      - run:
+          name: Configure G+Smo on CentOS
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [circleci98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=14 -DGISMO_WITH_ONURBS=ON
+      - run:
+          name: Build and test G+Smo on CentOS
+          command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
+
+  macos_build98:
     macos:
       xcode: "11.7.0"
     filters:
@@ -34,11 +76,53 @@ jobs:
     steps:
       - run:
           name: Install dependencies
-          command: brew install git cmake # make clang libgcc #valgrind
+          command: brew install cmake # git make clang libgcc #valgrind
       - checkout
       - run:
           name: Configure G+Smo on MacOS
-          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DGISMO_WITH_ONURBS=ON
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=98 -DGISMO_WITH_ONURBS=ON
+      - run:
+          name: Build and test G+Smo on MacOS
+          command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
+
+  macos_build11:
+    macos:
+      xcode: "11.7.0"
+    filters:
+      branches:
+        - only: stable
+    working_directory: ~/gismo
+    environment:
+      MAKEFLAGS: -j4
+    steps:
+      - run:
+          name: Install dependencies
+          command: brew install cmake # git make clang libgcc #valgrind
+      - checkout
+      - run:
+          name: Configure G+Smo on MacOS
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=11 -DGISMO_WITH_ONURBS=ON
+      - run:
+          name: Build and test G+Smo on MacOS
+          command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
+
+  macos_build14:
+    macos:
+      xcode: "11.7.0"
+    filters:
+      branches:
+        - only: stable
+    working_directory: ~/gismo
+    environment:
+      MAKEFLAGS: -j4
+    steps:
+      - run:
+          name: Install dependencies
+          command: brew install cmake # git make clang libgcc #valgrind
+      - checkout
+      - run:
+          name: Configure G+Smo on MacOS
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=14 -DGISMO_WITH_ONURBS=ON
       - run:
           name: Build and test G+Smo on MacOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
@@ -61,7 +145,11 @@ workflows:
   build:
     jobs:
       - centos_build98
-      - macos_build
+      - centos_build11
+      - centos_build14
+      - macos_build98
+      - macos_build11
+      - macos_build14
 
 #      - deployment:
 #          requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.0
 
 jobs:
-  centos_build98:
+  centos7_gcc_cxx98
     docker:
       - image: centos:7
     filters:
@@ -17,14 +17,14 @@ jobs:
       - checkout
       - run:
           name: Configure G+Smo on CentOS
-          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [circleci98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=98 -DGISMO_WITH_ONURBS=ON
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [centos7_gcc_cxx98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=98 -DGISMO_WITH_ONURBS=ON
       - run:
           name: Build and test G+Smo on CentOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
 
-  centos_build11:
+  centos8_gcc_cxx11
     docker:
-      - image: centos:7
+      - image: centos:8
     filters:
       branches:
         - only: stable
@@ -38,33 +38,12 @@ jobs:
       - checkout
       - run:
           name: Configure G+Smo on CentOS
-          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [circleci98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=11 -DGISMO_WITH_ONURBS=ON
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [centos8_gcc_cxx11]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=11 -DGISMO_WITH_ONURBS=ON
       - run:
           name: Build and test G+Smo on CentOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
 
-  centos_build14:
-    docker:
-      - image: centos:7
-    filters:
-      branches:
-        - only: stable
-    working_directory: ~/gismo
-    environment:
-      MAKEFLAGS: -j4
-    steps:
-      - run:
-          name: Install dependencies
-          command: yum install -y git cmake make gcc-c++ #valgrind
-      - checkout
-      - run:
-          name: Configure G+Smo on CentOS
-          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [circleci98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=14 -DGISMO_WITH_ONURBS=ON
-      - run:
-          name: Build and test G+Smo on CentOS
-          command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
-
-  macos_build98:
+  macos_xcode11_cxx98
     macos:
       xcode: "11.7.0"
     filters:
@@ -80,14 +59,14 @@ jobs:
       - checkout
       - run:
           name: Configure G+Smo on MacOS
-          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=98 -DGISMO_WITH_ONURBS=ON
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos_xcode11_cxx98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=98 -DGISMO_WITH_ONURBS=ON
       - run:
           name: Build and test G+Smo on MacOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
 
-  macos_build11:
+  macos_xcode12_cxx11
     macos:
-      xcode: "11.7.0"
+      xcode: "12.1.0"
     filters:
       branches:
         - only: stable
@@ -101,28 +80,7 @@ jobs:
       - checkout
       - run:
           name: Configure G+Smo on MacOS
-          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=11 -DGISMO_WITH_ONURBS=ON
-      - run:
-          name: Build and test G+Smo on MacOS
-          command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
-
-  macos_build14:
-    macos:
-      xcode: "11.7.0"
-    filters:
-      branches:
-        - only: stable
-    working_directory: ~/gismo
-    environment:
-      MAKEFLAGS: -j4
-    steps:
-      - run:
-          name: Install dependencies
-          command: brew install cmake # git make clang libgcc #valgrind
-      - checkout
-      - run:
-          name: Configure G+Smo on MacOS
-          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos98]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=14 -DGISMO_WITH_ONURBS=ON
+          command: cmake . -DSITE="$CIRCLE_USERNAME-$CIRCLE_BRANCH [macos_xcode12_cxx11]" -DGISMO_INSOURCE_BUILD=ON -DGISMO_BUILD_UNITTESTS=ON -DCMAKE_CXX_STANDARD=11 -DGISMO_WITH_ONURBS=ON
       - run:
           name: Build and test G+Smo on MacOS
           command: ctest $MAKEFLAGS --output-on-failure -D ExperimentalStart -D ExperimentalConfigure -D ExperimentalBuild -D ExperimentalTest -D ExperimentalSubmit #-D ExperimentalMemCheck
@@ -144,12 +102,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - centos_build98
-      - centos_build11
-      - centos_build14
-      - macos_build98
-      - macos_build11
-      - macos_build14
+      - centos7_gcc_cxx98
+      - centos8_gcc_cxx11
+      - macos_xcode11_cxx98
+      - macos_xcode12_cxx11
 
 #      - deployment:
 #          requires:


### PR DESCRIPTION
CircleCI pipeline fails because brew tries to install `git` which is already installed.