### PR TITLE
evalAllDers_into in gsGeometry

### DIFF
--- a/src/gsCore/gsConstantFunction.h
+++ b/src/gsCore/gsConstantFunction.h
@@ -15,6 +15,7 @@
 
 #include <gsCore/gsLinearAlgebra.h>
 #include <gsCore/gsFunction.h>
+#include <gsUtils/gsCombinatorics.h>
 
 namespace gismo
 {
@@ -169,8 +170,19 @@ public:
     {
         GISMO_ASSERT(u.rows() == m_domainDim, "Wrong domain dimension "<< u.rows()
                                               << ", expected "<< m_domainDim);
-        result = gsMatrix<T>::Zero( (this->domainDim()*(this->domainDim()+1))/2,
-                                    this->targetDim()*u.cols() );
+        result = gsMatrix<T>::Zero(this->targetDim()*(this->domainDim()*(this->domainDim()+1))/2,
+                                   u.cols() );
+    }
+
+    void evalAllDers_into(const gsMatrix<T> & u, int n,
+                          std::vector<gsMatrix<T> > & result) const
+    {
+        GISMO_ASSERT(u.rows() == m_domainDim, "Wrong domain dimension "<< u.rows()
+                     << ", expected "<< m_domainDim);
+        result.resize(n+1,gsMatrix<T>());
+        for (int i = 0; i<=n; ++i)
+            result[i].resize( this->targetDim()*binomial(i+m_domainDim-1,m_domainDim-1)
+                           , u.cols() );
     }
 
     // Documentation in gsFunction class

--- a/src/gsCore/gsConstantFunction.h
+++ b/src/gsCore/gsConstantFunction.h
@@ -179,8 +179,10 @@ public:
     {
         GISMO_ASSERT(u.rows() == m_domainDim, "Wrong domain dimension "<< u.rows()
                      << ", expected "<< m_domainDim);
+        
         result.resize(n+1,gsMatrix<T>());
-        for (int i = 0; i<=n; ++i)
+        eval_into(u,result.front());
+        for (int i = 1; i<=n; ++i)
             result[i].resize( this->targetDim()*binomial(i+m_domainDim-1,m_domainDim-1)
                            , u.cols() );
     }

--- a/src/gsCore/gsGeometry.h
+++ b/src/gsCore/gsGeometry.h
@@ -261,6 +261,10 @@ public:
     void deriv2_into(const gsMatrix<T>& u, gsMatrix<T>& result) const
     { this->basis().deriv2Func_into(u, m_coefs, result); }
 
+    void evalAllDers_into(const gsMatrix<T> & u, int n,
+                          std::vector<gsMatrix<T> > & result) const
+    { this->basis().evalAllDersFunc_into(u, m_coefs, n, result); }
+
     /// @}
 
 


### PR DESCRIPTION
Added function evalAllDers_into to gsGeometry (in the same way as for deriv_into and deriv2_into).

Without this, calling evallAllDers_into on a gsGeometry leads to the implementation in gsFunctionSet, which is only implemented up to second derivatives.
