### PR TITLE
MG should provide basic support for systems

### DIFF
--- a/src/gsCore/gsMultiBasis.h
+++ b/src/gsCore/gsMultiBasis.h
@@ -346,7 +346,7 @@ public:
     ///
     /// For computing the transfer matrix (but not for refinement), the \a boundaryConditions and
     /// the \a assemblerOptions have to be provided. By deault, the boundary conditions for
-    /// component 0 are chosen. Use the parameter comp to choose another one.
+    /// unknown 0 are chosen. Use the parameter unk to choose another one.
     ///
     /// \sa gsMultiBasis::uniformRefine
     void uniformRefine_withTransfer(
@@ -355,7 +355,7 @@ public:
         const gsOptionList& assemblerOptions,
         int numKnots = 1,
         int mul = 1,
-        index_t comp = 0
+        index_t unk = 0
         );
 
     /// @brief Refine the component \a comp of every basis uniformly
@@ -413,7 +413,7 @@ public:
     ///
     /// For computing the transfer matrix (but not for refinement), the \a boundaryConditions and
     /// the \a assemblerOptions have to be provided. By deault, the boundary conditions for
-    /// component 0 are chosen. Use the parameter comp to choose another one.
+    /// unknown 0 are chosen. Use the parameter unk to choose another one.
     ///
     /// \sa gsMultiBasis::uniformCoarsen
     void uniformCoarsen_withTransfer(
@@ -421,7 +421,7 @@ public:
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
         int numKnots = 1,
-        index_t comp = 0
+        index_t unk = 0
         );
 
     /// @brief Returns the basis that corresponds to the component

--- a/src/gsCore/gsMultiBasis.h
+++ b/src/gsCore/gsMultiBasis.h
@@ -345,7 +345,8 @@ public:
     /// grid functions.
     ///
     /// For computing the transfer matrix (but not for refinement), the \a boundaryConditions and
-    /// the \a assemblerOptions have to be provided
+    /// the \a assemblerOptions have to be provided. By deault, the boundary conditions for
+    /// component 0 are chosen. Use the parameter comp to choose another one.
     ///
     /// \sa gsMultiBasis::uniformRefine
     void uniformRefine_withTransfer(
@@ -353,7 +354,8 @@ public:
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
         int numKnots = 1,
-        int mul = 1
+        int mul = 1,
+        index_t comp = 0
         );
 
     /// @brief Refine the component \a comp of every basis uniformly
@@ -410,14 +412,16 @@ public:
     /// grid functions.
     ///
     /// For computing the transfer matrix (but not for refinement), the \a boundaryConditions and
-    /// the \a assemblerOptions have to be provided
+    /// the \a assemblerOptions have to be provided. By deault, the boundary conditions for
+    /// component 0 are chosen. Use the parameter comp to choose another one.
     ///
     /// \sa gsMultiBasis::uniformCoarsen
     void uniformCoarsen_withTransfer(
         gsSparseMatrix<T, RowMajor>& transfer,
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
-        int numKnots = 1
+        int numKnots = 1,
+        index_t comp = 0
         );
 
     /// @brief Returns the basis that corresponds to the component

--- a/src/gsCore/gsMultiBasis.hpp
+++ b/src/gsCore/gsMultiBasis.hpp
@@ -180,7 +180,8 @@ void gsMultiBasis<T>::uniformRefine_withTransfer(
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
         int numKnots,
-        int mul)
+        int mul,
+        index_t comp)
 {
     // Get coarse mapper
     gsDofMapper coarseMapper;
@@ -189,7 +190,7 @@ void gsMultiBasis<T>::uniformRefine_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             coarseMapper,
-            0
+            comp
     );
 
     // Refine
@@ -206,7 +207,7 @@ void gsMultiBasis<T>::uniformRefine_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             fineMapper,
-            0
+            comp
     );
 
     // restrict to free dofs
@@ -219,7 +220,8 @@ void gsMultiBasis<T>::uniformCoarsen_withTransfer(
         gsSparseMatrix<T, RowMajor>& transferMatrix,
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
-        int numKnots)
+        int numKnots,
+        index_t comp)
 {
     // Get fine mapper
     gsDofMapper fineMapper;
@@ -228,7 +230,7 @@ void gsMultiBasis<T>::uniformCoarsen_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             fineMapper,
-            0
+            comp
     );
 
     // Refine
@@ -245,7 +247,7 @@ void gsMultiBasis<T>::uniformCoarsen_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             coarseMapper,
-            0
+            comp
     );
 
     // restrict to free dofs

--- a/src/gsCore/gsMultiBasis.hpp
+++ b/src/gsCore/gsMultiBasis.hpp
@@ -181,7 +181,7 @@ void gsMultiBasis<T>::uniformRefine_withTransfer(
         const gsOptionList& assemblerOptions,
         int numKnots,
         int mul,
-        index_t comp)
+        index_t unk)
 {
     // Get coarse mapper
     gsDofMapper coarseMapper;
@@ -190,7 +190,7 @@ void gsMultiBasis<T>::uniformRefine_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             coarseMapper,
-            comp
+            unk
     );
 
     // Refine
@@ -207,7 +207,7 @@ void gsMultiBasis<T>::uniformRefine_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             fineMapper,
-            comp
+            unk
     );
 
     // restrict to free dofs
@@ -221,7 +221,7 @@ void gsMultiBasis<T>::uniformCoarsen_withTransfer(
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
         int numKnots,
-        index_t comp)
+        index_t unk)
 {
     // Get fine mapper
     gsDofMapper fineMapper;
@@ -230,7 +230,7 @@ void gsMultiBasis<T>::uniformCoarsen_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             fineMapper,
-            comp
+            unk
     );
 
     // Refine
@@ -247,7 +247,7 @@ void gsMultiBasis<T>::uniformCoarsen_withTransfer(
             (iFace    ::strategy)assemblerOptions.askInt("InterfaceStrategy", 1),
             boundaryConditions,
             coarseMapper,
-            comp
+            unk
     );
 
     // restrict to free dofs

--- a/src/gsMultiGrid/gsGridHierarchy.h
+++ b/src/gsMultiGrid/gsGridHierarchy.h
@@ -43,13 +43,17 @@ public:
     /// @param levels                    The number of levels
     /// @param numberOfKnotsToBeInserted The number of knots to be inserted, defaulted to 1
     /// @param multiplicityOfKnotsToBeInserted The multiplicity of the knots to be inserted, defaulted to 1
+    /// @param comp                      Since the gsBoundaryCondition object can obtain data for systems
+    ///                                  of PDEs, we have to provide information concerning which component
+    ///                                  we are refering to.
     static gsGridHierarchy buildByRefinement(
         gsMultiBasis<T> mBasis,
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
         index_t levels,
         index_t numberOfKnotsToBeInserted = 1,
-        index_t multiplicityOfKnotsToBeInserted = 1
+        index_t multiplicityOfKnotsToBeInserted = 1,
+        index_t comp = 0
         );
 
     /// @brief This function sets up a multigrid hierarchy by uniform refinement
@@ -57,6 +61,7 @@ public:
     /// @param mBasis                    The gsMultiBasis to be refined (initial basis)
     /// @param boundaryConditions        The boundary conditions
     /// @param options                   A gsOptionList defining the necessary infomation
+    /// Takes boundary conditions for component 0.
     static gsGridHierarchy buildByRefinement(
         gsMultiBasis<T> mBasis,
         const gsBoundaryConditions<T>& boundaryConditions,
@@ -69,7 +74,8 @@ public:
             options,
             options.askInt( "Levels", 3 ),
             options.askInt( "NumberOfKnotsToBeInserted", 1 ),
-            options.askInt( "MultiplicityOfKnotsToBeInserted", 1 )
+            options.askInt( "MultiplicityOfKnotsToBeInserted", 1 ),
+            0
         );
     }
 
@@ -81,6 +87,9 @@ public:
     /// @param assemblerOptions          A gsOptionList defining a "DirichletStrategy" and a "InterfaceStrategy"
     /// @param levels                    The maximum number of levels
     /// @param degreesOfFreedom          Number of dofs in the coarsest grid in the grid hierarchy
+    /// @param comp                      Since the gsBoundaryCondition object can obtain data for systems
+    ///                                  of PDEs, we have to provide information concerning which component
+    ///                                  we are refering to.
     ///
     /// The algorithm terminates if either the number of levels is reached or the number of degrees of freedom
     /// is below the given threshold.
@@ -90,7 +99,8 @@ public:
         const gsBoundaryConditions<T>& boundaryConditions,
         const gsOptionList& assemblerOptions,
         index_t levels,
-        index_t degreesOfFreedom = 0
+        index_t degreesOfFreedom = 0,
+        index_t comp = 0
         );
 
     /// @brief This function sets up a grid hierarchy by coarsening
@@ -99,6 +109,7 @@ public:
     /// @param boundaryConditions        The boundary conditions
     /// @param options                   A gsOptionList defining the necessary infomation
     ///
+    /// Takes boundary conditions for component 0.
     static gsGridHierarchy buildByCoarsening(
         gsMultiBasis<T> mBasis,
         const gsBoundaryConditions<T>& boundaryConditions,
@@ -110,7 +121,8 @@ public:
             boundaryConditions,
             options,
             options.askInt( "Levels", 3 ),
-            options.askInt( "DegreesOfFreedom", 0 )
+            options.askInt( "DegreesOfFreedom", 0 ),
+            0
         );
     }
 
@@ -127,15 +139,9 @@ public:
         return opt;
     }
 
-    /// Get the stored options
-    const gsOptionList& getOptions() const
-    { return m_options; }
-
     /// Reset the object (to save memory)
     void clear()
     {
-        //m_boundaryConditions.clear();
-        //m_options.clear();
         m_mBases.clear();
         m_transferMatrices.clear();
     }
@@ -156,14 +162,7 @@ public:
     gsGridHierarchy& moveTransferMatricesTo( std::vector< gsSparseMatrix<T, RowMajor> >& o )
     { o = give(m_transferMatrices); return *this; }
 
-    /// Get the boundary conditions
-    const gsBoundaryConditions<T>& getBoundaryConditions() const
-    { return m_boundaryConditions; }
-
 private:
-    gsBoundaryConditions<T> m_boundaryConditions;
-    gsOptionList m_options;
-
     std::vector< gsMultiBasis<T> > m_mBases;
     std::vector< gsSparseMatrix<T, RowMajor> > m_transferMatrices;
 };

--- a/src/gsMultiGrid/gsGridHierarchy.h
+++ b/src/gsMultiGrid/gsGridHierarchy.h
@@ -43,8 +43,8 @@ public:
     /// @param levels                    The number of levels
     /// @param numberOfKnotsToBeInserted The number of knots to be inserted, defaulted to 1
     /// @param multiplicityOfKnotsToBeInserted The multiplicity of the knots to be inserted, defaulted to 1
-    /// @param comp                      Since the gsBoundaryCondition object can obtain data for systems
-    ///                                  of PDEs, we have to provide information concerning which component
+    /// @param unk                       Since the gsBoundaryCondition object can obtain data for systems
+    ///                                  of PDEs, we have to provide information concerning which unknown
     ///                                  we are refering to.
     static gsGridHierarchy buildByRefinement(
         gsMultiBasis<T> mBasis,
@@ -53,7 +53,7 @@ public:
         index_t levels,
         index_t numberOfKnotsToBeInserted = 1,
         index_t multiplicityOfKnotsToBeInserted = 1,
-        index_t comp = 0
+        index_t unk = 0
         );
 
     /// @brief This function sets up a multigrid hierarchy by uniform refinement
@@ -61,7 +61,7 @@ public:
     /// @param mBasis                    The gsMultiBasis to be refined (initial basis)
     /// @param boundaryConditions        The boundary conditions
     /// @param options                   A gsOptionList defining the necessary infomation
-    /// Takes boundary conditions for component 0.
+    /// Takes boundary conditions for unknown 0.
     static gsGridHierarchy buildByRefinement(
         gsMultiBasis<T> mBasis,
         const gsBoundaryConditions<T>& boundaryConditions,
@@ -87,8 +87,8 @@ public:
     /// @param assemblerOptions          A gsOptionList defining a "DirichletStrategy" and a "InterfaceStrategy"
     /// @param levels                    The maximum number of levels
     /// @param degreesOfFreedom          Number of dofs in the coarsest grid in the grid hierarchy
-    /// @param comp                      Since the gsBoundaryCondition object can obtain data for systems
-    ///                                  of PDEs, we have to provide information concerning which component
+    /// @param unk                       Since the gsBoundaryCondition object can obtain data for systems
+    ///                                  of PDEs, we have to provide information concerning which unknown
     ///                                  we are refering to.
     ///
     /// The algorithm terminates if either the number of levels is reached or the number of degrees of freedom
@@ -100,7 +100,7 @@ public:
         const gsOptionList& assemblerOptions,
         index_t levels,
         index_t degreesOfFreedom = 0,
-        index_t comp = 0
+        index_t unk = 0
         );
 
     /// @brief This function sets up a grid hierarchy by coarsening
@@ -109,7 +109,7 @@ public:
     /// @param boundaryConditions        The boundary conditions
     /// @param options                   A gsOptionList defining the necessary infomation
     ///
-    /// Takes boundary conditions for component 0.
+    /// Takes boundary conditions for unkown 0.
     static gsGridHierarchy buildByCoarsening(
         gsMultiBasis<T> mBasis,
         const gsBoundaryConditions<T>& boundaryConditions,

--- a/src/gsMultiGrid/gsGridHierarchy.hpp
+++ b/src/gsMultiGrid/gsGridHierarchy.hpp
@@ -30,12 +30,11 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByRefinement(
     const gsOptionList& options,
     index_t levels,
     index_t numberOfKnotsToBeInserted,
-    index_t multiplicityOfKnotsToBeInserted
+    index_t multiplicityOfKnotsToBeInserted,
+    index_t comp
     )
 {
     gsGridHierarchy<T> result;
-    result.m_boundaryConditions = boundaryConditions,
-    result.m_options = options,
     result.m_mBases.resize(levels);
     result.m_transferMatrices.resize(levels-1);
     result.m_mBases[0] = give(mBasis);
@@ -44,10 +43,11 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByRefinement(
         result.m_mBases[i] = result.m_mBases[i-1];
         result.m_mBases[i].uniformRefine_withTransfer(
             result.m_transferMatrices[i-1],
-            result.m_boundaryConditions,
-            result.m_options,
+            boundaryConditions,
+            options,
             numberOfKnotsToBeInserted,
-            multiplicityOfKnotsToBeInserted
+            multiplicityOfKnotsToBeInserted,
+            comp
         );
     }
     return result;
@@ -59,12 +59,11 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByCoarsening(
     const gsBoundaryConditions<T>& boundaryConditions,
     const gsOptionList& options,
     index_t levels,
-    index_t degreesOfFreedom
+    index_t degreesOfFreedom,
+    index_t comp
     )
 {
     gsGridHierarchy<T> result;
-    result.m_boundaryConditions = boundaryConditions,
-    result.m_options = options,
 
     result.m_mBases.push_back(give(mBasis));
 
@@ -77,9 +76,10 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByCoarsening(
         coarseMBasis.uniformCoarsen_withTransfer(
             transferMatrix,
             boundaryConditions,
-            options
+            options,
+            1,
+            comp
         );
-
 
         index_t newSize = coarseMBasis.totalSize();
         // If the number of dofs could not be decreased, then cancel. However, if only the number

--- a/src/gsMultiGrid/gsGridHierarchy.hpp
+++ b/src/gsMultiGrid/gsGridHierarchy.hpp
@@ -31,7 +31,7 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByRefinement(
     index_t levels,
     index_t numberOfKnotsToBeInserted,
     index_t multiplicityOfKnotsToBeInserted,
-    index_t comp
+    index_t unk
     )
 {
     gsGridHierarchy<T> result;
@@ -47,7 +47,7 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByRefinement(
             options,
             numberOfKnotsToBeInserted,
             multiplicityOfKnotsToBeInserted,
-            comp
+            unk
         );
     }
     return result;
@@ -60,7 +60,7 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByCoarsening(
     const gsOptionList& options,
     index_t levels,
     index_t degreesOfFreedom,
-    index_t comp
+    index_t unk
     )
 {
     gsGridHierarchy<T> result;
@@ -78,7 +78,7 @@ gsGridHierarchy<T> gsGridHierarchy<T>::buildByCoarsening(
             boundaryConditions,
             options,
             1,
-            comp
+            unk
         );
 
         index_t newSize = coarseMBasis.totalSize();


### PR DESCRIPTION
Now, one can choose the component index from the boundary conditions object that should be chosen. So far, always the component 0 was used.

Moreover, the options and the boundary conditions do not need to be stored as members.