### PR TITLE
allowed for volume averages as primals 

### DIFF
--- a/src/gsIeti/gsIetiMapper.h
+++ b/src/gsIeti/gsIetiMapper.h
@@ -117,8 +117,12 @@ public:
     /// @param geo             \a gsMultiPatch object describing the geometry
     /// @param d               The dimension of the interfaces to be considered:
     ///                        d=1 yields edge averages, d=2 yields face averages
-    ///                        Works for d=geo.dim() as well, but this is no
-    ///                        longer an interface.
+    ///
+    /// Adds contributions only iff the interface (edge, face,...) belongs to at
+    /// least two patches. This function also works if d=geo.dim(), i.e., for the
+    /// patch averages. In this case, the requirement that it contributes to
+    /// at least two patches does not apply. For corners, use \ref cornersAsPrimals
+    /// instead.
     void interfaceAveragesAsPrimals(const gsMultiPatch<T>& geo, short_t d);
 
     /// @brief With this function, the caller can register more primal constraints

--- a/src/gsIeti/gsIetiMapper.h
+++ b/src/gsIeti/gsIetiMapper.h
@@ -117,6 +117,8 @@ public:
     /// @param geo             \a gsMultiPatch object describing the geometry
     /// @param d               The dimension of the interfaces to be considered:
     ///                        d=1 yields edge averages, d=2 yields face averages
+    ///                        Works for d=geo.dim() as well, but this is no
+    ///                        longer an interface.
     void interfaceAveragesAsPrimals(const gsMultiPatch<T>& geo, short_t d);
 
     /// @brief With this function, the caller can register more primal constraints

--- a/src/gsIeti/gsIetiMapper.hpp
+++ b/src/gsIeti/gsIetiMapper.hpp
@@ -202,8 +202,8 @@ void gsIetiMapper<T>::interfaceAveragesAsPrimals(const gsMultiPatch<T>& geo, con
 {
     GISMO_ASSERT( m_status&1, "gsIetiMapper: The class has not been initialized." );
     GISMO_ASSERT( d>0, "gsIetiMapper::interfaceAveragesAsPrimals cannot handle corners." );
-    GISMO_ASSERT( d<m_multiBasis->dim(), "gsIetiMapper::interfaceAveragesAsPrimals: "
-        "Interfaces must have smaller dimension than considered object." );
+    GISMO_ASSERT( d<=m_multiBasis->dim(), "gsIetiMapper::interfaceAveragesAsPrimals: "
+        "Interfaces cannot have larger dimension than considered object." );
     GISMO_ASSERT( (index_t)(geo.nPatches()) == m_multiBasis->nPieces(),
         "gsIetiMapper::interfaceAveragesAsPrimals: The given geometry does not fit.");
     GISMO_ASSERT( geo.parDim() == m_multiBasis->dim(),
@@ -219,7 +219,7 @@ void gsIetiMapper<T>::interfaceAveragesAsPrimals(const gsMultiPatch<T>& geo, con
     for (index_t n=0; n<nComponents; ++n)
     {
         const index_t sz = components[n].size();
-        if ( sz > 1 && components[n][0].dim() == d )
+        if ( components[n][0].dim() == d && ( sz > 1 || m_multiBasis->dim() == d ))
         {
             index_t used = 0;
             for (index_t i=0; i<sz; ++i)


### PR DESCRIPTION
Allowed for volume averages as primals. 

@stefantakacs :
I tested it for the pressure and the values correspond with what I get when using generic assembler momentum (rhs).
I did not change the name (but this could be considered).
Please check that the new if statement does not make trouble for other problems.


