### PR TITLE
gsSpectra: fixed specialization for GEigsMode flag

### DIFF
--- a/extensions/gsSpectra/examples/spectra_test01.cpp
+++ b/extensions/gsSpectra/examples/spectra_test01.cpp
@@ -18,13 +18,41 @@ using namespace gismo;
 
 int main(int argc, char *argv[])
 {
-    gsMatrix<real_t> A(10,10);
-    A.setRandom();
-    A = (A + A.transpose()) * 0.5;
+    gsMatrix<real_t> Ad(10,10), Bd(10,10);
+    Ad.setRandom();
+    Ad = (Ad + Ad.transpose()) * 0.5;
+    Bd.setIdentity();
+    Bd = (Bd + Bd.transpose()) * 0.5;
 
-    gsSpectraSymSolver<gsMatrix<>> minev(A, 5, 10);
+    gsSparseMatrix<real_t> A, B;
+    A = Ad.sparseView();
+    B = Bd.sparseView();
+
+
+    gsSpectraSymSolver<gsMatrix<real_t>> minev(Ad, 5, 10);
     minev.compute(Spectra::SortRule::SmallestAlge);
     gsInfo << "Eigenvalues:" << minev.eigenvalues().transpose() <<"\n";
+
+    gsSpectraGenSymSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::Cholesky> Chsolver(A,B,5,10);
+    Chsolver.compute(Spectra::SortRule::SmallestAlge,1000,1e-3);
+    gsInfo << "Eigenvalues:" << Chsolver.eigenvalues().transpose() <<"\n";
+
+    gsSpectraGenSymSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::RegularInverse> Rsolver(A,B,5,10);
+    Rsolver.compute(Spectra::SortRule::SmallestAlge,1000,1e-3);
+    gsInfo << "Eigenvalues:" << Rsolver.eigenvalues().transpose() <<"\n";
+
+    gsSpectraGenSymShiftSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::ShiftInvert> Ssolver(A,B,5,10,1);
+    Ssolver.compute(Spectra::SortRule::SmallestAlge,1000,1e-3);
+    gsInfo << "Eigenvalues:" << Ssolver.eigenvalues().transpose() <<"\n";
+
+    gsSpectraGenSymShiftSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::Buckling> Bsolver(A,B,5,10,1);
+    Bsolver.compute(Spectra::SortRule::SmallestAlge,1000,1e-3);
+    gsInfo << "Eigenvalues:" << Bsolver.eigenvalues().transpose() <<"\n";
+
+    gsSpectraGenSymShiftSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::Cayley> Csolver(A,B,5,10,1);
+    Csolver.compute(Spectra::SortRule::SmallestAlge,1000,1e-3);
+    gsInfo << "Eigenvalues:" << Csolver.eigenvalues().transpose() <<"\n";
+
     return EXIT_SUCCESS;
 
 }//main

--- a/extensions/gsSpectra/examples/spectra_test01.cpp
+++ b/extensions/gsSpectra/examples/spectra_test01.cpp
@@ -18,7 +18,7 @@ using namespace gismo;
 
 int main(int argc, char *argv[])
 {
-    size_t sz = 10;
+    index_t sz = 10;
     gsMatrix<real_t> Ad(sz,sz);
     Ad.setRandom();
     Ad = (Ad + Ad.transpose());
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
 
     // Define the B matrix, a tridiagonal matrix with 2 on the diagonal
     // and 1 on the subdiagonals
-    for (int i = 0; i < sz; i++)
+    for (index_t i = 0; i < sz; i++)
     {
         B.insert(i, i) = 2.0;
         if (i > 0)

--- a/extensions/gsSpectra/gsSpectra.h
+++ b/extensions/gsSpectra/gsSpectra.h
@@ -20,12 +20,15 @@
 #include <Spectra/Spectra/SymEigsSolver.h>
 #include <Spectra/Spectra/SymEigsShiftSolver.h>
 #include <Spectra/Spectra/SymGEigsSolver.h>
+#include <Spectra/Spectra/SymGEigsShiftSolver.h>
 #include <Spectra/Spectra/GenEigsSolver.h>
 #include <Spectra/Spectra/GenEigsRealShiftSolver.h>
 #include <Spectra/Spectra/MatOp/SparseGenMatProd.h>
 //#include <Spectra/Spectra/MatOp/DenseSymMatProd.h> // included by SymEigsSolver.h
 #include <Spectra/Spectra/MatOp/SparseCholesky.h>
 #include <Spectra/Spectra/MatOp/DenseCholesky.h>
+#include <Spectra/Spectra/MatOp/SparseRegularInverse.h>
+#include <Spectra/Spectra/MatOp/SymShiftInvert.h>
 
 namespace gismo {
 
@@ -88,7 +91,7 @@ public:
 };
 
 
-template <class MatrixType> class SpectraOps
+template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::Cholesky> class SpectraOps
 {
 public:
     typedef Spectra::SparseCholesky<typename MatrixType::Scalar> InvOp;
@@ -96,6 +99,27 @@ public:
     SpectraMatProd<MatrixType>                           opA;
     Spectra::SparseCholesky<typename MatrixType::Scalar> opB;
 };
+
+template <class MatrixType> class SpectraOps<MatrixType,Spectra::GEigsMode::RegularInverse>
+{
+public:
+    typedef Spectra::SparseRegularInverse<typename MatrixType::Scalar> InvOp;
+    SpectraOps(const MatrixType & A, const MatrixType & B) : opA(A), opB(B) { }
+    SpectraMatProd<MatrixType>                           opA;
+    Spectra::SparseRegularInverse<typename MatrixType::Scalar> opB;
+};
+
+template <class MatrixType> class SpectraShiftOps
+{
+public:
+    typedef typename MatrixType::Scalar Scalar;
+    typedef Spectra::SymShiftInvert<typename MatrixType::Scalar> InvOp;
+    SpectraShiftOps(const MatrixType & A, const MatrixType & B) : opA(A,B), opB(B) { }
+    Spectra::SymShiftInvert<typename MatrixType::Scalar> opA;
+    SpectraMatProd<MatrixType>                           opB;
+};
+
+// Add more specializations
 
 //template<> //compilation fails with this
 template <class T> class SpectraOps<gsMatrix<T> >
@@ -110,17 +134,33 @@ protected:
 };
 
 template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::Cholesky>
-class gsSpectraGenSymSolver : private SpectraOps<MatrixType>,
-public Spectra::SymGEigsSolver<SpectraMatProd<MatrixType>, typename SpectraOps<MatrixType>::InvOp, GEigsMode>
+class gsSpectraGenSymSolver : private SpectraOps<MatrixType,GEigsMode>,
+public Spectra::SymGEigsSolver<SpectraMatProd<MatrixType>, typename SpectraOps<MatrixType,GEigsMode>::InvOp, GEigsMode>
 {
     typedef typename MatrixType::Scalar Scalar;
-    typedef SpectraOps<MatrixType> Ops;
+    typedef SpectraOps<MatrixType,GEigsMode> Ops;
     typedef SpectraMatProd<MatrixType> MatOp;
 
     typedef Spectra::SymGEigsSolver<MatOp, typename Ops::InvOp,GEigsMode> Base;
 public:
     gsSpectraGenSymSolver(const MatrixType & Amat, const MatrixType & Bmat, int nev_, int ncv_)
     : Ops(Amat,Bmat), Base(this->opA, this->opB, nev_, math::min(ncv_,Amat.rows()))
+    { Base::init(); }
+};
+
+/// NEEDS CHANGE OF SpectraOps
+template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::ShiftInvert>
+class gsSpectraGenSymShiftSolver : private SpectraShiftOps<MatrixType>,
+public Spectra::SymGEigsShiftSolver<typename SpectraShiftOps<MatrixType>::InvOp, SpectraMatProd<MatrixType>, GEigsMode>
+{
+    typedef typename MatrixType::Scalar Scalar;
+    typedef SpectraShiftOps<MatrixType> OpType;
+    typedef SpectraMatProd<MatrixType> BOpType;
+
+    typedef Spectra::SymGEigsShiftSolver<typename OpType::InvOp, BOpType,GEigsMode> Base;
+public:
+    gsSpectraGenSymShiftSolver(const MatrixType & Amat, const MatrixType & Bmat, int nev_, int ncv_, const Scalar& sigma)
+    : OpType(Amat,Bmat), Base(this->opA, this->opB, nev_, math::min(ncv_,Amat.rows()),sigma)
     { Base::init(); }
 };
 

--- a/extensions/gsSpectra/gsSpectra.h
+++ b/extensions/gsSpectra/gsSpectra.h
@@ -91,6 +91,7 @@ public:
 };
 
 
+/// For GEigsMode::Cholesky
 template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::Cholesky>
 class SpectraOps
 {
@@ -101,6 +102,7 @@ public:
     Spectra::SparseCholesky<typename MatrixType::Scalar> opB;
 };
 
+/// For GEigsMode::RegularInverse
 template <class MatrixType>
 class SpectraOps<MatrixType,Spectra::GEigsMode::RegularInverse>
 {
@@ -111,6 +113,7 @@ public:
     Spectra::SparseRegularInverse<typename MatrixType::Scalar> opB;
 };
 
+/// For GEigsMode::ShiftInvert and GEigsMode::Cayley
 template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::ShiftInvert>
 class SpectraShiftOps
 {
@@ -122,6 +125,7 @@ public:
     SpectraMatProd<MatrixType>                           opB;
 };
 
+/// Specialization for GEigsMode::Buckling
 template <class MatrixType>
 class SpectraShiftOps<MatrixType,Spectra::GEigsMode::Buckling>
 {
@@ -132,8 +136,6 @@ public:
     Spectra::SymShiftInvert<typename MatrixType::Scalar> opA;
     SpectraMatProd<MatrixType>                           opB;
 };
-
-// Add more specializations
 
 //template<> //compilation fails with this
 template <class T> class SpectraOps<gsMatrix<T> >
@@ -147,6 +149,8 @@ protected:
     InvOp opB;
 };
 
+/// GE Solver with shifts. Works for GEigsMode = Cholesky or RegularInverse.
+/// See the Spectra Documentation (SymGEigsSolver) for more information
 template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::Cholesky>
 class gsSpectraGenSymSolver : private SpectraOps<MatrixType,GEigsMode>,
 public Spectra::SymGEigsSolver<SpectraMatProd<MatrixType>, typename SpectraOps<MatrixType,GEigsMode>::InvOp, GEigsMode>
@@ -162,7 +166,8 @@ public:
     { Base::init(); }
 };
 
-/// NEEDS CHANGE OF SpectraOps
+/// GE Solver with shifts. Works for GEigsMode = ShiftInvert, Buckling or Cayley
+/// See the Spectra Documentation (SymGEigsShiftSolver) for more information
 template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::ShiftInvert>
 class gsSpectraGenSymShiftSolver : private SpectraShiftOps<MatrixType,GEigsMode>,
 public Spectra::SymGEigsShiftSolver<typename SpectraShiftOps<MatrixType,GEigsMode>::InvOp, SpectraMatProd<MatrixType>, GEigsMode>

--- a/extensions/gsSpectra/gsSpectra.h
+++ b/extensions/gsSpectra/gsSpectra.h
@@ -91,7 +91,8 @@ public:
 };
 
 
-template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::Cholesky> class SpectraOps
+template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::Cholesky>
+class SpectraOps
 {
 public:
     typedef Spectra::SparseCholesky<typename MatrixType::Scalar> InvOp;
@@ -100,7 +101,8 @@ public:
     Spectra::SparseCholesky<typename MatrixType::Scalar> opB;
 };
 
-template <class MatrixType> class SpectraOps<MatrixType,Spectra::GEigsMode::RegularInverse>
+template <class MatrixType>
+class SpectraOps<MatrixType,Spectra::GEigsMode::RegularInverse>
 {
 public:
     typedef Spectra::SparseRegularInverse<typename MatrixType::Scalar> InvOp;
@@ -109,12 +111,24 @@ public:
     Spectra::SparseRegularInverse<typename MatrixType::Scalar> opB;
 };
 
-template <class MatrixType> class SpectraShiftOps
+template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::ShiftInvert>
+class SpectraShiftOps
 {
 public:
     typedef typename MatrixType::Scalar Scalar;
     typedef Spectra::SymShiftInvert<typename MatrixType::Scalar> InvOp;
     SpectraShiftOps(const MatrixType & A, const MatrixType & B) : opA(A,B), opB(B) { }
+    Spectra::SymShiftInvert<typename MatrixType::Scalar> opA;
+    SpectraMatProd<MatrixType>                           opB;
+};
+
+template <class MatrixType>
+class SpectraShiftOps<MatrixType,Spectra::GEigsMode::Buckling>
+{
+public:
+    typedef typename MatrixType::Scalar Scalar;
+    typedef Spectra::SymShiftInvert<typename MatrixType::Scalar> InvOp;
+    SpectraShiftOps(const MatrixType & A, const MatrixType & B) : opA(A,B), opB(A) { }
     Spectra::SymShiftInvert<typename MatrixType::Scalar> opA;
     SpectraMatProd<MatrixType>                           opB;
 };
@@ -150,11 +164,11 @@ public:
 
 /// NEEDS CHANGE OF SpectraOps
 template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::ShiftInvert>
-class gsSpectraGenSymShiftSolver : private SpectraShiftOps<MatrixType>,
-public Spectra::SymGEigsShiftSolver<typename SpectraShiftOps<MatrixType>::InvOp, SpectraMatProd<MatrixType>, GEigsMode>
+class gsSpectraGenSymShiftSolver : private SpectraShiftOps<MatrixType,GEigsMode>,
+public Spectra::SymGEigsShiftSolver<typename SpectraShiftOps<MatrixType,GEigsMode>::InvOp, SpectraMatProd<MatrixType>, GEigsMode>
 {
     typedef typename MatrixType::Scalar Scalar;
-    typedef SpectraShiftOps<MatrixType> OpType;
+    typedef SpectraShiftOps<MatrixType,GEigsMode> OpType;
     typedef SpectraMatProd<MatrixType> BOpType;
 
     typedef Spectra::SymGEigsShiftSolver<typename OpType::InvOp, BOpType,GEigsMode> Base;


### PR DESCRIPTION
Previous gsSpectra did not work for changing GEigsMode template since the Cholesky was hardcoded. Changed this now for all GEigsMode templates and added the gsSpectraGenSymShiftSolver for GEigsMode::ShiftInvert, GEigsMode::Buckling and GEigsMode::Cayley

- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
