### PR TITLE
Move gsCDRAssembler::assemble to its own hpp file

### DIFF
--- a/src/gsAssembler/gsCDRAssembler.h
+++ b/src/gsAssembler/gsCDRAssembler.h
@@ -14,31 +14,37 @@
 #pragma once
 
 #include <gsAssembler/gsPoissonAssembler.h>
-#include <gsAssembler/gsAssemblerOptions.h>
-
-#include <gsAssembler/gsVisitorPoisson.h> // Stiffness volume integrals
-#include <gsAssembler/gsVisitorCDR.h> //
-#include <gsAssembler/gsVisitorNeumann.h> // Neumann boundary integrals
-#include <gsAssembler/gsVisitorNitsche.h> // Nitsche boundary integrals
-//#include <gsAssembler/gsVisitorDg.h>      // Disc. Galerkin interface integrals
-
-#include <gsPde/gsPoissonPde.h>
-
-//#include <gsAssembler/gsAssemblerUtils.h>
+#include <gsPde/gsConvDiffRePde.h>
 
 namespace gismo
 {
 
+
+/** @brief Stabililzer for the CDR discretization
+ *  @relates gsCDRAssembler
+ */
+struct stabilizerCDR
+{
+    enum method
+    {
+        SUPG = 1, ///< Use SUPG
+        none = 0  ///< Do not use a stabilizer
+    };
+};
+
+
 /** @brief
-    Implementation of an (multiple righ-hand side) Poisson solver.
-
-    The Poisson equation: \f$-\Delta\mathbf{u}=\mathbf{f} \f$
-
-    It sets up an assembler and assembles the system patch wise and combines
-    the patch-local stiffness matrices into a global system by various methods
-    (see gismo::gsInterfaceStrategy). It can also enforce Dirichlet boundary
-    conditions in various ways (see gismo::gsDirichletStrategy).
-*/
+ *  Implementation of an (multiple righ-hand side) Poisson solver.
+ *
+ *  The Poisson equation: \f$-\Delta\mathbf{u}=\mathbf{f} \f$
+ *
+ *  It sets up an assembler and assembles the system patch wise and combines
+ *  the patch-local stiffness matrices into a global system by various methods
+ *  (see gismo::gsInterfaceStrategy). It can also enforce Dirichlet boundary
+ *  conditions in various ways (see gismo::gsDirichletStrategy).
+ *
+ *  @ingroup Assembler
+ */
 template<class T>
 class gsCDRAssembler : public gsPoissonAssembler<T>
 {
@@ -48,10 +54,10 @@ public:
 public:
 
     /** @brief Main Constructor of the assembler object.
-        \param[in] pde A boundary value Poisson problem
-        \param[in] bases a multi-basis that contains patch-wise bases
-        \param[in] flagStabilization (default noStabilization)
-    */
+     *  \param[in] pde A boundary value Poisson problem
+     *  \param[in] bases a multi-basis that contains patch-wise bases
+     *  \param[in] flagStabilization (default noStabilization)
+     */
     gsCDRAssembler(const gsConvDiffRePde<T> & pde,
                    const gsMultiBasis<T>    & bases,
                    stabilizerCDR::method      flagStabilization = stabilizerCDR::none)
@@ -65,12 +71,12 @@ public:
     }
 
     /** @brief Constructor of the assembler object.
-        \param[in] pde A boundary value Poisson problem
-        \param[in] bases a multi-basis that contains patch-wise bases
-        \param[in] dirStrategy option for the treatment of Dirichlet boundary
-        \param[in] intStrategy option for the treatment of patch interfaces
-        \param[in] flagStabilization (default noStabilization)
-    */
+     *  \param[in] pde A boundary value Poisson problem
+     *  \param[in] bases a multi-basis that contains patch-wise bases
+     *  \param[in] dirStrategy option for the treatment of Dirichlet boundary
+     *  \param[in] intStrategy option for the treatment of patch interfaces
+     *  \param[in] flagStabilization (default noStabilization)
+     */
     gsCDRAssembler(const gsConvDiffRePde<T> & pde,
                    const gsMultiBasis<T>    & bases,
                    dirichlet::strategy        dirStrategy,
@@ -88,16 +94,16 @@ public:
     }
 
     /** @brief Constructor of the assembler object.
-        \param[in] patches is a gsMultiPatch object describing the geometry.
-        \param[in] bases a multi-basis that contains patch-wise bases
-        \param[in] bconditions is a gsBoundaryConditions object that holds all boundary conditions.
-        \param[in] rhs is the right-hand side of the equation, \f$\mathbf{f}\f$.
-        \param[in] coeff_A diffusion coefficient.
-        \param[in] coeff_b convection velocity.
-        \param[in] coeff_c reaction coefficient.
-        \param[in] dirStrategy option for the treatment of Dirichlet boundary
-        \param[in] intStrategy option for the treatment of patch interfaces
-        \param[in] flagStabilization (default noStabilization)
+     *  \param[in] patches is a gsMultiPatch object describing the geometry.
+     *  \param[in] bases a multi-basis that contains patch-wise bases
+     *  \param[in] bconditions is a gsBoundaryConditions object that holds all boundary conditions.
+     *  \param[in] rhs is the right-hand side of the equation, \f$\mathbf{f}\f$.
+     *  \param[in] coeff_A diffusion coefficient.
+     *  \param[in] coeff_b convection velocity.
+     *  \param[in] coeff_c reaction coefficient.
+     *  \param[in] dirStrategy option for the treatment of Dirichlet boundary
+     *  \param[in] intStrategy option for the treatment of patch interfaces
+     *  \param[in] flagStabilization (default noStabilization)
      */
     gsCDRAssembler(gsMultiPatch<T> const         & patches,
                    gsMultiBasis<T> const         & bases,
@@ -123,45 +129,7 @@ public:
     }
 
     /// Main assembly routine
-    void assemble()
-    {
-        GISMO_ASSERT(m_system.initialized(),
-                     "Sparse system is not initialized, call initialize() or refresh()");
-
-        // Reserve sparse system
-        m_system.reserve(m_bases[0], m_options, this->pde().numRhs());
-
-        // Compute the Dirichlet Degrees of freedom (if needed by m_options)
-        Base::computeDirichletDofs();
-
-        if (0 == this->numDofs()) // Are there any interior dofs ?
-        {
-            gsWarn << " No internal DOFs. Computed Dirichlet boundary only.\n" << "\n";
-            return;
-        }
-
-        // Assemble volume integrals
-        Base::template push<gsVisitorCDR<T> >();
-
-        // Enforce Neumann boundary conditions
-        Base::template push<gsVisitorNeumann<T> >(m_pde_ptr->bc().neumannSides());
-
-        // If requested, enforce Dirichlet boundary conditions by Nitsche's method
-        if (m_options.getInt("DirichletStrategy") == dirichlet::nitsche)
-            Base::template push<gsVisitorNitsche<T> >(m_pde_ptr->bc().dirichletSides());
-
-            // If requested, enforce Dirichlet boundary conditions by diagonal penalization
-        else if (m_options.getInt("DirichletStrategy") == dirichlet::penalize)
-            Base::penalizeDirichletDofs();
-
-        // If we are in in dg (Discontinuous Galerkin) mode: add
-        // interface contributions
-        if (m_options.getInt("InterfaceStrategy") == iFace::dg)
-            gsWarn << "DG option is ignored.\n";
-
-        // Assembly is done, compress the matrix
-        Base::finalize();
-    }
+    void assemble();
 
 protected:
 

--- a/src/gsAssembler/gsCDRAssembler.hpp
+++ b/src/gsAssembler/gsCDRAssembler.hpp
@@ -1,0 +1,69 @@
+/** @file gsCDRAssembler.hpp
+
+    @brief Provides assembler and solver for the Poisson equation, incl. adaptive refinement.
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): S. Kleiss, A. Mantzaflaris
+*/
+
+
+#include <gsAssembler/gsAssemblerOptions.h>
+
+#include <gsAssembler/gsVisitorPoisson.h> // Stiffness volume integrals
+#include <gsAssembler/gsVisitorCDR.h> //
+#include <gsAssembler/gsVisitorNeumann.h> // Neumann boundary integrals
+#include <gsAssembler/gsVisitorNitsche.h> // Nitsche boundary integrals
+#include <gsAssembler/gsVisitorDg.h>      // Disc. Galerkin interface integrals
+
+//#include <gsAssembler/gsAssemblerUtils.h>
+
+namespace gismo
+{
+
+template<class T>
+void gsCDRAssembler<T>::assemble()
+{
+    GISMO_ASSERT(m_system.initialized(),
+                 "Sparse system is not initialized, call initialize() or refresh()");
+
+    // Reserve sparse system
+    m_system.reserve(m_bases[0], m_options, this->pde().numRhs());
+
+    // Compute the Dirichlet Degrees of freedom (if needed by m_options)
+    Base::computeDirichletDofs();
+
+    if (0 == this->numDofs()) // Are there any interior dofs ?
+    {
+        gsWarn << " No internal DOFs. Computed Dirichlet boundary only.\n" << "\n";
+        return;
+    }
+
+    // Assemble volume integrals
+    Base::template push<gsVisitorCDR<T> >();
+
+    // Enforce Neumann boundary conditions
+    Base::template push<gsVisitorNeumann<T> >(m_pde_ptr->bc().neumannSides());
+
+    // If requested, enforce Dirichlet boundary conditions by Nitsche's method
+    if (m_options.getInt("DirichletStrategy") == dirichlet::nitsche)
+        Base::template push<gsVisitorNitsche<T> >(m_pde_ptr->bc().dirichletSides());
+
+    // If requested, enforce Dirichlet boundary conditions by diagonal penalization
+    else if (m_options.getInt("DirichletStrategy") == dirichlet::penalize)
+            Base::penalizeDirichletDofs();
+
+    // If we are in in dg (Discontinuous Galerkin) mode: add
+    // interface contributions
+    if (m_options.getInt("InterfaceStrategy") == iFace::dg)
+        gsWarn << "DG option is ignored.\n";
+
+    // Assembly is done, compress the matrix
+    Base::finalize();
+}
+
+} // namespace gismo

--- a/src/gsAssembler/gsCDRAssembler_.cpp
+++ b/src/gsAssembler/gsCDRAssembler_.cpp
@@ -1,0 +1,10 @@
+
+#include <gsCore/gsTemplateTools.h>
+
+#include <gsAssembler/gsCDRAssembler.h>
+#include <gsAssembler/gsCDRAssembler.hpp>
+
+namespace gismo
+{
+    CLASS_TEMPLATE_INST gsCDRAssembler<real_t>;
+}

--- a/src/gsAssembler/gsVisitorCDR.h
+++ b/src/gsAssembler/gsVisitorCDR.h
@@ -32,17 +32,8 @@ namespace gismo
  * Obviously, setting \f$ A= I\f$, \f$ b= 0\f$, and \f$c = 0\f$ results
  * in the special case of the Poisson equation.
  *
+ * \ingroup Assembler
  */
-
-struct stabilizerCDR
-{
-    enum method
-    {
-        SUPG = 1,
-        none = 0
-    };
-};
-
 template <class T>
 class gsVisitorCDR
 {
@@ -50,17 +41,17 @@ public:
 
 
     gsVisitorCDR(const gsPde<T> & pde)
-    { 
+    {
         const gsConvDiffRePde<T>* cdr =
             static_cast<const gsConvDiffRePde<T>*>(&pde);
-        
+
         coeff_A_ptr = cdr->diffusion ();
         coeff_b_ptr = cdr->convection();
         coeff_c_ptr = cdr->reaction  ();
         rhs_ptr     = cdr->rhs       ();
 
         flagStabType = stabilizerCDR::none;
-        
+
         GISMO_ASSERT( rhs_ptr->targetDim() == 1 ,
                       "Not yet tested for multiple right-hand-sides");
     }
@@ -142,7 +133,7 @@ public:
         localRhs.setZero(numActive, rhsVals.rows());//multiple right-hand sides
     }
 
-    
+
     inline void assemble(gsDomainIterator<T>    & element,
                          const gsVector<T>      & quWeights)
     {
@@ -416,4 +407,3 @@ protected:
 
 
 } // namespace gismo
-


### PR DESCRIPTION
With this change we do not need to recompile everything if, e.g., gsVisitorDG, is changed