### PR TITLE
Improvements for gsVisitorDg and gsVisitorNitsche and others

### DIFF
--- a/src/gsAssembler/gsAssembler.h
+++ b/src/gsAssembler/gsAssembler.h
@@ -489,6 +489,7 @@ public: /* Element visitors */
         }
     }
 
+
 public:  /* Dirichlet degrees of freedom computation */
 
     /// @brief Triggers computation of the Dirichlet dofs

--- a/src/gsAssembler/gsAssembler.h
+++ b/src/gsAssembler/gsAssembler.h
@@ -480,7 +480,7 @@ public: /* Element visitors */
         for ( typename gsMultiPatch<T>::const_iiterator
                   it = mp.iBegin(); it != mp.iEnd(); ++it )
         {
-            const boundaryInterface & iFace = //recover master elemen
+            const boundaryInterface & iFace = //recover master element
                 ( m_bases[0][it->first() .patch].numElements(it->first() .side() ) <
                   m_bases[0][it->second().patch].numElements(it->second().side() ) ?
                   it->getInverse() : *it );
@@ -488,7 +488,6 @@ public: /* Element visitors */
             this->apply(visitor, iFace);
         }
     }
-
 
 public:  /* Dirichlet degrees of freedom computation */
 

--- a/src/gsAssembler/gsBiharmonicAssembler.h
+++ b/src/gsAssembler/gsBiharmonicAssembler.h
@@ -1,6 +1,6 @@
 /** @file gsBiharmonicAssembler.h
 
-    @brief Provides assembler for a homogenius Biharmonic equation.
+    @brief Provides assembler for a homogeneous Biharmonic equation.
 
     This file is part of the G+Smo library.
 
@@ -15,16 +15,14 @@
 #pragma once
 
 #include <gsAssembler/gsAssembler.h>
-
 #include <gsPde/gsBiharmonicPde.h>
 
-#include <gsAssembler/gsVisitorBiharmonic.h>
-#include <gsAssembler/gsVisitorNeumann.h>
-#include <gsAssembler/gsVisitorNeumannBiharmonic.h>
-//#include <gsAssembler/gsVisitorNitscheBiharmonic.h>
 
 namespace gismo
 {
+
+// Forward declaration
+template <class T> class gsVisitorBiharmonic;
 
 /** @brief
     Implementation of a homogeneous Biharmonic Assembler.
@@ -87,52 +85,10 @@ protected:
     using Base::m_system;
 };
 
-template <class T, class bhVisitor>
-void gsBiharmonicAssembler<T,bhVisitor>::refresh()
-{
-    // We use predefined helper which initializes the system matrix
-    // rows and columns using the same test and trial space
-    Base::scalarProblemGalerkinRefresh();
-}
-
-template <class T, class bhVisitor>
-void gsBiharmonicAssembler<T,bhVisitor>::assemble()
-{
-    GISMO_ASSERT(m_system.initialized(), "Sparse system is not initialized, call refresh()");
-
-    // Reserve sparse system
-    const index_t nz = gsAssemblerOptions::numColNz(m_bases[0][0],2,1,0.333333);
-    m_system.reserve(nz, this->pde().numRhs());
-
-    // Compute the Dirichlet Degrees of freedom (if needed by m_options)
-    Base::computeDirichletDofs();
-    
-    // Assemble volume integrals
-    Base::template push<bhVisitor >();
-    
-    // Newman conditions of first kind
-    Base::template push<gsVisitorNeumann<T> >(
-        m_ppde.bcFirstKind().neumannSides() );
-    
-    // Newman conditions of second kind
-    Base::template push<gsVisitorNeumannBiharmonic<T> >(
-        m_ppde.bcSecondKind().neumannSides() );
-
-    if ( m_options.getInt("InterfaceStrategy") == iFace::dg )
-        gsWarn <<"DG option ignored.\n";
-
-    /*
-    // If requested, force Dirichlet boundary conditions by Nitsche's method
-    this->template push<gsVisitorNitscheBiharmonic<T> >(
-    m_ppde.bcSecondKind().dirichletSides() );
-    */
-    
-    // Assembly is done, compress the matrix
-    Base::finalize();
-}
-
-
 } // namespace gismo
 
 
+#ifndef GISMO_BUILD_LIB
+#include GISMO_HPP_HEADER(gsBiharmonicAssembler.hpp)
+#endif
 

--- a/src/gsAssembler/gsBiharmonicAssembler.hpp
+++ b/src/gsAssembler/gsBiharmonicAssembler.hpp
@@ -1,0 +1,67 @@
+/** @file gsBiharmonicAssembler.hpp
+
+    @brief Provides assembler for a homogenius Biharmonic equation.
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): J. Sogn
+*/
+
+#include <gsAssembler/gsVisitorBiharmonic.h>
+#include <gsAssembler/gsVisitorNeumann.h>
+#include <gsAssembler/gsVisitorNeumannBiharmonic.h>
+//#include <gsAssembler/gsVisitorNitscheBiharmonic.h>
+
+namespace gismo
+{
+
+template <class T, class bhVisitor>
+void gsBiharmonicAssembler<T,bhVisitor>::refresh()
+{
+    // We use predefined helper which initializes the system matrix
+    // rows and columns using the same test and trial space
+    Base::scalarProblemGalerkinRefresh();
+}
+
+template <class T, class bhVisitor>
+void gsBiharmonicAssembler<T,bhVisitor>::assemble()
+{
+    GISMO_ASSERT(m_system.initialized(), "Sparse system is not initialized, call refresh()");
+
+    // Reserve sparse system
+    const index_t nz = gsAssemblerOptions::numColNz(m_bases[0][0],2,1,0.333333);
+    m_system.reserve(nz, this->pde().numRhs());
+
+    // Compute the Dirichlet Degrees of freedom (if needed by m_options)
+    Base::computeDirichletDofs();
+
+    // Assemble volume integrals
+    Base::template push<bhVisitor >();
+
+    // Neumann conditions of first kind
+    Base::template push<gsVisitorNeumann<T> >(
+        m_ppde.bcFirstKind().neumannSides() );
+
+    // Neumann conditions of second kind
+    Base::template push<gsVisitorNeumannBiharmonic<T> >(
+        m_ppde.bcSecondKind().neumannSides() );
+
+    if ( m_options.getInt("InterfaceStrategy") == iFace::dg )
+        gsWarn <<"DG option ignored.\n";
+
+    /*
+    // If requested, force Dirichlet boundary conditions by Nitsche's method
+    this->template push<gsVisitorNitscheBiharmonic<T> >(
+    m_ppde.bcSecondKind().dirichletSides() );
+    */
+
+    // Assembly is done, compress the matrix
+    Base::finalize();
+}
+
+
+} // namespace gismo

--- a/src/gsAssembler/gsBiharmonicAssembler_.cpp
+++ b/src/gsAssembler/gsBiharmonicAssembler_.cpp
@@ -1,0 +1,10 @@
+
+#include <gsCore/gsTemplateTools.h>
+
+#include <gsAssembler/gsBiharmonicAssembler.h>
+#include <gsAssembler/gsBiharmonicAssembler.hpp>
+
+namespace gismo
+{
+    CLASS_TEMPLATE_INST gsBiharmonicAssembler<real_t, gsVisitorBiharmonic<real_t> >;
+}

--- a/src/gsAssembler/gsCDRAssembler.h
+++ b/src/gsAssembler/gsCDRAssembler.h
@@ -53,6 +53,9 @@ public:
 
 public:
 
+    /// Returns the list of default options for assembly
+    static gsOptionList defaultOptions();
+
     /** @brief Main Constructor of the assembler object.
      *  \param[in] pde A boundary value Poisson problem
      *  \param[in] bases a multi-basis that contains patch-wise bases
@@ -66,6 +69,7 @@ public:
 
         // 0: no stabilization
         // 1: SUPG
+        m_options = defaultOptions();
         m_options.addInt("Stabilization", "Choice of stabilization method; 0 := no; 1 := SUPG;", flagStabilization);
         Base::initialize(pde, bases, m_options);
     }
@@ -83,6 +87,7 @@ public:
                    iFace::strategy            intStrategy = iFace::glue,
                    stabilizerCDR::method      flagStabilization = stabilizerCDR::none)
     {
+        m_options = defaultOptions();
         m_options.setInt("DirichletStrategy", dirStrategy);
         m_options.setInt("InterfaceStrategy", intStrategy);
 
@@ -116,6 +121,7 @@ public:
                    iFace::strategy                 intStrategy = iFace::glue,
                    stabilizerCDR::method           flagStabilization = stabilizerCDR::none)
     {
+        m_options = defaultOptions();
         m_options.setInt("DirichletStrategy", dirStrategy);
         m_options.setInt("InterfaceStrategy", intStrategy);
 

--- a/src/gsAssembler/gsCDRAssembler.hpp
+++ b/src/gsAssembler/gsCDRAssembler.hpp
@@ -18,12 +18,19 @@
 #include <gsAssembler/gsVisitorCDR.h> //
 #include <gsAssembler/gsVisitorNeumann.h> // Neumann boundary integrals
 #include <gsAssembler/gsVisitorNitsche.h> // Nitsche boundary integrals
-#include <gsAssembler/gsVisitorDg.h>      // Disc. Galerkin interface integrals
 
 //#include <gsAssembler/gsAssemblerUtils.h>
 
 namespace gismo
 {
+
+template <class T>
+gsOptionList gsCDRAssembler<T>::defaultOptions()
+{
+    gsOptionList options = gsAssembler<T>::defaultOptions();
+    options.update( gsVisitorNitsche<T>::defaultOptions(), gsOptionList::addIfUnknown );
+    return options;
+}
 
 template<class T>
 void gsCDRAssembler<T>::assemble()

--- a/src/gsAssembler/gsDirichletValues.h
+++ b/src/gsAssembler/gsDirichletValues.h
@@ -1,4 +1,18 @@
-#include <gsUtils/gsPointGrid.h>
+/** @file gsDirichletValues.h
+
+    @brief
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): A. Mantzaflaris
+*/
+
+#include<gsUtils/gsPointGrid.h>
+
 namespace gismo {
 
 namespace expr

--- a/src/gsAssembler/gsDirichletValues.h
+++ b/src/gsAssembler/gsDirichletValues.h
@@ -11,7 +11,7 @@
     Author(s): A. Mantzaflaris
 */
 
-#include<gsUtils/gsPointGrid.h>
+#include <gsUtils/gsPointGrid.h>
 
 namespace gismo {
 

--- a/src/gsAssembler/gsGenericAssembler.h
+++ b/src/gsAssembler/gsGenericAssembler.h
@@ -198,3 +198,4 @@ private:
 
 
 } // namespace gismo
+

--- a/src/gsAssembler/gsGenericAssembler.h
+++ b/src/gsAssembler/gsGenericAssembler.h
@@ -14,13 +14,7 @@
 #pragma once
 
 #include <gsAssembler/gsAssembler.h>
-#include <gsAssembler/gsVisitorMass.h>
-//#include <gsAssembler/gsVisitorTPmass.h>
-#include <gsAssembler/gsVisitorGradGrad.h>
-#include <gsAssembler/gsVisitorMoments.h>
-
 #include <gsPde/gsLaplacePde.h>
-
 
 #include <gsAssembler/gsExpressions.h>
 #include <gsAssembler/gsExprHelper.h>
@@ -29,12 +23,11 @@
 namespace gismo
 {
 
-/**
-   @brief Assembles the mass, stiffness matrix on a given domain
+   /** @brief Assembles mass and stiffness matrices and right-hand sides on a given domain
+     *
+     * @ingroup Assembler
+     */
 
-   
-   \ingroup Assembler
- */
 template <class T>
 class gsGenericAssembler : public gsAssembler<T>
 {
@@ -43,10 +36,18 @@ public:
 
 public:
 
-    /// Constructor with gsMultiBasis
-    gsGenericAssembler( const gsMultiPatch<T>    & patches,
-                        const gsMultiBasis<T>    & bases,
-                        const gsOptionList & opt = Base::defaultOptions(),
+    /// Returns the list of default options for assembly
+    static gsOptionList defaultOptions();
+
+    /// @brief Constructor
+    ///
+    /// @param  patches   The geometry as \a gsMultiPatch
+    /// @param  bases     The bases as \a gsMultiBasis
+    /// @param  opt       The assembler options
+    /// @param  bc        The boundary conditons (used for setting up \a gsDofMapper)
+    gsGenericAssembler( const gsMultiPatch<T>         & patches,
+                        const gsMultiBasis<T>         & bases,
+                        const gsOptionList            & opt = defaultOptions(),
                         const gsBoundaryConditions<T> * bc = NULL)
     : m_pde(patches)
     {
@@ -55,7 +56,7 @@ public:
             m_pde.boundaryConditions() = *bc;
             this->m_ddof.resize(1);
         }
-        
+
         Base::initialize(m_pde, bases, opt);
         gsGenericAssembler::refresh();
     }
@@ -74,6 +75,7 @@ public:
     }
     */
 
+    /// Refreshes the sparse system (deletes assembled matrices and vectors)
     void refresh()
     {
         // Setup sparse system
@@ -88,52 +90,28 @@ public:
         //        m_system.reserve(nz, 1);
     }
 
-    /// Mass assembly routine
-    const gsSparseMatrix<T> & assembleMass()
+    /// Refreshes the sparse system based on given dof mapper
+    void refresh(gsDofMapper mapper)
     {
-        /*
-        typedef gsExprAssembler<>::geometryMap geometryMap;
-        typedef gsExprAssembler<>::variable    variable;
-        typedef gsExprAssembler<>::space       space;
-        typedef gsExprAssembler<>::solution    solution;
-        
-        // Elements used for numerical integration
-        gsExprAssembler<> A(1,1);
-        A.setIntegrationElements(m_bases.front());
-        geometryMap G = A.getMap(m_pde_ptr->patches());
-        space u = A.getSpace(m_bases.front());
-
-        A.initSystem();
-        //m_system.matrix() = A.assemble( u * u.tr() * meas(G) );
-        A.assemble( u * u.tr() * meas(G) );
-        m_system.matrix() = A.matrix();
-        
-        return m_system.matrix();
-        */
-
-        // Clean the sparse system
-        gsGenericAssembler::refresh();
-        const index_t nz = gsAssemblerOptions::numColNz(m_bases[0][0],2,1,0.333333);
-        m_system.matrix().reservePerColumn(nz);
-        
-        // Assemble mass integrals
-        //this->template push<gsVisitorMass<T> >();
-        this->template push<gsVisitorMass<T> >();
-
-        // Assembly is done, compress the matrix
-        this->finalize();
-
-        return m_system.matrix();
+         m_system = gsSparseSystem<T>(mapper);
     }
 
-        /// Mass assembly routine
+    /// @brief Mass assembly routine
+    ///
+    /// @param patchIndex   If non-negative, only assemble matrix for specified patch
+    /// @param refresh      Calles member refresh
+    const gsSparseMatrix<T> & assembleMass(const index_t patchIndex = -1, bool refresh = true);
+
+    /// @brief Mass assembly routine
+    ///
+    /// This routine uses the expression assembler and always overwrites already assembled matrices.
     const gsSparseMatrix<T> & assembleMass2()
     {
         typedef gsExprAssembler<>::geometryMap geometryMap;
         typedef gsExprAssembler<>::variable    variable;
         typedef gsExprAssembler<>::space       space;
         typedef gsExprAssembler<>::solution    solution;
-        
+
         // Elements used for numerical integration
         gsExprAssembler<> A(1,1);
         A.setIntegrationElements(m_bases.front());
@@ -144,77 +122,47 @@ public:
         //m_system.matrix() = A.assemble( u * u.tr() * meas(G) );
         A.assemble( u * u.tr() * meas(G) );
         m_system.matrix() = A.matrix();
-        
-        return m_system.matrix();
-    }
-
-    /*// Mass assembly routine
-    const gsSparseMatrix<T> & assembleMass3()
-    {
-        // Clean the sparse system
-        gsGenericAssembler::refresh();
-        
-        //this->template push<gsVisitorTPmass<T> >();
-        this->finalize();
-        return m_system.matrix();
-    }
-    */
-
-    /// Stiffness assembly routine
-    const gsSparseMatrix<T> & assembleStiffness()
-    {
-        // Clean the sparse system
-        gsGenericAssembler::refresh();
-        const index_t nz = gsAssemblerOptions::numColNz(m_bases[0][0],2,1,0.333333);
-        m_system.matrix().reservePerColumn(nz);
-
-        // Assemble stiffness integrals
-        this->template push<gsVisitorGradGrad<T> >();
-
-        // Assembly is done, compress the matrix
-        this->finalize();
 
         return m_system.matrix();
     }
 
-    /// Moments assembly routine
-    const gsMatrix<T> & assembleMoments(const gsFunction<T> & func)
-    {
-        // Reset the right-hand side vector
-        m_system.rhs().setZero(m_system.cols(), 1);
+    /// @brief Stiffness assembly routine
+    ///
+    /// @param patchIndex   If non-negative, only assemble matrix for specified patch
+    /// @param refresh      Calles member refresh
+    const gsSparseMatrix<T> & assembleStiffness(const index_t patchIndex = -1, const bool refresh = true);
 
-        // Assemble moment integrals
-        gsVisitorMoments<T> mom(func);
-        this->push(mom);
-        
-        // Assembly is done, compress the matrix
-        this->finalize();
+    /// @brief Moments assembly routine
+    ///
+    /// @param func         Right-hand-side (source) function
+    /// @param patchIndex   If non-negative, only assemble matrix for specified patch
+    /// @param refresh      Calles member refresh
+    const gsMatrix<T> & assembleMoments(const gsFunction<T> & func, index_t patchIndex = -1, bool refresh = true);
 
-        return m_system.rhs();
-    }
+    /// @brief Assemble dG interface terms
+    ///
+    /// @param iFace        The interface for which assembling is done
+    /// @param refresh      Calles member refresh
+    /// See \a gsVisiorDg for possible options
+    const gsSparseMatrix<T> & assembleDG(const boundaryInterface & iFace, bool refresh = true);
 
-    /// Stiffness assembly routine on patch \a patchIndex
-    const gsSparseMatrix<T> & assembleMass(index_t patchIndex)
-    {
-        gsGenericAssembler<T> tmp(m_pde.patches().patch(patchIndex), 
-                                  m_bases[patchIndex], m_options);
-        tmp.assembleMass();
-        m_system.matrix().swap(tmp.m_system.matrix());
-        return m_system.matrix();
-    }
+    /// @brief Assemble Neumann boundary terms
+    ///
+    /// @param bc           The boundary condition for which assembling is done
+    /// @param refresh      Calles member refresh
+    const gsSparseMatrix<T> & assembleNeumann(const boundary_condition<T> & bc, bool refresh = true);
 
-    /// Stiffness assembly routine on patch \a patchIndex
-    const gsSparseMatrix<T> & assembleStiffness(index_t patchIndex)
-    {
-        gsGenericAssembler<T> tmp(m_pde.patches().patch(patchIndex), 
-                                  m_bases[patchIndex],  m_options);
-        tmp.assembleStiffness();
-        m_system.matrix().swap(tmp.m_system.matrix());
-        return m_system.matrix();
-    }
-    
-    /// Returns an expression of the "full" assembled sparse
-    /// matrix. Note that matrix() might return a lower diagonal
+    /// @brief Assemble Nitsche terms for weakly imposing Dirichlet conditions
+    ///
+    /// @param bc           The boundary condition for which assembling is done
+    /// @param refresh      Calles member refresh
+    ///
+    /// See \a gsVisiorNitsche for possible options
+    const gsSparseMatrix<T> & assembleNitsche(const boundary_condition<T> & bc, bool refresh = true);
+
+    /// @brief Returns an expression of the "full" assembled sparse matrix.
+    ///
+    /// Note that matrix() might return a lower diagonal
     /// matrix, if we exploit possible symmetry during assembly
     /// (check: m_matrix.symmetry() == true )
     typename gsSparseMatrix<T>::fullView fullMatrix()
@@ -222,15 +170,16 @@ public:
         return m_system.matrix().template selfadjointView<Lower>();
     }
 
-    /// Returns an expression of the "full" assembled sparse
-    /// matrix. Note that matrix() might return a lower diagonal
+    /// @brief Returns an expression of the "full" assembled sparse matrix.
+    ///
+    /// Note that matrix() might return a lower diagonal
     /// matrix, if we exploit possible symmetry during assembly
     /// (check: m_matrix.symmetry() == true )
     const typename gsSparseMatrix<T>::constFullView fullMatrix() const
     {
         return m_system.matrix().template selfadjointView<Lower>();
     }
-    
+
 
 private:
 
@@ -249,4 +198,3 @@ private:
 
 
 } // namespace gismo
-

--- a/src/gsAssembler/gsGenericAssembler.hpp
+++ b/src/gsAssembler/gsGenericAssembler.hpp
@@ -1,0 +1,183 @@
+/** @file gsGenericAssembler.h
+
+    @brief Provides an assembler for common IGA matrices
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): S. Kleiss, A. Mantzaflaris
+*/
+
+#pragma once
+
+#include <gsAssembler/gsAssembler.h>
+#include <gsAssembler/gsVisitorMass.h>
+#include <gsAssembler/gsVisitorGradGrad.h>
+#include <gsAssembler/gsVisitorMoments.h>
+#include <gsAssembler/gsVisitorDg.h>
+#include <gsAssembler/gsVisitorNeumann.h>
+#include <gsAssembler/gsVisitorNitsche.h>
+
+namespace gismo
+{
+
+template <class T>
+gsOptionList gsGenericAssembler<T>::defaultOptions()
+{
+    gsOptionList options = gsAssembler<T>::defaultOptions();
+    options.update( gsVisitorDg<T>::defaultOptions(), gsOptionList::addIfUnknown );
+    options.update( gsVisitorNitsche<T>::defaultOptions(), gsOptionList::addIfUnknown );
+    return options;
+}
+
+template <class T>
+const gsSparseMatrix<T> & gsGenericAssembler<T>::assembleMass(const index_t patchIndex, const bool refresh)
+{
+    // Clean the sparse system
+    if (refresh)
+    {
+        gsGenericAssembler::refresh();
+        m_system.reserve(m_bases[0], m_options, 1);
+        Base::computeDirichletDofs();
+    }
+
+    // Assemble mass integrals
+    if ( patchIndex < 0 )
+    {
+        this->template push<gsVisitorMass<T> >();
+    }
+    else
+    {
+        gsVisitorMass<T> visitor(*m_pde_ptr);
+        this->apply(visitor, patchIndex);
+    }
+
+    // Assembly is done, compress the matrix
+    this->finalize();
+
+    return m_system.matrix();
+}
+
+template <class T>
+const gsSparseMatrix<T> & gsGenericAssembler<T>::assembleStiffness(const index_t patchIndex, const bool refresh)
+{
+    // Clean the sparse system
+    if (refresh)
+    {
+        gsGenericAssembler::refresh();
+        m_system.reserve(m_bases[0], m_options, 1);
+        Base::computeDirichletDofs();
+    }
+
+    // Assemble stiffness integrals
+    if ( patchIndex < 0 )
+    {
+        this->template push<gsVisitorGradGrad<T> >();
+    }
+    else
+    {
+        gsVisitorGradGrad<T> visitor(*m_pde_ptr);
+        this->apply(visitor, patchIndex);
+    }
+
+    // Assembly is done, compress the matrix
+    this->finalize();
+
+    return m_system.matrix();
+}
+
+template <class T>
+const gsMatrix<T> & gsGenericAssembler<T>::assembleMoments(const gsFunction<T> & func, const index_t patchIndex, const bool refresh)
+{
+    // Clean the sparse system
+    if (refresh)
+    {
+        gsGenericAssembler::refresh();
+        m_system.rhs().setZero(m_system.cols(), 1);
+    }
+
+    // Assemble moment integrals
+    gsVisitorMoments<T> mom(func);
+    if (patchIndex<0)
+        this->push(mom);
+    else
+        this->apply(mom,patchIndex);
+
+    // Assembly is done, compress the matrix
+    this->finalize();
+
+    return m_system.rhs();
+}
+
+template <class T>
+const gsSparseMatrix<T> & gsGenericAssembler<T>::assembleDG(const boundaryInterface & iFace, const bool refresh)
+{
+    GISMO_ENSURE( m_options.getInt("InterfaceStrategy")==iFace::dg,
+        "Assembling DG terms only makes sense in corresponding setting." );
+
+    // Clean the sparse system
+    if (refresh)
+    {
+        gsGenericAssembler::refresh();
+        m_system.reserve(m_bases[0], m_options, 1);
+        Base::computeDirichletDofs();
+    }
+
+    gsVisitorDg<T> visitor(*m_pde_ptr);
+    this->apply(visitor, iFace);
+
+    // Assembly is done, compress the matrix
+    this->finalize();
+
+    return m_system.matrix();
+}
+
+template <class T>
+const gsSparseMatrix<T> & gsGenericAssembler<T>::assembleNeumann(const boundary_condition<T> & bc, const bool refresh)
+{
+    GISMO_ASSERT( bc.ctype() == "Neumann", "gsGenericAssembler::assembleNeumann: Got " << bc.ctype() << "bc.");
+
+    // Clean the sparse system
+    if (refresh)
+    {
+        gsGenericAssembler::refresh();
+        m_system.rhs().setZero(m_system.cols(), 1);
+    }
+
+    gsVisitorNeumann<T> visitor(*m_pde_ptr,bc);
+    this->apply(visitor, bc.patch(), bc.side());
+
+    // Assembly is done, compress the matrix
+    this->finalize();
+
+    return m_system.matrix();
+}
+
+template <class T>
+const gsSparseMatrix<T> & gsGenericAssembler<T>::assembleNitsche(const boundary_condition<T> & bc, const bool refresh)
+{
+    GISMO_ASSERT( bc.ctype() == "Dirichlet", "gsGenericAssembler::assembleNitsche: Got " << bc.ctype() << "bc.");
+
+    // Clean the sparse system
+    if (refresh)
+    {
+        gsGenericAssembler::refresh();
+        m_system.reserve(m_bases[0], m_options, 1);
+        Base::computeDirichletDofs();
+    }
+
+
+    gsVisitorNitsche<T> visitor(*m_pde_ptr,bc);
+    this->apply(visitor, bc.patch(), bc.side());
+
+    // Assembly is done, compress the matrix
+    this->finalize();
+
+    return m_system.matrix();
+}
+
+
+} // namespace gismo

--- a/src/gsAssembler/gsGenericAssembler_.cpp
+++ b/src/gsAssembler/gsGenericAssembler_.cpp
@@ -1,0 +1,10 @@
+
+#include <gsCore/gsTemplateTools.h>
+
+#include <gsAssembler/gsGenericAssembler.h>
+#include <gsAssembler/gsGenericAssembler.hpp>
+
+namespace gismo
+{
+    CLASS_TEMPLATE_INST gsGenericAssembler<real_t>;
+}

--- a/src/gsAssembler/gsHeatEquation.h
+++ b/src/gsAssembler/gsHeatEquation.h
@@ -43,7 +43,7 @@ public:
        m_stationary(&stationary), m_theta(0.5)
     {
         m_options.addReal("theta",
-        "Theta parameter determining the time integration scheme[0..1]", m_theta);
+        "Theta parameter determining the time integration scheme [0..1]", m_theta);
     }
 
 public:
@@ -208,7 +208,7 @@ void gsHeatEquation<T>::assembleMass()
 
     // Pre-allocate non-zero elements for each column of the
     // sparse matrix
-    m_system.reserve(m_bases[0], m_options, 0);// zero rhs's
+    m_system.reserve(m_bases[0], m_options, 1);// zero rhs's
 
     // Assemble mass integrals
     gsVisitorMass<T> mass;

--- a/src/gsAssembler/gsHeatEquation.h
+++ b/src/gsAssembler/gsHeatEquation.h
@@ -12,7 +12,7 @@
 */
 
 #pragma once
-
+#include <gsAssembler/gsVisitorMass.h>
 
 namespace gismo
 {

--- a/src/gsAssembler/gsPoissonAssembler.h
+++ b/src/gsAssembler/gsPoissonAssembler.h
@@ -40,6 +40,9 @@ public:
 
 public:
 
+    /// Returns the list of default options for assembly
+    static gsOptionList defaultOptions();
+
     gsPoissonAssembler()
     { }
 
@@ -51,6 +54,7 @@ public:
     gsPoissonAssembler( const gsPoissonPde<T>          & pde,
                         const gsMultiBasis<T>          & bases)
     {
+        m_options = defaultOptions();
         Base::initialize(pde, bases, m_options);
     }
 
@@ -67,6 +71,7 @@ public:
                         dirichlet::strategy           dirStrategy,
                         iFace::strategy               intStrategy = iFace::glue)
     {
+        m_options = defaultOptions();
         m_options.setInt("DirichletStrategy", dirStrategy);
         m_options.setInt("InterfaceStrategy", intStrategy);
 
@@ -92,6 +97,7 @@ public:
                         dirichlet::strategy           dirStrategy = dirichlet::elimination,
                         iFace::strategy               intStrategy = iFace::glue)
     {
+        m_options = defaultOptions();
         m_options.setInt("DirichletStrategy", dirStrategy);
         m_options.setInt("InterfaceStrategy", intStrategy);
 

--- a/src/gsAssembler/gsPoissonAssembler.hpp
+++ b/src/gsAssembler/gsPoissonAssembler.hpp
@@ -20,6 +20,15 @@
 namespace gismo
 {
 
+template <class T>
+gsOptionList gsPoissonAssembler<T>::defaultOptions()
+{
+    gsOptionList options = gsAssembler<T>::defaultOptions();
+    options.update( gsVisitorDg<T>::defaultOptions(), gsOptionList::addIfUnknown );
+    options.update( gsVisitorNitsche<T>::defaultOptions(), gsOptionList::addIfUnknown );
+    return options;
+}
+
 template<class T>
 void gsPoissonAssembler<T>::refresh()
 {

--- a/src/gsAssembler/gsVisitorBiharmonic.h
+++ b/src/gsAssembler/gsVisitorBiharmonic.h
@@ -13,37 +13,43 @@
 
 #pragma once
 
+#include <gsAssembler/gsQuadrature.h>
+
 namespace gismo
 {
 
-/** \brief Visitor for the biharmonic equation.
- *
- * Assembles the bilinear terms
- * \f[ (\Delta u,\Delta v)_\Omega \text{ and } (f,v)_\Omega \f]
- * For \f[ u = g \quad on \quad \partial \Omega \f],
- *
- */
+   /** @brief Visitor for the biharmonic equation.
+     *
+     * Assembles the bilinear form
+     * \f[ (\Delta u,\Delta v)_\Omega \f]
+     * And the linear form
+     * \f[ (f,v)_\Omega. \f]
+     *
+     * @ingroup Assembler
+     */
 
 template <class T>
 class gsVisitorBiharmonic
 {
 public:
 
+    /// @brief Constructor
+    ///
+    /// @param pde     Reference to \a gsBiharmonicPde object
     gsVisitorBiharmonic(const gsPde<T> & pde)
-    { 
-        rhs_ptr = static_cast<const gsBiharmonicPde<T>&>(pde).rhs() ;
-    }
+       : rhs_ptr(static_cast<const gsBiharmonicPde<T>&>(pde).rhs())
+    {}
 
-    /** \brief Constructor for gsVisitorBiharmonic.
-     *
-     * \param[in] rhs Given right-hand-side function/source term that, for
-     */
-    gsVisitorBiharmonic(const gsFunction<T> & rhs) :
-        rhs_ptr(&rhs)
+    /// @brief Constructor
+    ///
+    /// @param rhs Right-hand-side function/source term
+    gsVisitorBiharmonic(const gsFunction<T> & rhs)
+        : rhs_ptr(&rhs)
     {
-        GISMO_ASSERT( rhs.targetDim() == 1 ,"Not yet tested for multiple right-hand-sides");
+        GISMO_ASSERT( rhs.targetDim() == 1, "Not yet tested for multiple right-hand-sides");
     }
 
+    /// Initialize
     void initialize(const gsBasis<T> & basis,
                     gsQuadRule<T>    & rule)
     {
@@ -58,9 +64,10 @@ public:
         md.flags = NEED_VALUE | NEED_MEASURE | NEED_GRAD_TRANSFORM | NEED_2ND_DER;
     }
 
+    /// Initialize
     void initialize(const gsBasis<T> & basis,
                     const index_t ,
-                    const gsOptionList & options, 
+                    const gsOptionList & options,
                     gsQuadRule<T>    & rule)
     {
         // Setup Quadrature
@@ -70,7 +77,7 @@ public:
         md.flags = NEED_VALUE | NEED_MEASURE | NEED_GRAD_TRANSFORM | NEED_2ND_DER;
     }
 
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>       & basis, // to do: more unknowns
                          const gsGeometry<T>    & geo,
                          gsMatrix<T>            & quNodes)
@@ -98,7 +105,7 @@ public:
         localRhs.setZero(numActive, rhsVals.rows());//multiple right-hand sides
     }
 
-
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & ,
                          const gsVector<T>      & quWeights)
     {
@@ -121,6 +128,7 @@ public:
         }
     }
 
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t                     patchIndex,
                               const std::vector<gsMatrix<T> > & eliminatedDofs,
                               gsSparseSystem<T>               & system)
@@ -195,4 +203,3 @@ protected:
 
 
 } // namespace gismo
-

--- a/src/gsAssembler/gsVisitorCDR.h
+++ b/src/gsAssembler/gsVisitorCDR.h
@@ -16,30 +16,32 @@
 namespace gismo
 {
 
-/** \brief Visitor for the convection-diffusion-reaction equation.
- *
- * Visitor for PDEs of the form\n
- * Find \f$ u: \mathbb R^d \rightarrow \mathbb R^d\f$
- * \f[ -\mathrm{div}( A \nabla u ) + b\cdot \nabla u + c u = f \f]
- * (+ boundary conditions), where\n
- * \f$ A \f$ (diffusion coefficient) is a \f$d\times d\f$-matrix,\n
- * \f$ b \f$ (convection velocity) is a \f$d\times 1\f$-vector,\n
- * \f$ c \f$ (reaction coefficient) is a scalar
- *
- * The coefficients are given as gsFunction with vector-valued return.\n
- * See the constructor gsVisitorCDR() for details on their format!
- *
- * Obviously, setting \f$ A= I\f$, \f$ b= 0\f$, and \f$c = 0\f$ results
- * in the special case of the Poisson equation.
- *
- * \ingroup Assembler
- */
+   /** @brief Visitor for the convection-diffusion-reaction equation.
+     *
+     * Visitor for PDEs of the form\n
+     * Find \f$ u: \mathbb R^d \rightarrow \mathbb R^d\f$
+     * \f[ -\mathrm{div}( A \nabla u ) + b\cdot \nabla u + c u = f \f]
+     * (+ boundary conditions), where\n
+     * \f$ A \f$ (diffusion coefficient) is a \f$d\times d\f$-matrix,\n
+     * \f$ b \f$ (convection velocity) is a \f$d\times 1\f$-vector,\n
+     * \f$ c \f$ (reaction coefficient) is a scalar
+     *
+     * The coefficients are given as gsFunction with vector-valued return.\n
+     * See the constructor gsVisitorCDR() for details on their format!
+     *
+     * Obviously, setting \f$ A = I\f$, \f$ b = 0\f$, and \f$c = 0\f$ results
+     * in the special case of the Poisson equation.
+     *
+     * @ingroup Assembler
+     */
 template <class T>
 class gsVisitorCDR
 {
 public:
 
-
+    /// @brief Constructor
+    ///
+    /// @param pde  Reference to \a gsConvDiffRePde object
     gsVisitorCDR(const gsPde<T> & pde)
     {
         const gsConvDiffRePde<T>* cdr =
@@ -86,6 +88,7 @@ public:
         GISMO_ASSERT( flagStabilization == stabilizerCDR::none || flagStabilization == stabilizerCDR::SUPG, "flagStabilization not known");
     }
 
+    /// Initialize
     void initialize(const gsBasis<T> & basis,
                     const index_t ,
                     const gsOptionList & options,
@@ -101,7 +104,7 @@ public:
         md.flags = NEED_VALUE | NEED_MEASURE | NEED_GRAD_TRANSFORM | NEED_2ND_DER;
     }
 
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>       & basis, // to do: more unknowns
                          const gsGeometry<T>    & geo,
                          const gsMatrix<T>      & quNodes)
@@ -133,7 +136,7 @@ public:
         localRhs.setZero(numActive, rhsVals.rows());//multiple right-hand sides
     }
 
-
+    /// Assemble
     inline void assemble(gsDomainIterator<T>    & element,
                          const gsVector<T>      & quWeights)
     {
@@ -263,10 +266,11 @@ public:
         system.push(localMat, localRhs, actives, eliminatedDofs.front(), 0, 0);
     }
 
+    /// Returns the parameter required for SUPG
     T getSUPGParameter( const gsVector<T> & lo,
                         const gsVector<T> & up)
     {
-        const int N = 2;
+        const index_t N = 2;
 
         const index_t d = lo.size();
 
@@ -280,7 +284,7 @@ public:
         coeff_b_ptr->eval_into( phys_pts, b_at_phys_pts );
         // ...and get it's norm.
         T b_norm = 0;
-        for( int i=0; i < d; i++)
+        for( index_t i=0; i < d; i++)
             b_norm += b_at_phys_pts(i,0) * b_at_phys_pts(i,0);
         b_norm = math::sqrt( b_norm );
 
@@ -291,11 +295,11 @@ public:
 
             if( d == 2 )
             {
-                int N1 = N+1;
+                index_t N1 = N+1;
                 md.points.resize( 2, 4*N1 );
                 aMat.resize( 2, 4*N1 );
 
-                for( int i = 0; i <= N; ++i )
+                for( index_t i = 0; i <= N; ++i )
                 {
                     T a = T(i)/T(N);
                     aMat(0,i) = a;
@@ -318,13 +322,13 @@ public:
                 md.points.resize( 3, 6*(N+1)*(N+1) );
                 aMat.resize( 3, 6*(N+1)*(N+1) );
 
-                int N1 = N+1;
+                index_t N1 = N+1;
                 md.points.resize( 2, 4*N1 );
                 aMat.resize( 2, 4*N1 );
 
-                int ij = 0;
-                for( int i = 0; i <= N; ++i )
-                    for( int j = 0; j <= N; ++j )
+                index_t ij = 0;
+                for( index_t i = 0; i <= N; ++i )
+                    for( index_t j = 0; j <= N; ++j )
                     {
                         T ai = T(i)/T(N);
                         T aj = T(j)/T(N);

--- a/src/gsAssembler/gsVisitorDg.h
+++ b/src/gsAssembler/gsVisitorDg.h
@@ -1,6 +1,7 @@
 /** @file gsVisitorDg.h
 
-    @brief A DG interface visitor for the Poisson problem .
+    @brief Visitor for adding the interface conditions for the interior
+    penalty methods of the Poisson problem.
 
     This file is part of the G+Smo library.
 
@@ -15,56 +16,121 @@
 
 namespace gismo
 {
-/** @brief
-    Implementation of a interface condition for the
-    discontinuous Galerkin Assembler.
-
-    It sets up an assembler and assembles the system patch wise and
-    combines the patch-local stiffness matrices into a global system.
-    Dirichlet boundary can also be imposed weakly (i.e. Nitsche).
-*/
+   /** \brief Visitor for adding the interface conditions for the interior
+     * penalty methods of the Poisson problem.
+     *
+     * This visitor adds the following term to the left-hand side (bilinear form):
+     * \f[
+     *     s_{k,\ell}(u,v) :=
+     *        - \alpha \int_{\Gamma^{(k,\ell)}}  \{\nabla u\} \cdot \mathbf{n} [ v ]
+     *        - \beta  \int_{\Gamma^{(k,\ell)}}  \{\nabla v\} \cdot \mathbf{n} [ u ]
+     *        + \delta ( h_k^{-1} + h_\ell^{-1}) \int_{\Gamma^{(k,\ell)}}  [ u ][ v ],
+     * \f]
+     * where \f$ v \f$ is the test function and \f$ u \f$ is trial function,
+     * \f$ [u] = u^{(k)} - u^{(\ell)} \f$ denotes the jump accross the interface
+     * and \f$ \{ u \} = (u^{(k)} + u^{(\ell)})/2\f$ denotes the average between
+     * the two patches.
+     *
+     * The default values for DG.Alpha and DG.Beta are \f$\alpha=\beta=1\f$,
+     * which corresponds to the Symmetric Interior Penalty discontinuous Galerkin
+     * (SIPG) method. The default value for DG.Penalty is -1, which yields
+     * \f$\delta=4(p+d)(p+1)\f$. If a positive value for DG.Penalty is chosen,
+     * that value is taken for \f$\delta\f$.
+     *
+     * The (normal) grid sizes are estimated based on the geometry function. Use
+     * the option DG.ParameterGridSize to just use the grid size on the parameter
+     * domain.
+     *
+     * An analogous visitor for handling the Dirichlet boundary conditions weakly,
+     * is the \a gsVisitorNitsche.
+     *
+     * \ingroup Assembler
+     */
 
 template <class T>
 class gsVisitorDg
 {
 public:
 
-   /** \brief Visitor for adding the interface conditions for the
-     * interior penalty method of the Poisson problem.
-     *
-     * This visitor adds the following term to the left-hand side (bilinear form).
-     * \f[ - \{\nabla u\} \cdot \mathbf{n} [ v ]
-     *     - \{\nabla v\} \cdot \mathbf{n} [ u ]
-     *     + \alpha [ u ][  v ] \f].
-     * Where \f[v\f] is the test function and \f[ u \f] is trial function.
-     */
-
-    gsVisitorDg(const gsPde<T> &)
+    /// Constructor
+    gsVisitorDg()
+    : m_pde(NULL)
     {}
 
+    /// @brief Constructor
+    ///
+    /// @param pde     Reference to \a gsPde object
+    gsVisitorDg(const gsPde<T> & pde)
+    : m_pde(&pde)
+    {}
+
+    /// Default options
+    static gsOptionList defaultOptions()
+    {
+        gsOptionList options;
+        options.addReal  ("DG.Alpha",
+                          "Parameter alpha for dG scheme; use 1 for SIPG and NIPG.",                              1);
+        options.addReal  ("DG.Beta",
+                          "Parameter beta for dG scheme; use 1 for SIPG and -1 for NIPG",                         1);
+        options.addReal  ("DG.Penalty",
+                          "Penalty parameter penalty for dG scheme; if negative, default 4(p+d)(p+1) is used.",  -1);
+        options.addSwitch("DG.ParameterGridSize",
+                          "Use grid size on parameter domain for the penalty term.",                          false);
+        return options;
+    }
+
+    /// Initialize
     void initialize(const gsBasis<T> & basis1,
-                    const gsBasis<T> & ,
+                    const gsBasis<T> & basis2,
                     const boundaryInterface & bi,
                     const gsOptionList & options,
                     gsQuadRule<T> & rule)
     {
-        side1 = bi.first().side();
+        m_side1 = bi.first();
+        m_side2 = bi.second();
 
         // Setup Quadrature
-        rule = gsQuadrature::get(basis1, options, side1.direction());
+        rule = gsQuadrature::get(basis1, options, m_side1.direction());
 
-        // Compute penalty parameter
-        const int deg = basis1.maxDegree();
-        penalty = (deg + basis1.dim()) * (deg + 1) * T(2.0);
+        m_penalty     = options.askReal("DG.Penalty",-1);
+        // If not given, use default
+        if (m_penalty<0)
+        {
+            const index_t deg = math::max( basis1.maxDegree(), basis2.maxDegree() );
+            m_penalty = T(4) * (deg + basis1.dim()) * (deg + 1);
+        }
+
+        m_alpha     = options.askReal("DG.Alpha", 1);
+        m_beta      = options.askReal("DG.Beta" , 1);
+
+        if (options.getSwitch("DG.ParameterGridSize"))
+        {
+            m_h1    = basis1.getMinCellLength();
+            m_h2    = basis2.getMinCellLength();
+        }
+        else
+        {
+            GISMO_ENSURE (m_pde, "gsVisitorDg::initialize: No PDE given.");
+            m_h1    = estimateSmallestPerpendicularCellSize(
+                          basis1,
+                          m_pde->patches()[m_side1.patch],
+                          m_side1
+                      );
+            m_h2    = estimateSmallestPerpendicularCellSize(
+                          basis2,
+                          m_pde->patches()[m_side2.patch],
+                          m_side2
+                      );
+        }
 
         // Set Geometry evaluation flags
         md1.flags = md2.flags = NEED_VALUE|NEED_JACOBIAN|NEED_GRAD_TRANSFORM;
     }
 
-    // Evaluate on element.
-    inline void evaluate(const gsBasis<T>       & B1, // to do: more unknowns
+    /// Evaluate on element
+    inline void evaluate(const gsBasis<T>       & B1,
                          const gsGeometry<T>    & geo1,
-                         const gsBasis<T>       & B2, // to do: more unknowns
+                         const gsBasis<T>       & B2,
                          const gsGeometry<T>    & geo2,
                          const gsMatrix<T>      & quNodes1,
                          const gsMatrix<T>      & quNodes2)
@@ -78,8 +144,8 @@ public:
         const index_t numActive2 = actives2.rows();
 
         // Evaluate basis functions and their first derivatives
-        B1.evalAllDers_into( md1.points, 1, basisData1);
-        B2.evalAllDers_into( md2.points, 1, basisData2);
+        B1.evalAllDers_into(md1.points, 1, basisData1);
+        B2.evalAllDers_into(md2.points, 1, basisData2);
 
         // Compute image of Gauss nodes under geometry mapping as well as Jacobians
         geo1.computeMap(md1);
@@ -92,7 +158,7 @@ public:
         E22.setZero(numActive2, numActive2); E21.setZero(numActive2, numActive1);
     }
 
-    // assemble on element
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & element1,
                          gsDomainIterator<T>    & element2,
                          gsVector<T>            & quWeights)
@@ -103,8 +169,9 @@ public:
         for (index_t k = 0; k < quWeights.rows(); ++k) // loop over quadrature nodes
         {
             // Compute the outer normal vector from patch1
-            outerNormal(md1, k, side1, unormal);
+            outerNormal(md1, k, m_side1, unormal);
 
+            // Multiply quadrature weight by the geometry measure
             // Integral transformation and quadrature weight (patch1)
             // assumed the same on both sides
             const T weight = quWeights[k] * unormal.norm();
@@ -113,10 +180,8 @@ public:
             unormal.normalize();
 
             // Take blocks of values and derivatives of basis functions
-            //const typename gsMatrix<T>::Column val1 = basisData1.col(k);//bug
             const typename gsMatrix<T>::Block val1 = basisData1[0].block(0,k,numActive1,1);
             gsMatrix<T> & grads1 = basisData1[1];// all grads
-            //const typename gsMatrix<T>::Column val2 = basisData2.col(k);//bug
             const typename gsMatrix<T>::Block val2 = basisData2[0].block(0,k,numActive2,1);
             gsMatrix<T> & grads2 = basisData2[1];// all grads
 
@@ -125,26 +190,27 @@ public:
             transformGradients(md2, k, grads2, phGrad2);
 
             // Compute element matrices
-            const T c1     = weight * T(0.5);
+            const T c1     = weight / T(2);
             N1.noalias()   = unormal.transpose() * phGrad1;
             N2.noalias()   = unormal.transpose() * phGrad2;
+
             B11.noalias() += c1 * ( val1 * N1 );
+            B21.noalias() -= c1 * ( val2 * N1 );
             B12.noalias() += c1 * ( val1 * N2 );
             B22.noalias() -= c1 * ( val2 * N2 );
-            B21.noalias() -= c1 * ( val2 * N1 );
 
-            const T h1     = element1.getCellSize();
-            const T h2     = element2.getCellSize();
-            // Maybe, the h should be scaled with the patch diameter, since its the h from the parameterdomain.
-            const T c2     = weight * penalty * 2*(1./h1 + 1./h2);
+            const T c2     = weight * m_penalty * (1./m_h1 + 1./m_h2);
 
             E11.noalias() += c2 * ( val1 * val1.transpose() );
             E12.noalias() += c2 * ( val1 * val2.transpose() );
             E22.noalias() += c2 * ( val2 * val2.transpose() );
             E21.noalias() += c2 * ( val2 * val1.transpose() );
+
         }
     }
-    
+public:
+
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t                     patch1,
                               const index_t                     patch2,
                               const std::vector<gsMatrix<T> > & eliminatedDofs,
@@ -157,26 +223,67 @@ public:
         m_localRhs1.setZero(actives1.rows(),system.rhsCols());
         m_localRhs2.setZero(actives2.rows(),system.rhsCols());
 
-        system.push(-B11 - B11.transpose() + E11, m_localRhs1,actives1,actives1,eliminatedDofs.front(),0,0);
-        system.push(-B21 - B12.transpose() - E21, m_localRhs2,actives2,actives1,eliminatedDofs.front(),0,0);
-        system.push(-B12 - B21.transpose() - E12, m_localRhs1,actives1,actives2,eliminatedDofs.front(),0,0);
-        system.push(-B22 - B22.transpose() + E22, m_localRhs2,actives2,actives2,eliminatedDofs.front(),0,0);
-
+        system.push(-m_alpha*B11 - m_beta*B11.transpose() + E11, m_localRhs1,actives1,actives1,eliminatedDofs.front(),0,0);
+        system.push(-m_alpha*B21 - m_beta*B12.transpose() - E21, m_localRhs2,actives2,actives1,eliminatedDofs.front(),0,0);
+        system.push(-m_alpha*B12 - m_beta*B21.transpose() - E12, m_localRhs1,actives1,actives2,eliminatedDofs.front(),0,0);
+        system.push(-m_alpha*B22 - m_beta*B22.transpose() + E22, m_localRhs2,actives2,actives2,eliminatedDofs.front(),0,0);
     }
+
+    /// Estimates the gird size perpendicular to the given side on the physical domain, as required for SIPG and Nitsche
+    static T estimateSmallestPerpendicularCellSize(const gsBasis<T> & basis,
+                                                   const gsGeometry<T> & geo,
+                                                   patchSide side)
+    {
+        T result = 0;
+        bool first = true;
+        typename gsDomainIterator<T>::uPtr domIt = basis.makeDomainIterator(side);
+
+        for (gsDomainIterator<T>& element = *domIt; element.good(); element.next() )
+        {
+            gsVector<T> parameterCenter = element.centerPoint();
+            const gsMatrix<T> center1 = geo.eval(parameterCenter);
+
+            parameterCenter(side.direction()) += ( side.parameter() == 0 ? 1 : -1 )
+                                                 * element.getPerpendicularCellSize();
+            const gsMatrix<T> center2 = geo.eval(parameterCenter);
+
+            const real_t diff = (center1 - center2).norm();
+
+            if (first || result > diff)
+                result = diff;
+
+            first = false;
+        }
+        return result;
+    }
+
+
 
 private:
 
-    // Penalty constant
-    T penalty;
+    /// The underlying PDE
+    const gsPde<T> * m_pde;
 
-    // Side
-    boxSide side1;
+    /// Parameter \f$\alpha\f$ for the bilinear form
+    T m_alpha;
+
+    /// Parameter \f$\beta\f$ for the bilinear form
+    T m_beta;
+
+    /// Parameter \f$\delta\f$ for the bilinear form
+    T m_penalty;
+
+    /// Side on first patch that corresponds to interface
+    patchSide m_side1;
+
+    /// Side on second patch that corresponds to interface
+    patchSide m_side2;
 
 private:
 
     // Basis values etc
     std::vector<gsMatrix<T> > basisData1, basisData2;
-    gsMatrix<T>        phGrad1   , phGrad2;
+    gsMatrix<T>       phGrad1   , phGrad2;
     gsMatrix<index_t> actives1  , actives2;
 
     // Outer normal
@@ -185,10 +292,13 @@ private:
     // Auxiliary element matrices
     gsMatrix<T> B11, B12, E11, E12, N1,
                 B22, B21, E22, E21, N2;
-                
+
     gsMatrix<T> m_localRhs1, m_localRhs2;
 
     gsMapData<T> md1, md2;
+
+    // Grid sizes
+    T m_h1, m_h2;
 };
 
 

--- a/src/gsAssembler/gsVisitorDg.h
+++ b/src/gsAssembler/gsVisitorDg.h
@@ -195,8 +195,8 @@ public:
             N2.noalias()   = unormal.transpose() * phGrad2;
 
             B11.noalias() += c1 * ( val1 * N1 );
-            B21.noalias() -= c1 * ( val2 * N1 );
             B12.noalias() += c1 * ( val1 * N2 );
+            B21.noalias() -= c1 * ( val2 * N1 );
             B22.noalias() -= c1 * ( val2 * N2 );
 
             const T c2     = weight * m_penalty * (1./m_h1 + 1./m_h2);
@@ -208,7 +208,6 @@ public:
 
         }
     }
-public:
 
     /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t                     patch1,

--- a/src/gsAssembler/gsVisitorGradGrad.h
+++ b/src/gsAssembler/gsVisitorGradGrad.h
@@ -19,12 +19,16 @@
 namespace gismo
 {
 
+   /**
+     *  @brief The visitor computes element grad-grad integrals
+     *
+     *  This visitor assemble the element-wise bilinear form:
+     *  \f[ ( \nabla u, \nabla v )_\Omega, \f]
+     *  where \f$u\f$  is the trial function and \f$v\f$ is the test function.
+     *
+     *  @ingroup Assembler
+     */
 
-/** 
-    @brief The visitor computes element grad-grad integrals
-    
-    \ingroup Assembler
-*/
 template <class T>
 class gsVisitorGradGrad : public gsVisitorMass<T> // inherit to reuse functionality
 {
@@ -32,35 +36,17 @@ public:
     typedef gsVisitorMass<T> Base;
 
 public:
-/** @brief Visitor for stiffness (grad-grad) integrals
- * 
- * This visitor assemble the element-wise bilinear form:
- * \f[ ( \nabla u , \nabla v )_{K} \f].
- * Where \f[ v$ \f]  is the test function and \f[u \f] is trial function.
- */
-    gsVisitorGradGrad(const gsPde<T> & /*pde*/)
-    { }
 
-    /*
-    void initialize(const gsBasis<T> & basis,
-                           gsQuadRule<T> & rule)
-    {
-        gsVector<index_t> numQuadNodes( basis.dim() );
-        for (int i = 0; i < basis.dim(); ++i)
-            numQuadNodes[i] = basis.degree(i) + 1;
-        
-        // Setup Quadrature
-        rule = gsGaussRule<T>(numQuadNodes);// harmless slicing occurs here
+    /// Constructor
+    ///
+    /// @param pde     Reference to \a gsPde object (is ignored)
+    gsVisitorGradGrad(const gsPde<T> & pde)
+    { GISMO_UNUSED(pde); }
 
-        // Set Geometry evaluation flags
-        md.flags = NEED_MEASURE|NEED_GRAD_TRANSFORM;
-        // const gsGeometry<T> & patch = this->m_patches.patch(patchIndes); // -- TODO: Initialize inside visitor
-    }
-    */
-
+    /// Initialize
     void initialize(const gsBasis<T> & basis,
                     const index_t /*patchIndex*/,
-                    const gsOptionList & options, 
+                    const gsOptionList & options,
                     gsQuadRule<T>    & rule)
     {
         // Setup Quadrature
@@ -70,8 +56,7 @@ public:
         md.flags = NEED_MEASURE|NEED_GRAD_TRANSFORM;
     }
 
-
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>       & basis,
                          const gsGeometry<T>    & geo,
                          // todo: add element here for efficiency
@@ -93,6 +78,7 @@ public:
         localMat.setZero(numActive, numActive);
     }
 
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & /*element*/,
                          gsVector<T> const      & quWeights)
     {
@@ -100,7 +86,7 @@ public:
         {
             // Multiply quadrature weight by the geometry measure
             const T weight = quWeights[k] * md.measure(k);
-        
+
             // Compute physical gradients at k as a Dim x NumActive matrix
             transformGradients(md, k, basisData, basisPhGrads);
 
@@ -117,7 +103,7 @@ private:
     gsMatrix<T>  basisPhGrads;
     using Base:: basisData;
     using Base::actives;
-    
+
     // Local matrix
     using Base::localMat;
 
@@ -126,4 +112,3 @@ private:
 
 
 } // namespace gismo
-

--- a/src/gsAssembler/gsVisitorMass.h
+++ b/src/gsAssembler/gsVisitorMass.h
@@ -15,33 +15,36 @@
 
 namespace gismo
 {
-/** 
-    @brief The visitor computes element mass integrals
 
-    It sets up an assembler and assembles the mass matrix element-wise and
-    combines the patch-local mass matrices into a global matrix.
-      
-    \ingroup Assembler
-*/
+   /**  @brief The visitor computes element mass integrals
+     *
+     *  Assembles the bilinear term
+     *  \f[ (u,v)_\Omega, \f]
+     *  where \f$u\f$ is the trial function and \f$v\f$ is the test function.
+     *
+     *  @ingroup Assembler
+     */
+
 template <class T>
 class gsVisitorMass
 {
 public:
 
+    /// Constructor
     gsVisitorMass()
     { }
 
-    /** \brief Visitor for assembling the mass matrix
-     *  
-     * \f[ (u, v) \f]  
-     */
+    /// @brief Constructor
+    ///
+    /// @param pde     Reference to \a gsPde object (is ignored)
     gsVisitorMass(const gsPde<T> & pde)
     { GISMO_UNUSED(pde); }
 
-    void initialize(const gsBasis<T> & basis,
+    /// Initialize
+    void initialize(const gsBasis<T>   & basis,
                     const index_t ,
-                    const gsOptionList & options, 
-                    gsQuadRule<T>    & rule)
+                    const gsOptionList & options,
+                    gsQuadRule<T>      & rule)
     {
         // Setup Quadrature (harmless slicing occurs)
         rule = gsQuadrature::get(basis, options); // harmless slicing occurs here
@@ -50,7 +53,7 @@ public:
         md.flags = NEED_MEASURE;
     }
 
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>       & basis, // to do: more unknowns
                          const gsGeometry<T>    & geo,
                          // todo: add element here for efficiency
@@ -72,34 +75,36 @@ public:
         localMat.setZero(numActive, numActive);
     }
 
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & ,
                          gsVector<T> const      & quWeights)
     {
-        localMat.noalias() = 
-            basisData * quWeights.asDiagonal() * 
+        localMat.noalias() =
+            basisData * quWeights.asDiagonal() *
             md.measures.asDiagonal() * basisData.transpose();
     }
 
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t                     patchIndex,
-                              const std::vector<gsMatrix<T> > & ,
+                              const std::vector<gsMatrix<T> > & eliminatedDofs,
                               gsSparseSystem<T>               & system)
     {
         // Map patch-local DoFs to global DoFs
         system.mapColIndices(actives, patchIndex, actives);
 
         // Add contributions to the system matrix
-        system.pushToMatrix(localMat, actives, 0, 0);
+        system.pushToMatrix(localMat, actives, eliminatedDofs.front(), 0, 0);
     }
 
 /* -----------------------  to be removed later*/
 
-    void initialize(const gsBasis<T> & basis,
-                           gsQuadRule<T> & rule)
+    void initialize(const gsBasis<T>    & basis,
+                          gsQuadRule<T> & rule)
     {
         gsVector<short_t> numQuadNodes( basis.dim() );
         for (short_t i = 0; i < basis.dim(); ++i)
             numQuadNodes[i] = basis.degree(i) + 1;
-        
+
         // Setup Quadrature
         rule = gsGaussRule<T>(numQuadNodes);// harmless slicing occurs here
 
@@ -121,7 +126,7 @@ public:
         for (index_t i = 0; i < numActive; ++i)
         {
             const int ii = actives(i,0); // N_i
-            
+
             if ( mapper.is_free_index(ii) )
             {
                 for (index_t j = 0; j < numActive; ++j)
@@ -150,4 +155,3 @@ protected:
 
 
 } // namespace gismo
-

--- a/src/gsAssembler/gsVisitorMoments.h
+++ b/src/gsAssembler/gsVisitorMoments.h
@@ -2,12 +2,12 @@
 
     @brief Element visitor for moment vector.
 
-    This file is part of the G+Smo library. 
+    This file is part of the G+Smo library.
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
-    
+
     Author(s): A. Mantzaflaris
 */
 
@@ -16,27 +16,28 @@
 namespace gismo
 {
 
-/** \brief Visitor for the moment vector of a function
- *
- * Assembles the linear term
- * \f[ (f,v)_\Omega \f]
- *
- */
+   /** @brief Visitor for the moment vector of a function
+     *
+     *  Assembles the linear term
+     *  \f[ (f,v)_\Omega, \f]
+     *  where \f$f\f$ is the right-hand-side function and \f$v\f$ is the test function.
+     *
+     * @ingroup Assembler
+     */
 
 template <class T, bool paramCoef = false>
 class gsVisitorMoments
 {
 public:
-    
-    /** \brief Constructor for gsVisitorMoments.
-     *
-     * \param[in] rhs Given right-hand-side function/source term that, for
-     */
-    /// Constructor with the right hand side function of the Poisson equation
+
+    /// @brief Constructor for gsVisitorMoments.
+    ///
+    /// @param rhs Right-hand-side function/source term
     gsVisitorMoments(const gsFunction<T> & rhs)
     : rhs_ptr(&rhs)
     { }
 
+    /// Initialize
     void initialize(const gsBasis<T> & basis,
                     const index_t patchIndex,
                     const gsOptionList & options,
@@ -49,7 +50,7 @@ public:
         md.flags = NEED_MEASURE | NEED_VALUE;
     }
 
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>       & basis, // to do: more unknowns
                          const gsGeometry<T>    & geo,
                          const gsMatrix<T>      & quNodes)
@@ -74,7 +75,8 @@ public:
         // Initialize local matrix/rhs
         localRhs.setZero(numActive, rhsVals.rows());//multiple right-hand sides
     }
-    
+
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & /*element*/,
                          gsVector<T> const      & quWeights)
     {
@@ -93,7 +95,8 @@ public:
         //gsDebugVar(localRhs.transpose() );
         //gsDebugVar(localMat.asVector().transpose() );
     }
-    
+
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t                     patchIndex,
                               const std::vector<gsMatrix<T> > & eliminatedDofs,
                               gsSparseSystem<T>               & system)
@@ -105,6 +108,7 @@ public:
         system.pushToRhs(localRhs, actives, 0);
     }
 
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const gsDofMapper & mapper,
                               const gsMatrix<T> & eliminatedDofs,
                               const index_t       patchIndex,
@@ -116,7 +120,7 @@ public:
         // Local DoFs to global DoFs
         mapper.localToGlobal(actives, patchIndex, actives);
         //const int numActive = actives.rows();
-        
+
         for (index_t i=0; i < numActive; ++i)
         {
             const index_t ii = actives(i);
@@ -148,4 +152,3 @@ protected:
 
 
 } // namespace gismo
-

--- a/src/gsAssembler/gsVisitorNeumann.h
+++ b/src/gsAssembler/gsVisitorNeumann.h
@@ -156,6 +156,7 @@ public:
 
 protected:
 
+
     // Neumann function
     const gsFunction<T> * neudata_ptr;
     boxSide side;

--- a/src/gsAssembler/gsVisitorNeumann.h
+++ b/src/gsAssembler/gsVisitorNeumann.h
@@ -2,12 +2,12 @@
 
     @brief Neumann conditions visitor for elliptic problems.
 
-    This file is part of the G+Smo library. 
+    This file is part of the G+Smo library.
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
-    
+
     Author(s): A. Mantzaflaris
 */
 
@@ -17,35 +17,41 @@
 
 namespace gismo
 {
-/** @brief
-    Implementation of a Neumann BC for elliptic Assembler.
 
-    It sets up an assembler and adds the following term to the linear term.
-    \f[ \nabla u \cdot \mathbf{n} = g_N  \f]
-*/
+   /** @brief Implementation of a Neumann BC for elliptic assemblers.
+     *
+     *  The visior realizes the Neumann BC
+     *  \f[ \nabla u \cdot \mathbf{n} = g_N  \f]
+     *  by adding the following term to the linear form:
+     *  \f[ ( g_N, v )_{\Gamma_N},  \f]
+     *  where \f$ \Gamma_N \f$ is the Neumann boundary.
+     *
+     *  @ingroup Assembler
+     */
 
 template <class T>
 class gsVisitorNeumann
 {
 public:
 
-    gsVisitorNeumann(const gsPde<T> & , const boundary_condition<T> & s)
-    : neudata_ptr( s.function().get() ), side(s.side())
+    /// @brief Constructor
+    ///
+    /// @param pde     Reference to \a gsPde object (is ignored)
+    /// @param bc      The boundary condition to be realized
+    gsVisitorNeumann(const gsPde<T> & pde, const boundary_condition<T> & bc)
+    : neudata_ptr( bc.function().get() ), side(bc.side())
+    { GISMO_UNUSED(pde); }
+
+    /// @brief Constructor
+    ///
+    /// @param neudata Neumann boundary function
+    /// @param s       Side of the geometry where Neumann BC is prescribed
+    gsVisitorNeumann(const gsFunction<T> & neudata, boxSide s)
+    : neudata_ptr(&neudata), side(s)
     { }
 
-/** @brief
- * Constructor of the assembler object 
- * 
-   \param[in] neudata is the Neumann boundary data.
-   \param[in] s are the sides of the geometry where neumann BC are prescribed.
-   
-   \f[ \nabla u \cdot \mathbf{n} = g_N  \f]
-*/
-    gsVisitorNeumann(const gsFunction<T> & neudata, boxSide s) : 
-    neudata_ptr(&neudata), side(s)
-    { }
-
-    void initialize(const gsBasis<T> & basis, 
+    /// Initialize
+    void initialize(const gsBasis<T> & basis,
                     gsQuadRule<T>    & rule)
     {
         const int dir = side.direction();
@@ -61,9 +67,10 @@ public:
         md.flags = NEED_VALUE|NEED_JACOBIAN;
     }
 
+    /// Initialize
     void initialize(const gsBasis<T>   & basis,
                     const index_t ,
-                    const gsOptionList & options, 
+                    const gsOptionList & options,
                     gsQuadRule<T>      & rule)
     {
         // Setup Quadrature (harmless slicing occurs)
@@ -73,7 +80,7 @@ public:
         md.flags = NEED_VALUE | NEED_MEASURE | NEED_GRAD_TRANSFORM;
     }
 
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>       & basis, // to do: more unknowns
                          const gsGeometry<T>    & geo,
                          // todo: add element here for efficiency
@@ -84,7 +91,7 @@ public:
         // Assumes actives are the same for all quadrature points on the current element
         basis.active_into(md.points.col(0) , actives);
         const index_t numActive = actives.rows();
- 
+
         // Evaluate basis functions on element
         basis.eval_into(md.points, basisData);
 
@@ -98,6 +105,7 @@ public:
         localRhs.setZero(numActive, neudata_ptr->targetDim() );
     }
 
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & ,
                          const gsVector<T>      & quWeights)
     {
@@ -105,14 +113,15 @@ public:
         {
             // Compute the outer normal vector on the side
             outerNormal(md, k, side, unormal);
-            
+
             // Multiply quadrature weight by the measure of normal
             const T weight = quWeights[k] * unormal.norm();
-            
+
             localRhs.noalias() += weight * basisData.col(k) * neuData.col(k).transpose() ;
         }
     }
-    
+
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t patchIndex,
                               const std::vector<gsMatrix<T> > & ,
                               gsSparseSystem<T>               & system)
@@ -124,6 +133,7 @@ public:
         system.pushToRhs(localRhs, actives, 0);
     }
 
+    /// Adds the contributions to the sparse system
     void localToGlobal(const gsDofMapper & mapper,
                        const gsMatrix<T> & eliminatedDofs,
                        const index_t       patchIndex,
@@ -146,7 +156,6 @@ public:
 
 protected:
 
-    
     // Neumann function
     const gsFunction<T> * neudata_ptr;
     boxSide side;

--- a/src/gsAssembler/gsVisitorNeumannBiharmonic.h
+++ b/src/gsAssembler/gsVisitorNeumannBiharmonic.h
@@ -2,12 +2,12 @@
 
     @brief Neumann conditions visitor for 4th order problems.
 
-    This file is part of the G+Smo library. 
+    This file is part of the G+Smo library.
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
-    
+
     Author(s): A. Mantzaflaris, J. Sogn
 */
 
@@ -16,29 +16,42 @@
 namespace gismo
 {
 
-/** \brief Visitor for Neumann boundary condition for the biharmonic equation.
- *
- * Visitor for boundary condition term of the form:\n
- * Let g be the function given BVP formulation, typically
- * \f[ g = \Delta u\f].
- * Then this visitor adds the follow term on the right-hand side.
- * \f[ (g, \nabla v \cdot \mathbf{n})_\Gamma \f]
- * Where v is the test function and \f[ \Gamma \f] is the boundary.
- */
+   /** @brief Visitor for Neumann boundary condition for the biharmonic equation.
+     *
+     * Visitor for boundary condition term of the form:
+     *
+     * Let g be the function given BVP formulation, typically
+     * \f[ g = \Delta u. \f]
+     * Then this visitor adds the following term on the right-hand side:
+     * \f[ (g, \nabla v \cdot \mathbf{n})_\Gamma, \f]
+     * where v is the test function and \f$ \Gamma \f$ is the boundary.
+     *
+     * @ingroup Assembler
+     */
+
 template <class T>
 class gsVisitorNeumannBiharmonic
 {
 public:
 
-    gsVisitorNeumannBiharmonic(const gsPde<T> & , const boundary_condition<T> & s)
-    : neudata_ptr( s.function().get() ), side(s.side())
+    /// @brief Constructor
+    ///
+    /// @param pde     Reference to \a gsPde object (is ignored)
+    /// @param bc      The boundary condition to be realized
+    gsVisitorNeumannBiharmonic(const gsPde<T> & pde, const boundary_condition<T> & bc)
+    : neudata_ptr( bc.function().get() ), side(bc.side())
+    { GISMO_UNUSED(pde); }
+
+    /// @brief Constructor
+    ///
+    /// @param neudata Neumann boundary function
+    /// @param s       Side of the geometry where neumann BC is prescribed
+    gsVisitorNeumannBiharmonic(const gsFunction<T> & neudata, boxSide s)
+    : neudata_ptr(&neudata), side(s)
     { }
 
-    gsVisitorNeumannBiharmonic(const gsFunction<T> & neudata, boxSide s) :
-    neudata_ptr(&neudata), side(s)
-    { }
-
-    void initialize(const gsBasis<T> & basis, 
+    /// Initialize
+    void initialize(const gsBasis<T> & basis,
                     gsQuadRule<T>    & rule)
     {
         const int dir = side.direction();
@@ -55,9 +68,10 @@ public:
 
     }
 
+    /// Initialize
     void initialize(const gsBasis<T> & basis,
                     const index_t ,
-                    const gsOptionList & options, 
+                    const gsOptionList & options,
                     gsQuadRule<T>    & rule)
     {
         // Setup Quadrature (harmless slicing occurs)
@@ -69,7 +83,7 @@ public:
         md.flags = NEED_VALUE | NEED_MEASURE | NEED_GRAD_TRANSFORM;
     }
 
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>       & basis, // to do: more unknowns
                          const gsGeometry<T>    & geo,
                          // todo: add element here for efficiency
@@ -94,6 +108,7 @@ public:
         localRhs.setZero(numActive, neudata_ptr->targetDim() );
     }
 
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & ,
                          gsVector<T> const      & quWeights)
     {
@@ -101,7 +116,7 @@ public:
         {
             // Compute the outer normal vector on the side
             outerNormal(md, k, side, unormal);
-            
+
             // Multiply quadrature weight by the measure of normal
             const T weight = quWeights[k] * unormal.norm();
             unormal.normalize();
@@ -111,7 +126,8 @@ public:
             localRhs.noalias() += weight *(( physBasisGrad.transpose() * unormal )* neuData.col(k).transpose());
         }
     }
-    
+
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t                     patchIndex,
                               const std::vector<gsMatrix<T> > & ,
                               gsSparseSystem<T>               & system)
@@ -148,7 +164,7 @@ public:
 
 protected:
 
-    
+
     // Neumann function
     const gsFunction<T> * neudata_ptr;
     boxSide side;

--- a/src/gsAssembler/gsVisitorNitsche.h
+++ b/src/gsAssembler/gsVisitorNitsche.h
@@ -1,87 +1,124 @@
 /** @file gsVisitorNitsche.h
 
-    @brief Weak (Nitsche-type) BC imposition visitor for elliptic problems.
+    @brief Weak (Nitsche-type) imposition of the Dirichlet boundary conditions.
 
-    This file is part of the G+Smo library. 
+    This file is part of the G+Smo library.
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
-    
-    Author(s): A. Mantzaflaris , S. Moore
+
+    Author(s): A. Mantzflaris, S. Moore, S. Takacs
 */
 
 #pragma once
 
+#include <gsAssembler/gsVisitorDg.h>
+
 namespace gismo
 {
-/** \brief Visitor for the weak imposition of the dirichlet boundary condition.
- *
- * Adds this term to the bilinear terms
- * \f[ (\nabla u, v)_{\partial \Omega} + (u, \nabla v )_{\partial \Omega} 
- *                                     + (\mu*u, v)_{\partial \Omega} \f]
- * 
- * The following term is also added to the linear form
- * \f[ (g_D, \mu*v + \nabla v)_{\partial \Omega} \f],
- * where the dirichlet term is given as \f[ g_D \f].
- */
+
+   /** @brief Visitor for adding the terms associated to weak (Nitsche-type) imposition
+     * of the Dirichlet boundary conditions.
+     *
+     * This visitor adds the following term to the left-hand side (bilinear form):
+     * \f[
+     *          \alpha \int_{\Gamma_D}  \nabla u \cdot \mathbf{n} v
+     *        + \beta  \int_{\Gamma_D}  \nabla v \cdot \mathbf{n} u
+     *        + \delta h^{-1} \int_{\Gamma_D}  u  v
+     * \f]
+     * and the following terms to the right-hand side (linear form):
+     * \f[
+     *          \beta   \int_{\Gamma_D} g_D \nabla v \cdot \mathbf{n} u
+     *        + \delta h^{-1} \int_{\Gamma_D} g_D v \cdot \mathbf{n} u,
+     * \f]
+     * where \f$g_D\f$ is the Dirichlet value.
+     *
+     * The default values for Nitsche.Alpha and Nitsche.Beta are \f$\alpha=\beta=1\f$,
+     * which corresponds to the standard Nitsche method. The default value for
+     * Nitsche.Penalty is -1, which yields \f$\delta=2.5(p+d)(p+1)\f$. If a positive
+     * value for Nitsche.Penalty is chosen, that value is taken for \f$\delta\f$.
+     *
+     * The (normal) grid sizes are estimated based on the geometry function. Use
+     * the option Nitsche.ParameterGridSize to just use the grid size on the parameter
+     * domain.
+     *
+     * An analogous visitor for handling the internal smoothness weakly, is the
+     * \a gsVisitorDg.
+     *
+     * @ingroup Assembler
+     */
+
 
 template <class T>
 class gsVisitorNitsche
 {
 public:
 
-    gsVisitorNitsche(const gsPde<T> & , const boundary_condition<T> & s)
-    : dirdata_ptr( s.function().get() ), side(s.side())
+    /// @brief Constructor
+    ///
+    /// @param pde     Reference to \a gsPde object
+    /// @param bc      The boundary condition to be realized
+    gsVisitorNitsche(const gsPde<T> & pde, const boundary_condition<T> & bc)
+        : m_pde(&pde), m_dirdata_ptr( bc.function().get() ), m_side(bc.ps), m_penalty(-1)
     { }
 
-/** @brief
-    Constructor of the assembler object.
-
-    \param[in] dirdata  is a gsBoundaryConditions object that holds boundary conditions of the form:
-    \f[ \text{Dirichlet: } u = g_D \text{ on } \Gamma.\f]
-    \f$ v \f$ is the test function and \f$ \Gamma\f$ is the boundary side.
-    \param[in] _penalty for inputing the penalty choice
-    \param[in] s
-*/
-    gsVisitorNitsche(const gsFunction<T> & dirdata, T _penalty, boxSide s) : 
-    dirdata_ptr(&dirdata),penalty(_penalty), side(s)
-    { }
-
-    void initialize(const gsBasis<T> & basis, 
-                    gsQuadRule<T> & rule)
+    /// Default options
+    static gsOptionList defaultOptions()
     {
-        const int dir = side.direction();
-        gsVector<int> numQuadNodes ( basis.dim() );
-        for (int i = 0; i < basis.dim(); ++i)
-            numQuadNodes[i] = 2* basis.degree(i) + 1;
-        numQuadNodes[dir] = 1;
-        
-        // Setup Quadrature
-        rule = gsGaussRule<T>(numQuadNodes);// harmless slicing occurs here
-
-        // Set Geometry evaluation flags
-        md.flags = NEED_VALUE|NEED_JACOBIAN|NEED_GRAD_TRANSFORM;
+        gsOptionList options;
+        options.addReal  ("Nitsche.Alpha",
+                          "Parameter alpha for Nitsche scheme.",                                                       1);
+        options.addReal  ("Nitsche.Beta",
+                          "Parameter beta for Nitsche scheme.",                                                        1);
+        options.addReal  ("Nitsche.Penalty",
+                          "Penalty parameter penalty for Nitsche scheme; if negative, default 2.5(p+d)(p+1) is used.",-1);
+        options.addSwitch("Nitsche.ParameterGridSize",
+                          "Use grid size on parameter domain for the penalty term.",                               false);
+        return options;
     }
 
+    /// Initialize
     void initialize(const gsBasis<T> & basis,
-                    const index_t ,
-                    const gsOptionList & options, 
-                    gsQuadRule<T>    & rule)
+                    const index_t,
+                    const gsOptionList & options,
+                    gsQuadRule<T> & rule)
     {
         // Setup Quadrature (harmless slicing occurs)
-        rule = gsQuadrature::get(basis, options, side.direction());
+        rule = gsQuadrature::get(basis, options, m_side.direction());
+
+        m_penalty     = options.askReal("Nitsche.Penalty",-1);
+        // If not given, use default
+        if (m_penalty<0)
+        {
+            const index_t deg = basis.maxDegree();
+            m_penalty = T(2.5) * (deg + basis.dim()) * (deg + 1);
+        }
+
+        m_alpha     = options.askReal("Nitsche.Alpha", 1);
+        m_beta      = options.askReal("Nitsche.Beta" , 1);
+
+        if (options.getSwitch("DG.ParameterGridSize"))
+        {
+            m_h     = basis.getMinCellLength();
+        }
+        else
+        {
+            GISMO_ENSURE (m_pde, "gsVisitorNitsche::initialize: No PDE given.");
+            m_h     = gsVisitorDg<T>::estimateSmallestPerpendicularCellSize(
+                          basis,
+                          m_pde->patches()[m_side.patch],
+                          m_side
+                      );
+        }
 
         // Set Geometry evaluation flags
         md.flags = NEED_VALUE | NEED_MEASURE | NEED_GRAD_TRANSFORM;
 
-        // Compute penalty parameter
-        const int deg = basis.maxDegree();
-        penalty = T((deg + basis.dim()) * (deg + 1)) * T(2.5);
     }
 
-    // Evaluate on element.
-    inline void evaluate(const gsBasis<T>       & basis, // to do: more unknowns
+    /// Evaluate on element
+    inline void evaluate(const gsBasis<T>       & basis,
                          const gsGeometry<T>    & geo,
                          // todo: add element here for efficiency
                          const gsMatrix<T>      & quNodes)
@@ -99,13 +136,14 @@ public:
         geo.computeMap(md);
 
         // Evaluate the Dirichlet data
-        dirdata_ptr->eval_into(md.values[0], dirData);
+        m_dirdata_ptr->eval_into(md.values[0], dirData);
 
         // Initialize local matrix/rhs
         localMat.setZero(numActive, numActive);
-        localRhs.setZero(numActive, dirdata_ptr->targetDim() );
+        localRhs.setZero(numActive, m_dirdata_ptr->targetDim() );
     }
 
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T>    & element,
                          const gsVector<T>      & quWeights)
     {
@@ -114,36 +152,37 @@ public:
 
         for (index_t k = 0; k < quWeights.rows(); ++k) // loop over quadrature nodes
         {
-        
-        const typename gsMatrix<T>::Block bVals =
-            basisData[0].block(0,k,numActive,1);
 
-        // Compute the outer normal vector on the side
-        outerNormal(md, k, side, unormal);
+            const typename gsMatrix<T>::Block bVals =
+                basisData[0].block(0,k,numActive,1);
 
-        // Multiply quadrature weight by the geometry measure
-        const T weight = quWeights[k] *unormal.norm();   
+            // Compute the outer normal vector on the side
+            outerNormal(md, k, m_side, unormal);
 
-        // Compute the unit normal vector 
-        unormal.normalize();
-        
-        // Compute physical gradients at k as a Dim x NumActive matrix
-        transformGradients(md, k, bGrads, pGrads);
-        
-        // Get penalty parameter
-        const T h = element.getCellSize();
-        const T mu = penalty / (0!=h?h:1);
+            // Multiply quadrature weight by the geometry measure
+            const T weight = quWeights[k] * unormal.norm();
 
-        // Sum up quadrature point evaluations
-        localRhs.noalias() -= weight * (( pGrads.transpose() * unormal - mu * bVals )
-                                        * dirData.col(k).transpose() );
+            // Compute the unit normal vector
+            unormal.normalize();
 
-        localMat.noalias() -= weight * ( bVals * unormal.transpose() * pGrads
-                           +  (bVals * unormal.transpose() * pGrads).transpose()
-                           -  mu * bVals * bVals.transpose() );
+            // Compute physical gradients at k as a Dim x NumActive matrix
+            transformGradients(md, k, bGrads, pGrads);
+
+            // Get penalty parameter
+            const T mu = m_penalty / m_h;
+
+            // Sum up quadrature point evaluations
+            localRhs.noalias() -= weight * ( ( m_beta * pGrads.transpose() * unormal - mu * bVals ) * dirData.col(k).transpose() );
+
+            localMat.noalias() -= weight * (
+                                            m_alpha *  bVals * unormal.transpose() * pGrads
+                                            + m_beta  * (bVals * unormal.transpose() * pGrads).transpose()
+                                            - mu      *  bVals                       * bVals.transpose()
+                                        );
         }
     }
 
+    /// Adds the contributions to the sparse system
     inline void localToGlobal(const index_t                     patchIndex,
                               const std::vector<gsMatrix<T> > & ,
                               gsSparseSystem<T>               & system)
@@ -154,7 +193,8 @@ public:
         // Add contributions to the system matrix and right-hand side
         system.pushAllFree(localMat, localRhs, actives, 0);
     }
-    
+
+    /// Adds the contributions to the sparse system
     void localToGlobal(const gsDofMapper  & mapper,
                        const gsMatrix<T>  & eliminatedDofs,
                        const index_t        patchIndex,
@@ -181,14 +221,25 @@ public:
     }
 
 private:
-    // Dirichlet function
-    const gsFunction<T> * dirdata_ptr;
 
-    // Penalty constant
-    T penalty;
+    /// The underlying PDE
+    const gsPde<T> * m_pde;
 
-    // Side
-    boxSide side;
+    /// Dirichlet function
+    const gsFunction<T> * m_dirdata_ptr;
+
+    /// Parameter \f$\alpha\f$ for the linear form
+    T m_alpha;
+
+    /// Parameter \f$\beta\f$ for the linear form
+    T m_beta;
+
+    /// Parameter \f$\delta\f$ for the linear form
+    T m_penalty;
+
+    /// Patch side
+    patchSide m_side;
+
 
 private:
     // Basis values
@@ -205,6 +256,9 @@ private:
     gsMatrix<T> localRhs;
 
     gsMapData<T> md;
+
+    // Grid size
+    T m_h;
 };
 
 

--- a/src/gsAssembler/gsVisitorNitscheBiharmonic.h
+++ b/src/gsAssembler/gsVisitorNitscheBiharmonic.h
@@ -1,14 +1,14 @@
 /** @file gsVisitorNitscheBiharmonic.h
 
-    @brief First-type Nitsche BC imposition visitor for 
+    @brief First-type Nitsche BC imposition visitor for
            the biharmonic problem.
 
-    This file is part of the G+Smo library. 
+    This file is part of the G+Smo library.
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
-    
+
     Author(s): S. Moore
 */
 
@@ -16,34 +16,36 @@
 
 namespace gismo
 {
-/** @brief
-    Visitor for the first-type Nitsche BC of the biharmonic problem.
 
-    It sets up an assembler and assembles the system patch wise and
-    combines the patch-local stiffness matrices into a global system.
-    Dirichlet boundary can also be imposed weakly (i.e Nitsche ) 
-*/
+   /** \brief Visitor for the weak imposition of the first-type dirichlet
+     *         boundary condition.
+     *
+     * The visitor adds this term to the bilinear term
+     * \f[ (\Delta u, \nabla v)_{\partial \Omega} + (\nabla u, \Delta v )_{\partial \Omega}
+     *       + (\mu* \nabla u, \nabla v)_{\partial \Omega} \f]
+     *
+     * and the following term is also added to the linear term
+     * \f[ (g_1, \mu* \nabla v + \Delta v)_{\partial \Omega}  \f]
+     *
+     *  @ingroup Assembler
+     */
 
 template <class T>
 class gsVisitorNitscheBiharmonic
 {
 public:
-/** \brief Visitor for the weak imposition of the first-type dirichlet 
- *         boundary condition.
- *
- * The visitor adds this term to the bilinear term
- * \f[ (\Delta u, \nabla v)_{\partial \Omega} + (\nabla u, \Delta v )_{\partial \Omega} 
- *       + (\mu* \nabla u, \nabla v)_{\partial \Omega} \f]
- * 
- * and the following term is also added to the linear term
- * \f[ (g_1, \mu* \nabla v + \Delta v)_{\partial \Omega}  \f],
- *
- */
-    gsVisitorNitscheBiharmonic(const gsFunction<T> & dirdata, T _penalty, boxSide s) : 
-    dirdata_ptr(&dirdata),penalty(_penalty), side(s)
+
+    /// @brief Constructor
+    ///
+    /// @param dirdata Dirichlet boundary function
+    /// @param _penalty Penalty
+    /// @param s       Side of the geometry where Dirichlet BC is prescribed
+    gsVisitorNitscheBiharmonic(const gsFunction<T> & dirdata, T penalty, boxSide s)
+    : dirdata_ptr(&dirdata), m_penalty(penalty), side(s)
     { }
 
-    void initialize(const gsBasis<T> & basis, 
+    /// Initialize
+    void initialize(const gsBasis<T> & basis,
                     gsQuadRule<T>    & rule)
     {
         const int dir = side.direction();
@@ -59,7 +61,7 @@ public:
         md.flags = NEED_VALUE | NEED_MEASURE | NEED_GRAD_TRANSFORM | NEED_2ND_DER;
     }
 
-    // Evaluate on element.
+    /// Evaluate on element
     inline void evaluate(const gsBasis<T>    & basis, // to do: more unknowns
                          const gsGeometry<T> & geo,
                          // todo: add element here for efficiency
@@ -85,6 +87,7 @@ public:
         localRhs.setZero(numActive, dirdata_ptr->targetDim());
     }
 
+    /// Assemble on element
     inline void assemble(gsDomainIterator<T> & element,
                          const gsVector<T>   & quWeights)
     {
@@ -116,7 +119,7 @@ public:
 
             // Get penalty parameter
             const T h = element.getCellSize();
-            const T mu = penalty / (0 != h ? h : 1);
+            const T mu = m_penalty / (0 != h ? h : 1);
 
             // Sum up quadrature point evaluations
             localRhs.noalias() += weight * ((physBasisLaplace.transpose() + mu * physBasisGrads.transpose() * unormal)
@@ -127,7 +130,8 @@ public:
                 - mu * physBasisGrads.transpose() * physBasisGrads);
         }
     }
-    
+
+    /// Adds the contributions to the sparse system
     void localToGlobal(const gsDofMapper & mapper,
                        const gsMatrix<T> & eliminatedDofs,
                        const index_t       patchIndex,
@@ -158,7 +162,7 @@ private:
     const gsFunction<T> * dirdata_ptr;
 
     // Penalty constant
-    T penalty;
+    T m_penalty;
 
     // Side
     boxSide side;

--- a/src/gsAssembler/gsVisitorPoisson.h
+++ b/src/gsAssembler/gsVisitorPoisson.h
@@ -145,3 +145,4 @@ protected:
 
 
 } // namespace gismo
+


### PR DESCRIPTION
Improvements for gsVisitorDg and gsVisitorNitsche:
 * By default, the grid size on the physical domain should be considered.
 * Make penalty coefficient freely configurable
 * Introduce additional parameters alpha and beta to make other DG-types (like NIPG) possible

Improvements for gsGenericAssembler:
 * Allow to assemble all terms of interest separately
 * Allow to suppress refreshing, which allows successive assembling
 * Allow to provide custom gsDofMapper

Follow-up changes for assemblers:
 * Provide default options from gsVisitorDg and gsVisitorNitsche, if applicable

Moreover:
 * Improve doxygen (make visitors visible and put them now consistently to assembler module)
 * Prove hpp-file now for all assemblers (so there should be no header-dependence of examples on visitors, which should improve compilation times.)
