### PR TITLE
Add gsTHBSplineBasis::active_into

### DIFF
--- a/src/gsHSplines/gsHTensorBasis.h
+++ b/src/gsHSplines/gsHTensorBasis.h
@@ -468,7 +468,7 @@ public:
     }
 
     // Look at gsBasis.h for the documentation of this function
-    void active_into(const gsMatrix<T> & u, gsMatrix<index_t>& result) const;
+    virtual void active_into(const gsMatrix<T> & u, gsMatrix<index_t>& result) const;
 
 
     // Look at gsBasis.h for the documentation of this function

--- a/src/gsHSplines/gsTHBSplineBasis.h
+++ b/src/gsHSplines/gsTHBSplineBasis.h
@@ -128,6 +128,9 @@ public:
     BoundaryBasisType * basisSlice(index_t dir_fixed,T par ) const;
 
     // Look at gsBasis class for documentation
+    void active_into(const gsMatrix<T>& u, gsMatrix<index_t>& result) const;
+
+    // Look at gsBasis class for documentation
     void deriv2_into(const gsMatrix<T>& u, gsMatrix<T>& result)const;
 
     // Look at gsBasis class for documentatation

--- a/src/gsHSplines/gsTHBSplineBasis.hpp
+++ b/src/gsHSplines/gsTHBSplineBasis.hpp
@@ -1105,7 +1105,7 @@ void gsTHBSplineBasis<d,T>::active_into(const gsMatrix<T>& u, gsMatrix<index_t>&
 
                         for (index_t k = 0; k < ind.rows(); ++k) 
                         {
-                            if (math::abs(coefs(ind.at(k))) > std::numeric_limits<T>::epsilon() * 100)
+                            if (math::abs(coefs(ind.at(k))) > math::limits::epsilon() * 100)
                             {
                                 temp_output[p].push_back(act);
                                 break;

--- a/src/gsHSplines/gsTHBSplineBasis.hpp
+++ b/src/gsHSplines/gsTHBSplineBasis.hpp
@@ -1061,6 +1061,7 @@ template<short_t d, class T>
 void gsTHBSplineBasis<d,T>::active_into(const gsMatrix<T>& u, gsMatrix<index_t>& result) const
 {
     gsMatrix<T> currPoint;
+    gsMatrix<index_t> ind;
     point low, upp, cur;
     const int maxLevel = this->m_tree.getMaxInsLevel();
 
@@ -1100,12 +1101,11 @@ void gsTHBSplineBasis<d,T>::active_into(const gsMatrix<T>& u, gsMatrix<index_t>&
                         const gsTensorBSplineBasis<d, T>& base =
                             *this->m_bases[this->m_is_truncated[act]];
 
-                        gsMatrix<index_t> ind;
                         base.active_into(currPoint, ind);
 
                         for (index_t k = 0; k < ind.rows(); ++k) 
                         {
-                            if (!gsClose(coefs(ind.at(k)), 0.0, 1e-10)) 
+                            if (math::abs(coefs(ind.at(k))) > std::numeric_limits<T>::epsilon() * 100)
                             {
                                 temp_output[p].push_back(act);
                                 break;

--- a/src/gsHSplines/gsTHBSplineBasis.hpp
+++ b/src/gsHSplines/gsTHBSplineBasis.hpp
@@ -1105,7 +1105,7 @@ void gsTHBSplineBasis<d,T>::active_into(const gsMatrix<T>& u, gsMatrix<index_t>&
 
                         for (index_t k = 0; k < ind.rows(); ++k) 
                         {
-                            if (coefs(ind.at(k))) != 0)
+                            if (coefs(ind.at(k)) != 0)
                             {
                                 temp_output[p].push_back(act);
                                 break;

--- a/src/gsHSplines/gsTHBSplineBasis.hpp
+++ b/src/gsHSplines/gsTHBSplineBasis.hpp
@@ -1105,7 +1105,7 @@ void gsTHBSplineBasis<d,T>::active_into(const gsMatrix<T>& u, gsMatrix<index_t>&
 
                         for (index_t k = 0; k < ind.rows(); ++k) 
                         {
-                            if (math::abs(coefs(ind.at(k))) > math::limits::epsilon() * 100)
+                            if (coefs(ind.at(k))) != 0)
                             {
                                 temp_output[p].push_back(act);
                                 break;

--- a/src/gsHSplines/gsTHBSplineBasis.hpp
+++ b/src/gsHSplines/gsTHBSplineBasis.hpp
@@ -1083,7 +1083,7 @@ void gsTHBSplineBasis<d,T>::active_into(const gsMatrix<T>& u, gsMatrix<index_t>&
             cur = low;
             do
             {
-                CMatrix::const_iterator it =
+                typename CMatrix::const_iterator it =
                     m_xmatrix[i].find_it_or_fail( m_bases[i]->index(cur) );
 
                 if( it != m_xmatrix[i].end() )// if index is found


### PR DESCRIPTION
The member function active_into is added into gsTHBSplineBasis,
which now can really output the non-zero reasults, Instead of simply
Inherited from class gsHTensorBasis.