### PR TITLE
Dofs mapper

### DIFF
--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -909,8 +909,7 @@ public:
 
         const gsMultiBasis<T> * smb = static_cast<const gsMultiBasis<T>*>(&this->source());
 
-        if (!m_mapper.isFinalized()) // space has no mapper
-        {
+        if (!m_mapper.isFinalized()) { // space has no mapper
             if (const gsMultiBasis<T> * mb =
                 dynamic_cast<const gsMultiBasis<T>*>(&this->source()) )
             {


### PR DESCRIPTION
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----

I added in the input of setup() function the dofMapper to have an option for adding the own dofMapper, e.g. somebody wants dofs only at the first two rows of the tensor-product splines (could happen in the local projection).

I don't know why github is showing that much difference, but the main difference is line 903, 908 and 912 (with the closing bracket at the end), the others is keeped untouched even github is saying that there are differents.