### PR TITLE
Extend gsMultiGrid and improve docs

### DIFF
--- a/doc/multiGrid_example.dox
+++ b/doc/multiGrid_example.dox
@@ -140,15 +140,16 @@ on the command line options, we use
  - a Richardson smoother,
  - a Jacobi smoother,
  - a Gauss-Seidel smoother,
+ - an incomplete LU smoother,
  - a subspace corrected mass smoother, or
  - a hybrid smoother (subspace corrected mass smoother + Gauss-Seidel smoother).
 
 The subspace corrected mass smoother is a multi-patch version as introduced in
 
- - S. Takacs. Robust approximation error estimates and multigrid solvers for isogeometric multi-patch discretizations.
-Mathematical Models and Methods in Applied Sciences, vol. 28 (10), p. 1899 -- 1928, 2018.
  - C. Hofreither and S. Takacs. Robust multigrid for Isogeometric Analysis based on stable splittings of spline spaces.
 SIAM J. on Numerical Analysis, vol. 55 (4), p. 2004 -- 2024, 2017.
+ - S. Takacs. Robust approximation error estimates and multigrid solvers for isogeometric multi-patch discretizations.
+Mathematical Models and Methods in Applied Sciences, vol. 28 (10), p. 1899 -- 1928, 2018.
 
 \snippet multiGrid_example.cpp Define smoothers
 

--- a/src/gsMultiGrid/gsMultiGrid.hpp
+++ b/src/gsMultiGrid/gsMultiGrid.hpp
@@ -1,6 +1,6 @@
 /** @file gsMultiGrid.hpp
 
-    @brief Multigrid solver for isogeometric discretizations.
+    @brief Multigrid preconditioner
 
     This file is part of the G+Smo library.
 
@@ -22,11 +22,13 @@ gsMultiGridOp<T>::gsMultiGridOp(
     std::vector<SpMatrixRowMajor> transferMatrices,
     OpPtr coarseSolver
 )
-    : n_levels(transferMatrices.size()+1), m_ops(n_levels), m_smoother(n_levels), m_prolong(n_levels-1), m_restrict(n_levels-1),
-      m_coarseSolver(coarseSolver), m_numPreSmooth(1), m_numPostSmooth(1), m_numCycles(1), m_damping(1)
+    : m_nLevels(transferMatrices.size()+1), m_ops(m_nLevels), m_smoother(m_nLevels),
+      m_prolong(m_nLevels-1), m_restrict(m_nLevels-1), m_coarseSolver(coarseSolver),
+      m_numPreSmooth(1), m_numPostSmooth(1), m_symmSmooth(true), m_damping(1)
 {
-    std::vector<SpMatrixRowMajorPtr> transferMatrixPtrs(n_levels);
-    for (index_t i=0; i<n_levels-1; ++i)
+    m_numCycles.setConstant(m_nLevels-1,1);
+    std::vector<SpMatrixRowMajorPtr> transferMatrixPtrs(m_nLevels-1);
+    for (index_t i=0; i<m_nLevels-1; ++i)
         transferMatrixPtrs[i] = transferMatrices[i].moveToPtr();
 
     init(fineMatrix.moveToPtr(),give(transferMatrixPtrs));
@@ -38,9 +40,11 @@ gsMultiGridOp<T>::gsMultiGridOp(
     std::vector<SpMatrixRowMajorPtr> transferMatrices,
     OpPtr coarseSolver
 )
-    : n_levels(transferMatrices.size()+1), m_ops(n_levels), m_smoother(n_levels), m_prolong(n_levels-1), m_restrict(n_levels-1),
-      m_coarseSolver(coarseSolver), m_numPreSmooth(1), m_numPostSmooth(1), m_numCycles(1), m_damping(1)
+    : m_nLevels(transferMatrices.size()+1), m_ops(m_nLevels), m_smoother(m_nLevels),
+      m_prolong(m_nLevels-1), m_restrict(m_nLevels-1), m_coarseSolver(coarseSolver),
+      m_numPreSmooth(1), m_numPostSmooth(1), m_symmSmooth(true), m_damping(1)
 {
+    m_numCycles.setConstant(m_nLevels-1,1);
     init(give(fineMatrix),give(transferMatrices));
 }
 
@@ -51,9 +55,11 @@ gsMultiGridOp<T>::gsMultiGridOp(
     const std::vector<OpPtr>& restriction,
     OpPtr coarseSolver
 )
-    : n_levels(ops.size()), m_ops(ops), m_smoother(n_levels), m_prolong(prolongation), m_restrict(restriction),
-      m_coarseSolver(coarseSolver), m_numPreSmooth(1), m_numPostSmooth(1), m_numCycles(1), m_damping(1)
+    : m_nLevels(ops.size()), m_ops(ops), m_smoother(m_nLevels),
+      m_prolong(prolongation), m_restrict(restriction), m_coarseSolver(coarseSolver),
+      m_numPreSmooth(1), m_numPostSmooth(1), m_symmSmooth(true), m_damping(1)
 {
+    m_numCycles.setConstant(m_nLevels-1,1);
     GISMO_ASSERT (prolongation.size() == restriction.size(),
         "gsMultiGridOp: The number of prolongation and restriction operators differ.");
     GISMO_ASSERT (ops.size() == prolongation.size()+1,
@@ -66,9 +72,9 @@ void gsMultiGridOp<T>::init(SpMatrixPtr fineMatrix, std::vector<SpMatrixRowMajor
     GISMO_ASSERT (fineMatrix->rows() == fineMatrix->cols(), "gsMultiGridOp needs quadratic matrices.");
 
     SpMatrixPtr mat = fineMatrix;
-    m_ops[n_levels-1] = makeMatrixOp(mat);
+    m_ops[m_nLevels-1] = makeMatrixOp(mat);
 
-    for ( index_t i = n_levels - 2; i >= 0; --i )
+    for ( index_t i = m_nLevels - 2; i >= 0; --i )
     {
         SpMatrixPtr newMat = SpMatrixPtr(new SpMatrix(
             transferMatrices[i]->transpose() * *mat * *(transferMatrices[i])
@@ -77,13 +83,14 @@ void gsMultiGridOp<T>::init(SpMatrixPtr fineMatrix, std::vector<SpMatrixRowMajor
         mat = newMat; // copies just the smart pointers
     }
 
-    for ( index_t i=0; i<n_levels-1; ++i )
+    for ( index_t i=0; i<m_nLevels-1; ++i )
     {
         m_prolong[i] = makeMatrixOp(transferMatrices[i]);
-        m_restrict[i] = makeMatrixOp(transferMatrices[i]->transpose()); // note that this works as we know that
-                                                           // m_prolong does not get destroyed before
-                                                           // m_restrict, so the shared pointer stored in m_prolong
-                                                           // will make sure that the matrix will not get destroyed
+        // Note that the following works since we know that m_prolong does not
+        // get destroyed beforem_restrict, so the shared pointer stored in
+        // m_prolong will make sure that the underlying matrix will not get
+        // destroyed. Thus, there will be no dangling pointer.
+        m_restrict[i] = makeMatrixOp(transferMatrices[i]->transpose());
     }
 }
 
@@ -129,7 +136,10 @@ void gsMultiGridOp<T>::smoothingStep(index_t level, const Matrix& rhs, Matrix& x
     // post-smooth
     for (index_t i = 0; i < m_numPostSmooth; ++i)
     {
-        m_smoother[level]->stepT( rhs, x );
+        if (m_symmSmooth)
+            m_smoother[level]->stepT( rhs, x );
+        else
+            m_smoother[level]->step( rhs, x );
     }
 
 }
@@ -137,7 +147,7 @@ void gsMultiGridOp<T>::smoothingStep(index_t level, const Matrix& rhs, Matrix& x
 template<class T>
 void gsMultiGridOp<T>::multiGridStep(index_t level, const Matrix& rhs, Matrix& x) const
 {
-    GISMO_ASSERT ( 0 <= level && level < n_levels, "TgsMultiGridOp: the given level is not feasible." );
+    GISMO_ASSERT ( 0 <= level && level < m_nLevels, "TgsMultiGridOp: the given level is not feasible." );
 
     if (level == 0)
     {
@@ -168,7 +178,7 @@ void gsMultiGridOp<T>::multiGridStep(index_t level, const Matrix& rhs, Matrix& x
 
         // obtain coarse-grid correction by recursing
         coarseCorr.setZero( nDofs(lc), coarseRes.cols() );
-        for (index_t i = 0; i < ((lc==0 && m_numCycles>0) ? 1 : m_numCycles); ++i)   // coarse solve is never cycled
+        for (index_t i = 0; i < m_numCycles[lc]; ++i)
         {
             multiGridStep( lc, coarseRes, coarseCorr );
         }
@@ -182,7 +192,10 @@ void gsMultiGridOp<T>::multiGridStep(index_t level, const Matrix& rhs, Matrix& x
         // post-smooth
         for (index_t i = 0; i < m_numPostSmooth; ++i)
         {
-            m_smoother[lf]->stepT( rhs, x );
+            if (m_symmSmooth)
+                m_smoother[lf]->stepT( rhs, x );
+            else
+                m_smoother[lf]->step( rhs, x );
         }
     }
 }
@@ -195,12 +208,12 @@ void gsMultiGridOp<T>::fullMultiGrid(
 ) const
 {
 
-    GISMO_ASSERT (fixedValues.size() == static_cast<size_t>(n_levels),
+    GISMO_ASSERT (fixedValues.size() == static_cast<size_t>(m_nLevels),
         "gsMultiGridOp::fullMultiGrid: The size of fixedValues does not correspond to the number of levels.");
-    GISMO_ASSERT (rhs.size() == static_cast<size_t>(n_levels),
+    GISMO_ASSERT (rhs.size() == static_cast<size_t>(m_nLevels),
         "gsMultiGridOp::fullMultiGrid: The size of rhs does not correspond to the number of levels.");
 
-    std::vector<Matrix> u(n_levels);
+    std::vector<Matrix> u(m_nLevels);
 
     // solve coarse problem
     solveCoarse( rhs[0], u[0] );
@@ -226,12 +239,12 @@ void gsMultiGridOp<T>::cascadicMultiGrid(
 ) const
 {
 
-    GISMO_ASSERT (fixedValues.size() == static_cast<size_t>(n_levels),
+    GISMO_ASSERT (fixedValues.size() == static_cast<size_t>(m_nLevels),
         "gsMultiGridOp::cascadicMultiGrid: The size of fixedValue does not correspond to the number of levels.");
-    GISMO_ASSERT (rhs.size() == static_cast<size_t>(n_levels),
+    GISMO_ASSERT (rhs.size() == static_cast<size_t>(m_nLevels),
         "gsMultiGridOp::cascadicMultiGrid: The size of rhs does not correspond to the number of levels.");
 
-    std::vector<Matrix> u(n_levels);
+    std::vector<Matrix> u(m_nLevels);
 
     // solve coarse problem
     solveCoarse( rhs[0], u[0] );
@@ -252,7 +265,7 @@ void gsMultiGridOp<T>::cascadicMultiGrid(
 template<class T>
 void gsMultiGridOp<T>::restrictVector(index_t lf, const Matrix& fine, Matrix& coarse) const
 {
-    GISMO_ASSERT ( 0 < lf && lf < n_levels, "gsMultiGrid: The given level is not feasible." );
+    GISMO_ASSERT ( 0 < lf && lf < m_nLevels, "gsMultiGrid: The given level is not feasible." );
     GISMO_ASSERT ( fine.rows() == nDofs(lf), "gsMultiGrid: The dimensions do not fit." );
 
     m_restrict[lf-1]->apply( fine, coarse );
@@ -261,7 +274,7 @@ void gsMultiGridOp<T>::restrictVector(index_t lf, const Matrix& fine, Matrix& co
 template<class T>
 void gsMultiGridOp<T>::prolongVector(index_t lc, const Matrix& coarse, Matrix& fine) const
 {
-    GISMO_ASSERT ( 0 <= lc && lc < n_levels - 1, "gsMultiGrid: The given level is not feasible." );
+    GISMO_ASSERT ( 0 <= lc && lc < m_nLevels - 1, "gsMultiGrid: The given level is not feasible." );
     GISMO_ASSERT ( coarse.rows() == nDofs(lc), "gsMultiGrid: The dimensions do not fit." );
 
     m_prolong[lc]->apply( coarse, fine );
@@ -270,7 +283,7 @@ void gsMultiGridOp<T>::prolongVector(index_t lc, const Matrix& coarse, Matrix& f
 template<class T>
 void gsMultiGridOp<T>::setSmoother(index_t lvl, const PrecondPtr& sm)
 {
-    GISMO_ASSERT ( 0 <= lvl && lvl < n_levels, "gsMultiGrid: The given level is not feasible." );
+    GISMO_ASSERT ( 0 <= lvl && lvl < m_nLevels, "gsMultiGrid: The given level is not feasible." );
     m_smoother[lvl] = sm;
 }
 
@@ -287,10 +300,11 @@ template<class T>
 gsOptionList gsMultiGridOp<T>::defaultOptions()
 {
     gsOptionList opt = Base::defaultOptions();
-    opt.addInt   ("NumPreSmooth"                , "Number of pre-smoothing steps",                             1      );
-    opt.addInt   ("NumPostSmooth"               , "Number of post-smoothing steps",                            1      );
-    opt.addInt   ("NumCycles"                   , "Number of cycles (usually 1 for V-cycle or 2 for W-cycle)", 1      );
-    opt.addReal  ("CorarseGridCorrectionDamping", "Damping of the coarse-grid correction (usually 1)",      (T)1      );
+    opt.addInt   ("NumPreSmooth"                , "Number of pre-smoothing steps",                             1 );
+    opt.addInt   ("NumPostSmooth"               , "Number of post-smoothing steps",                            1 );
+    opt.addInt   ("NumCycles"                   , "Number of cycles (usually 1 for V-cycle or 2 for W-cycle)", 1 );
+    opt.addReal  ("CorarseGridCorrectionDamping", "Damping of the coarse-grid correction (usually 1)",      (T)1 );
+    opt.addSwitch("SymmSmooth"                  , "Iff true, stepT is called for post-smoothing",           true );
     return opt;
 }
 
@@ -300,8 +314,16 @@ void gsMultiGridOp<T>::setOptions(const gsOptionList & opt)
     Base::setOptions(opt);
     m_numPreSmooth     = opt.askInt   ("NumPreSmooth"                , m_numPreSmooth    );
     m_numPostSmooth    = opt.askInt   ("NumPostSmooth"               , m_numPostSmooth   );
-    m_numCycles        = opt.askInt   ("NumCycles"                   , m_numCycles       );
     m_damping          = opt.askReal  ("CorarseGridCorrectionDamping", m_damping         );
+    m_symmSmooth       = opt.askSwitch("SymmSmooth"                  , m_symmSmooth      );
+
+    const index_t nc   = opt.askInt   ("NumCycles"                   , -1                );
+    if (nc > -1)
+    {
+        m_numCycles.setConstant(m_nLevels-1, nc);
+        // The direct solver on coarsest level is only invoked once
+        m_numCycles[0] = 1;
+    }
 }
 
 }


### PR DESCRIPTION
This contains two features that are used in the pMultigrid example:
* Non-symmetric smoothing (i.e., pre- and post-smoothing are both forward Gauss-Seidel)
* Different cycles (V-cycle/W-cycle) depending on the level

Moreover, the class and its docs are improved.