### PR TITLE
change atomic to critical

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -503,7 +503,7 @@ private:
                                     {
                                         // Symmetric treatment of eliminated BCs
                                         // GISMO_ASSERT(1==m_rhs.cols(), "-");
-#                                       pragma omp atomic
+#                                       pragma omp critical (acc_m_rhs)
                                         m_rhs.at(ii) -= localMat(rls+i,cls+j) *
                                             fixedDofs.at(colMap.global_to_bindex(jj));
                                     }


### PR DESCRIPTION
Change atomic to critical. Seems to be more stable than atomic. 

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
