### PR TITLE
Fixes kirchhoff-Love_example.

### DIFF
--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -952,7 +952,8 @@ public:
             {
                 const int ii = m_sd->mapper.index(i, p, c);
                 if ( m_sd->mapper.is_free_index(ii) ) // DoF value is in the solVector
-                    result(i,c) = solVector.at(ii);
+                  for(index_t s = 0; s != solVector.cols(); ++s )
+                    result(i,c+s) = solVector(ii,s); //assume dim==1 xor solVector.cols()==1
                 else // eliminated DoF: fill with Dirichlet data
                 {
                     result(i,c) =  m_sd->fixedDofs.at( m_sd->mapper.global_to_bindex(ii) );

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -952,8 +952,7 @@ public:
             {
                 const int ii = m_sd->mapper.index(i, p, c);
                 if ( m_sd->mapper.is_free_index(ii) ) // DoF value is in the solVector
-                    result.row(i) = solVector.row(ii);
-                    //result(i,c) = solVector.at(ii);
+                    result(i,c) = solVector.at(ii);
                 else // eliminated DoF: fill with Dirichlet data
                 {
                     result(i,c) =  m_sd->fixedDofs.at( m_sd->mapper.global_to_bindex(ii) );


### PR DESCRIPTION
In gsExpressions.h, gsFeSpace::getCoeffs the
result.row(i) = solVector.row(ii);
Fails since the solvector is a column vector (since it is defined by a
gsDofMapper).


