### PR TITLE
reverting inheritance the way it was when gsMappedSpline was still gsCompositeGeom

### DIFF
--- a/src/gsMSplines/gsMappedSpline.h
+++ b/src/gsMSplines/gsMappedSpline.h
@@ -26,7 +26,7 @@ namespace gismo
 template<short_t d,class T> class gsMappedSingleSpline;
 
 template<short_t d,class T>
-class gsMappedSpline : public gsFunctionSet<T>
+class gsMappedSpline : public gsGeoTraits<d,T>::GeometryBase
 {
     friend class gsMappedSingleSpline<d,T>;
 
@@ -122,6 +122,10 @@ public:
 //////////////////////////////////////////////////
 // Virtual member functions required by the base class
 //////////////////////////////////////////////////
+
+    typedef gsMappedSingleBasis<d, T> Basis;
+
+    GISMO_BASIS_ACCESSORS
 
     GISMO_CLONE_FUNCTION(gsMappedSpline)
 


### PR DESCRIPTION
As far as I can tell, the stable class ```gsMappedSpline``` has been made from the unsupported class ```gsCompositeGeom```. However, there is an important difference:

- ```gsCompositeGeom``` inherits from ```gsGeoTraits<d,T>::GeometryBase```
- ```gsMappedSpline``` inherits from ```gsFunctionSet<T>```

Unless there is a reason for this change (@hverhelst or @filiatra probably know more), I would like to revert it and make ```gsMappedSpline``` inherit from ```gsGeoTraits<d,T>::GeometryBase```. In my view, this is required so that I can bring ```gsCompositeIncrSmoothnessGeom``` and the rest of ```gsSmoothPatches``` into a branch of stable.

The magic with ```GISMO_BASIS_ACCESSORS``` has been necessary to get around the rather cryptic compiler errors.

Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Le checklist
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
**Yes, see above**
- [X] Have you documented any new codes using Doxygen comments?
**No, I don't think it is necessary in this case.**
- [X] Have you written new tests or examples for your changes?
**No, I don't think it is necessary in this case.**
-----
