### PR TITLE
Fix Pardiso

### DIFF
--- a/cmake/FindPardiso.cmake
+++ b/cmake/FindPardiso.cmake
@@ -7,7 +7,9 @@
 
 # First try: Pardiso compiled with Intel fortran
 if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-  file(GLOB pardiso_names "${Pardiso_DIR}/libpardiso*INTEL*${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  string(TOUPPER ${CMAKE_SYSTEM_PROCESSOR} ARCH)
+  string(REPLACE "_" "-" ARCH ${ARCH})
+  file(GLOB pardiso_names "${Pardiso_DIR}/libpardiso*INTEL*${ARCH}*${CMAKE_SHARED_LIBRARY_SUFFIX}")
   list(GET pardiso_names 0 pardiso_first)
   get_filename_component(pardiso_name ${pardiso_first} NAME)
   find_library(PARDISO_LIBRARY NAMES ${pardiso_name}
@@ -31,7 +33,6 @@ if(PARDISO_LIBRARY)
    set_target_properties(Pardiso PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES "${LAPACK_LIBRARIES}")
 
 
-
   # Note libmkl_intel.so or libmkl_intel_lp64.so contains "pardiso/pardiso64"
 
    set(Pardiso_FOUND TRUE)
@@ -42,7 +43,10 @@ endif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 
 # Second try: Pardiso compiled with GNU GCC
 if(NOT Pardiso_FOUND)
-  file(GLOB pardiso_names "${Pardiso_DIR}/libpardiso*GNU*${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  string(TOUPPER ${CMAKE_SYSTEM_PROCESSOR} ARCH)
+  string(REPLACE "_" "-" ARCH ${ARCH})
+  file(GLOB pardiso_names "${Pardiso_DIR}/libpardiso*GNU*${ARCH}*${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                          "${Pardiso_DIR}/libpardiso*MACOS*${ARCH}*${CMAKE_SHARED_LIBRARY_SUFFIX}")
   list(GET pardiso_names 0 pardiso_first)
   get_filename_component(pardiso_name ${pardiso_first} NAME)
   find_library(PARDISO_LIBRARY NAMES ${pardiso_name}
@@ -60,6 +64,8 @@ if(NOT Pardiso_FOUND)
 
    #find_package(OpenMP)
    #set_target_properties(Pardiso IMPORTED_LINK_INTERFACE_LIBRARIES ${OpenMP_CXX_FLAGS})
+
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lgfortran")
 
   endif(PARDISO_LIBRARY)
 

--- a/external/rapidxml/rapidxml.hpp
+++ b/external/rapidxml/rapidxml.hpp
@@ -2,7 +2,7 @@
 #define RAPIDXML_HPP_INCLUDED
 
 
-#include <stdio.h> // G+Smo: for sprintf
+#include <stdio.h> // G+Smo: for snprintf
 
 
 // Copyright (C) 2006, 2009 Marcin Kalicinski
@@ -1387,7 +1387,7 @@ namespace rapidxml
         void appendToRoot(xml_node<Ch> * node, int id = -1)
         {
             char tmp[6];
-            sprintf(tmp,"%d", (unsigned short)(-1==id ? ++max_Id : id ));
+            snprintf(tmp, 6, "%d", (unsigned short)(-1==id ? ++max_Id : id ));
             node->append_attribute(this->allocate_attribute(
             this->allocate_string("id"), this->allocate_string(tmp) ) );
             getRoot()->append_node(node);

--- a/src/gsIO/gsXml.cpp
+++ b/src/gsIO/gsXml.cpp
@@ -44,7 +44,7 @@ gsXmlAttribute * makeAttribute( const std::string & name, const std::string & va
 gsXmlAttribute * makeAttribute( const std::string & name, const unsigned & value, gsXmlTree & data)
 {
     char tmp[16];
-    sprintf (tmp,"%d",value);
+    snprintf (tmp,16,"%d",value);
     return data.allocate_attribute( 
 	   data.allocate_string(name.c_str() ), 
 	   data.allocate_string(tmp) );
@@ -74,7 +74,7 @@ gsXmlNode * makeComment(const std::string & comment, gsXmlTree & data)
 std::string to_string(const unsigned & i)
 {
     char tmp[4];
-    sprintf (tmp,"%d",i);
+    snprintf (tmp,4,"%d",i);
     return tmp;
 }
 


### PR DESCRIPTION
Fix missing '-lgfortran' when G+Smo is compiled with `GISMO_WITH_PARDISO=ON`.
