### PR TITLE
removing references to deleted files from gsInstall.cmake

### DIFF
--- a/cmake/gsInstall.cmake
+++ b/cmake/gsInstall.cmake
@@ -135,10 +135,6 @@ install(FILES
   "${PROJECT_SOURCE_DIR}/cmake/CodeCoverage.cmake"
   "${PROJECT_SOURCE_DIR}/cmake/OptimizeForArchitecture.cmake"
   "${PROJECT_SOURCE_DIR}/cmake/AddCompilerFlag.cmake"
-  "${PROJECT_SOURCE_DIR}/cmake/CheckCCompilerFlag.cmake"
-  "${PROJECT_SOURCE_DIR}/cmake/CheckCXXCompilerFlag.cmake"
-  "${PROJECT_SOURCE_DIR}/cmake/CheckMicCCompilerFlag.cmake"
-  "${PROJECT_SOURCE_DIR}/cmake/CheckMicCXXCompilerFlag.cmake"
   DESTINATION "${CMAKE_INSTALL_DIR}" COMPONENT devel)
 
 # Install the export set for use with the install-tree


### PR DESCRIPTION
This is a tiny extension of #577: the deleted cmake files should not be referenced in the install scripts.