### PR TITLE
Add labels to boundaries for easy reference of multipatch geometries

### DIFF
--- a/filedata/pde/poisson2d_bvp.xml
+++ b/filedata/pde/poisson2d_bvp.xml
@@ -6,13 +6,15 @@
     <patches type="id_range">500 501</patches>
     <interfaces>501 1 500 2 0 1 1 1
     </interfaces>
-    <boundary>
+    <boundary name="dirichlet">
       501 4
-      501 3
-      501 2
       500 3
+      501 3
+    </boundary>
+    <boundary name="neumann">
       500 4
       500 1
+      501 2
     </boundary>
   </MultiPatch>
 
@@ -20,7 +22,7 @@
   <Function type="FunctionExpr" id="1" dim="2">2*pi^2*sin(pi*x)*sin(pi*y)</Function>
 
   <!-- The boundary conditions (multipatch=number of patches)-->
-  <boundaryConditions id="2" multipatch="2">
+  <boundaryConditions id="2" multipatch="0">
     <Function type="FunctionExpr" dim="2" index="0">sin(pi*x) * sin(pi*y)</Function>
     <Function type="FunctionExpr" dim="2" index="1" c="2">
       <c index="0">pi*cos(pi*x) * sin(pi*y)</c>
@@ -29,17 +31,10 @@
     <Function type="FunctionExpr" dim="2" index="2">0</Function><!--unused-->
 
     <!-- Dirichlet conditions (patch,side) -->
-    <bc type="Dirichlet" function="0" unknown="0">
-      1 4
-      0 3
-      1 3
+    <bc type="Dirichlet" function="0" unknown="0" name="dirichlet">
     </bc>
 
-    <!-- Neumann conditions (patch,side)-->
-    <bc unknown="0" type="Neumann" function="1">
-      0 4
-      0 1
-      1 2
+    <bc unknown="0" type="Neumann" function="1" name="neumann">
     </bc>
   </boundaryConditions>
 

--- a/src/gsCore/gsBoundary.h
+++ b/src/gsCore/gsBoundary.h
@@ -232,21 +232,25 @@ struct GISMO_EXPORT patchSide : public boxSide
 {
 public:
     index_t patch;              ///< The index of the patch.
+protected:
+    std::string m_label;        ///< The label of the patchSide.
 public:
 
-    patchSide() : boxSide(), patch(0) { }
+    patchSide() : boxSide(), patch(0), m_label("") { }
 
-    patchSide(index_t p, boxSide s)
-        : boxSide(s), patch(p) { }
+    patchSide(index_t p, boxSide s, const std::string & l="")
+        : boxSide(s), patch(p), m_label(l) { }
 
-    patchSide(index_t p, boundary::side s)
-        : boxSide(s), patch(p) { }
+    patchSide(index_t p, boundary::side s, const std::string & l="")
+        : boxSide(s), patch(p), m_label(l) { }
 
     // Accessors
     boxSide& side()       {return *this;}
     const boxSide& side() const {return *this;}
 
     index_t patchIndex() {return patch;}
+    const std::string & label() const {return m_label;}
+    std::string & label() {return m_label;}
 
     /**
      * @brief returns the vector of the corners contained in the side
@@ -262,7 +266,7 @@ public:
 inline std::ostream &operator<<(std::ostream &os, patchSide const & i)
 {
     //os<<"Side: patch="<< i.patch<<", side="<< int(i.side)<<", ie. "<< i.side << ".\n";
-    os<<i.patch<<":"<< i.side();
+    os<<i.patch<<":"<< i.side()<<" "<<i.label();
     return os;
 }
 
@@ -648,8 +652,9 @@ public:
     // special constructor for the 2d case
     boundaryInterface(patchSide const & _ps1,
                       patchSide const & _ps2,
-                      bool o1)
-        : ps1(_ps1), ps2(_ps2), m_type(interaction::conforming)
+                      bool o1,
+                      const std::string & l = "")
+        : m_label(l), ps1(_ps1), ps2(_ps2), m_type(interaction::conforming)
     {
         directionMap.resize(2);
         directionOrientation.resize(2);
@@ -663,8 +668,9 @@ public:
     //
     boundaryInterface(patchSide const & _ps1,
                       patchSide const & _ps2,
-                      short_t dim)
-        : ps1(_ps1), ps2(_ps2), m_type(interaction::conforming)
+                      short_t dim,
+                      const std::string & l = "")
+        : m_label(l), ps1(_ps1), ps2(_ps2), m_type(interaction::conforming)
     {
         directionMap.resize(dim);
         directionOrientation.resize(dim);
@@ -685,8 +691,9 @@ public:
 
     boundaryInterface(gsVector<short_t>     const & p,
                       gsVector<index_t> const & map_info,
-                      gsVector<bool>    const & orient_flags)
-    : ps1(p(0),p(1)), ps2(p(2),p(3)),
+                      gsVector<bool>    const & orient_flags,
+                      const std::string & l = "")
+    : m_label(l), ps1(p(0),p(1)), ps2(p(2),p(3)),
       directionMap(map_info),
       directionOrientation(orient_flags), m_type(interaction::conforming)
     {
@@ -698,8 +705,9 @@ public:
     boundaryInterface(patchSide const & _ps1,
                       patchSide const & _ps2,
                       gsVector<index_t> const & map_info,
-                      gsVector<bool>    const & orient_flags)
-        : ps1(_ps1), ps2(_ps2), directionMap(map_info), directionOrientation(orient_flags)
+                      gsVector<bool>    const & orient_flags,
+                      const std::string & l = "")
+        : m_label(l), ps1(_ps1), ps2(_ps2), directionMap(map_info), directionOrientation(orient_flags)
         , m_type(interaction::conforming)
     {
         directionMap(ps1.direction())=ps2.direction();
@@ -708,24 +716,28 @@ public:
 
     GISMO_DEPRECATED boundaryInterface(patchSide const & _ps1,
                       patchSide const & _ps2,
-                      gsVector<bool>    const & orient_flags)
+                      gsVector<bool>    const & orient_flags,
+                      const std::string & l = "")
     {
-        init(_ps1,_ps2,orient_flags);
+        init(_ps1,_ps2,orient_flags,l);
     }
 
     GISMO_DEPRECATED boundaryInterface(gsVector<short_t>     const & p,
-                      gsVector<bool>    const & orient_flags)
+                      gsVector<bool>    const & orient_flags,
+                      const std::string & l = "")
     {
-        init(patchSide(p(0),boxSide(p(1))),patchSide(p(2),boxSide(p(3))) ,orient_flags);
+        init(patchSide(p(0),boxSide(p(1))),patchSide(p(2),boxSide(p(3))) ,orient_flags,l);
     }
 
     //DEPRECATED
     void init (patchSide const & _ps1,
                patchSide const & _ps2,
-               gsVector<bool>    const & orient_flags)
+               gsVector<bool>    const & orient_flags,
+            const std::string & l = "")
     {
         ps1=_ps1;
         ps2=_ps2;
+        m_label = l;
 
         const index_t dim = orient_flags.cols()+1;
         directionMap.resize(dim);
@@ -738,6 +750,10 @@ public:
         directionOrientation(1-ps1.direction())= orient_flags(0);
         m_type = interaction::conforming;
     }
+
+    /// Return the label
+    const std::string & label() const {return m_label;}
+    std::string & label() {return m_label;}
 
 
     bool operator== (const boundaryInterface & other) const
@@ -906,6 +922,7 @@ public:
     interaction::type type() const { return m_type; }
 
 private:
+    std::string m_label; ///< The label of the interface.
 
     patchSide ps1; ///< The first patch side.
     patchSide ps2; ///< The second patch side.

--- a/src/gsCore/gsBoxTopology.h
+++ b/src/gsCore/gsBoxTopology.h
@@ -172,9 +172,10 @@ public:
 
     /// Add an interface between side \a s1 of box \a p1 and side \a s2 of box \a p2.
     void addInterface(index_t p1, boxSide s1,
-                      index_t p2, boxSide s2)
+                      index_t p2, boxSide s2,
+                      std::string l = "")
     {
-        addInterface(boundaryInterface(patchSide(p1, s1), patchSide(p2, s2), m_dim));
+        addInterface(boundaryInterface(patchSide(p1, s1), patchSide(p2, s2), m_dim,l));
     }
 
     /// Add an interface described by \a bi.
@@ -190,9 +191,9 @@ public:
     }
 
     /// Set side \a s of box \a p to a boundary.
-    void addBoundary(index_t p, boxSide s)
+    void addBoundary(index_t p, boxSide s, std::string l = "")
     {
-        addBoundary(patchSide(p, s));
+        addBoundary(patchSide(p, s, l));
     }
 
     /// Set patch side \a ps to a boundary.
@@ -223,9 +224,29 @@ public:
     const bContainer & boundaries() const { return m_boundary;}
     bContainer & boundaries() { return m_boundary;}
 
+    /// Return the vector of boundaries with label \a l.
+    bContainer   boundaries(const std::string l) const
+    {
+        bContainer result;
+        for (const_biterator bit = bBegin(); bit!=bEnd(); bit++)
+            if (bit->label() == l)
+                result.push_back(*bit);
+        return result;
+    }
+
     /// Return the vector of interfaces.
     const ifContainer & interfaces() const { return m_interfaces; }
     ifContainer & interfaces() { return m_interfaces; }
+
+    /// Return the vector of interfaces with label \a l.
+    ifContainer   interfaces(const std::string l) const
+    {
+        ifContainer result;
+        for (const_iiterator iit = iBegin(); iit!=iEnd(); iit++)
+            if (iit->label() == l)
+                result.push_back(*iit);
+        return result;
+    }
 
     ifContainer selectInterfaces(interaction::type ifc_type) const;
 

--- a/src/gsCore/gsMultiPatch.h
+++ b/src/gsCore/gsMultiPatch.h
@@ -370,6 +370,9 @@ public:
     void constructInterfaceRep();
     void constructBoundaryRep();
 
+    void constructInterfaceRep(const std::string l);
+    void constructBoundaryRep(const std::string l);
+
     const InterfaceRep & interfaceRep() const { return m_ifaces; }
     const BoundaryRep & boundaryRep() const { return m_bdr; }
     

--- a/src/gsCore/gsMultiPatch.h
+++ b/src/gsCore/gsMultiPatch.h
@@ -367,10 +367,14 @@ public:
     std::pair<index_t,gsVector<T> > closestPointTo(const gsVector<T> & pt,
                                                    const T accuracy = 1e-6) const;
 
+    /// Construct the interface representation
     void constructInterfaceRep();
+    /// Construct the boundary representation
     void constructBoundaryRep();
 
+    /// Construct the interface representation of sides with label \a l
     void constructInterfaceRep(const std::string l);
+    /// Construct the boundary representation of sides with label \a l
     void constructBoundaryRep(const std::string l);
 
     const InterfaceRep & interfaceRep() const { return m_ifaces; }

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -816,6 +816,7 @@ T gsMultiPatch<T>::closestDistance(const gsVector<T> & pt,
 template<class T>
 void gsMultiPatch<T>::constructInterfaceRep()
 {
+    m_ifaces.clear();
     for ( iiterator it = iBegin(); it != iEnd(); ++it ) // for all interfaces
     {
         const gsGeometry<T> & p1 = *m_patches[it->first() .patch];
@@ -827,7 +828,33 @@ void gsMultiPatch<T>::constructInterfaceRep()
 template<class T>
 void gsMultiPatch<T>::constructBoundaryRep()
 {
+    m_bdr.clear();
     for ( biterator it = bBegin(); it != bEnd(); ++it ) // for all boundaries
+    {
+        const gsGeometry<T> & p1 = *m_patches[it->patch];
+        m_bdr[*it] = p1.boundary(*it);
+    }//end for
+}
+
+template<class T>
+void gsMultiPatch<T>::constructInterfaceRep(const std::string l)
+{
+    m_ifaces.clear();
+    ifContainer ifaces = this->interfaces(l);
+    for ( iiterator it = ifaces.begin(); it != ifaces.end(); ++it ) // for all interfaces
+    {
+        const gsGeometry<T> & p1 = *m_patches[it->first() .patch];
+        const gsGeometry<T> & p2 = *m_patches[it->second().patch];
+        m_ifaces[*it] = p1.iface(*it,p2);
+    }//end for
+}
+
+template<class T>
+void gsMultiPatch<T>::constructBoundaryRep(const std::string l)
+{
+    m_bdr.clear();
+    bContainer bdrs = this->boundaries(l);
+    for ( biterator it = bdrs.begin(); it != bdrs.end(); ++it ) // for all boundaries
     {
         const gsGeometry<T> & p1 = *m_patches[it->patch];
         m_bdr[*it] = p1.boundary(*it);

--- a/src/gsIO/gsXml.cpp
+++ b/src/gsIO/gsXml.cpp
@@ -200,6 +200,7 @@ void appendBoxTopology(const gsBoxTopology& topology,
                 << it->dirOrientation().transpose() << "\n";
         }
         node->append_node(internal::makeNode("interfaces", oss.str(), data));
+        // todo: add export per group of interfaces
         oss.clear();
         oss.str("");
     }
@@ -228,6 +229,10 @@ void getInterfaces(gsXmlNode* node,
     // temporaries for interface reading
     gsVector<index_t> dirMap(d);
     gsVector<bool>    dirOrient(d);
+    std::string name;
+    const gsXmlAttribute * name_att = node->first_attribute("name");
+    if (NULL != name_att)
+        name = name_att->value();
 
     std::istringstream iss;
     iss.str( node->value() );
@@ -267,7 +272,7 @@ void getInterfaces(gsXmlNode* node,
             }
         }
         
-        result.push_back( boundaryInterface(p, dirMap, dirOrient) );
+        result.push_back( boundaryInterface(p, dirMap, dirOrient,name) );
         
 //            // OLD format: read in Orientation flags
 //            gsVector<bool> orient(d-1);// orientation flags
@@ -291,6 +296,10 @@ void getBoundaries(gsXmlNode * node, std::map<int, int> & ids,
     std::istringstream iss;
     iss.str(node->value());
     int patch, side;
+    std::string name;
+    const gsXmlAttribute * name_att = node->first_attribute("name");
+    if (NULL != name_att)
+        name = name_att->value();
     
     while (iss >> std::ws >> patch)
     {
@@ -299,7 +308,7 @@ void getBoundaries(gsXmlNode * node, std::map<int, int> & ids,
             patch = ids[patch];
         }
         iss >> std::ws >> side;
-        result.push_back(patchSide(patch, side));
+        result.push_back(patchSide(patch, side, name));
     }
 }
 

--- a/src/gsIO/gsXmlUtils.hpp
+++ b/src/gsIO/gsXmlUtils.hpp
@@ -1031,15 +1031,30 @@ public:
         
         // Read boundary
         std::vector< patchSide > boundaries;
-        tmp = node->first_node("boundary");
-        if (tmp)
-            getBoundaries(tmp, ids, boundaries);
+        for (gsXmlNode * child = node->first_node("boundary"); child;
+                child = child->next_sibling("boundary"))
+        {
+            std::vector< patchSide > tmp_boundaries;
+            if (child)
+            {
+                getBoundaries(child, ids, tmp_boundaries);
+                boundaries.insert( boundaries.end(), tmp_boundaries.begin(), tmp_boundaries.end() );
+            }
+        }
+        // todo: check for duplicates
         
         // Read interfaces
         std::vector< boundaryInterface > interfaces;
-        tmp = node->first_node("interfaces");
-        if (tmp)
-            getInterfaces(tmp, d, ids, interfaces);
+        for (gsXmlNode * child = node->first_node("interfaces"); child;
+                child = child->next_sibling("interfaces"))
+        {
+            std::vector< boundaryInterface > tmp_interfaces;
+            if (child)
+            {
+                getInterfaces(child, d, ids, tmp_interfaces);
+                interfaces.insert( interfaces.end(), tmp_interfaces.begin(), tmp_interfaces.end() );
+            }
+        }
 
         obj = gsMultiPatch<T>(patches, boundaries, interfaces);        
     }

--- a/src/gsIO/gsXmlUtils.hpp
+++ b/src/gsIO/gsXmlUtils.hpp
@@ -1041,8 +1041,10 @@ public:
                 boundaries.insert( boundaries.end(), tmp_boundaries.begin(), tmp_boundaries.end() );
             }
         }
-        // todo: check for duplicates
-        
+        // Remove duplicates (keeps the first one)
+        std::sort(boundaries.begin(), boundaries.end());
+        boundaries.erase(std::unique(boundaries.begin(), boundaries.end()), boundaries.end());
+
         // Read interfaces
         std::vector< boundaryInterface > interfaces;
         for (gsXmlNode * child = node->first_node("interfaces"); child;
@@ -1055,6 +1057,10 @@ public:
                 interfaces.insert( interfaces.end(), tmp_interfaces.begin(), tmp_interfaces.end() );
             }
         }
+        // Remove duplicates (keeps the first one)
+        std::sort(interfaces.begin(), interfaces.end());
+        interfaces.erase(std::unique(interfaces.begin(), interfaces.end()), interfaces.end());
+
 
         obj = gsMultiPatch<T>(patches, boundaries, interfaces);        
     }


### PR DESCRIPTION
Every patchSide and boundaryInterface can be assigned a label. In this way, 'groups' of boundaries can be defined for global geometry boundaries, using `mp.boundaries("label")`. The XML read also has been expanded for this purpose, allowing to assign boundary conditions on boundary groups that are stored in a multi-patch.

**Please consider the following checklist before issuing a pull request:**
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
