### PR TITLE
Fix DirichletStrategy in poisson2 example

### DIFF
--- a/filedata/pde/poisson2d_bvp.xml
+++ b/filedata/pde/poisson2d_bvp.xml
@@ -43,7 +43,7 @@
 
   <!-- Assembler options -->
  <OptionList id="4">
-  <int label="DirichletStrategy" desc="Method for enforcement of Dirichlet BCs [11..14]" value="11"/>
+  <int label="DirichletStrategy" desc="Strategy related to enforcement of Dirichlet DoF values [0ignore, 1:eliminate, 2:..]" value="1"/>
   <int label="DirichletValues" desc="Method for computation of Dirichlet DoF values [100..103]" value="101"/>
   <int label="InterfaceStrategy" desc="Method of treatment of patch interfaces [0..3]" value="1"/>
   <real label="bdA" desc="Estimated nonzeros per column of the matrix: bdA*deg + bdB" value="2"/>


### PR DESCRIPTION
The poisson2 example did not converge when the exact solution in `poisson2d_bvp.xml` is changed to a function that is non-zero at the Dirichlet boundary (e.g. the function from the file +1). This is because DirichletStrategy was set to 11, but `gsExprAssembler` expects 1 for elimination and defaults to ignoring the dofs. Thus, I changed it to 1 in `poisson2d_bvp.xml` together with the description taken from `gsExprAssembler<T>::defaultOptions()`.

More generally, I noticed that `gsExprAssembler` expects DirichletStrategy to be 0,1,2, while `gsAssembler` expects 0,11,12,13 as defined in `dirichlet::strategy`. Maybe it would make sense to unify this.

# Please consider the following checklist before issuing a pull request:

- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
