### PR TITLE
Fixes / enhancements to gsParaviewCollection

### DIFF
--- a/src/gsIO/gsParaviewCollection.cpp
+++ b/src/gsIO/gsParaviewCollection.cpp
@@ -35,11 +35,11 @@ namespace gismo
             // file use relative paths
             std::string name;
             if (filenames[i].find("_mesh") != std::string::npos)
-                name="Mesh";
+                name="Mesh"+std::to_string(i);
             else if (filenames[i].find("_cnet") != std::string::npos)
-                name="Control Net";
+                name="Control Net"+std::to_string(i);
             else if (filenames[i].find("_patch") != std::string::npos)
-                name="Geometry";
+                name="Geometry"+std::to_string(i);
             else
                 name="";
 

--- a/src/gsIO/gsParaviewCollection.cpp
+++ b/src/gsIO/gsParaviewCollection.cpp
@@ -22,9 +22,12 @@ namespace gismo
 
     // A gsParaviewDataSet is meant to be an abstraction for multiple <DataSet> tags in paraview, 
     // that all stem from the same gsGeometryMap, and refer to the same timestep.
-    void gsParaviewCollection::addDataSet(gsParaviewDataSet dataSet, real_t time)
+    void gsParaviewCollection::addDataSet(gsParaviewDataSet & dataSet, real_t time)
     {
-        dataSet.save(); // the actual files are written to disk/finalized
+        GISMO_ENSURE(!dataSet.isEmpty(), "The gsParaviewDataSet you are trying to add is empty!");
+        GISMO_ASSERT(time>=0, "Time should be a non-negative real number.");
+
+        if (! dataSet.isSaved()) dataSet.save(); // the actual files are written to disk/finalized
         std::vector<std::string> filenames( dataSet.filenames() );
 
         time = time==-1 ? m_time : time;
@@ -54,6 +57,9 @@ namespace gismo
 
     void gsParaviewCollection::newTimeStep(gsMultiPatch<real_t> * geometry, real_t time)
     {   
+        GISMO_ASSERT( m_dataset.isEmpty() || m_dataset.isSaved(), "Previous timestep has not been saved. try running saveTimeStep() before newTimeStep().");
+        GISMO_ASSERT(-1==time || time>=0, "Time should be a non-negative real number.");
+
         if (-1 == time )
         {
             m_time += 1.0;

--- a/src/gsIO/gsParaviewCollection.h
+++ b/src/gsIO/gsParaviewCollection.h
@@ -86,7 +86,8 @@ public:
                         m_isSaved(false),
                         m_time(-1),
                         m_evaluator(evaluator),
-                        m_options(gsParaviewDataSet::defaultOptions())
+                        m_options(gsParaviewDataSet::defaultOptions()),
+                        counter(0)
     {
         m_filename = gsFileManager::getPath(m_filename) + gsFileManager::getBasename(m_filename) + ".pvd";
         gsFileManager::mkdir( gsFileManager::getPath(m_filename) );
@@ -113,6 +114,47 @@ public:
         if (name != "") mfile << "name=\"" << name << "\" ";
         mfile << "file=\"" << fn <<"\"/>\n";
     }
+
+    // The following functions are all deprecated, only here for backwards compatibility!
+
+    /// Adds a part in the collection, with complete filename (including extension) \a fn
+    // GISMO_DEPRECATED void addPart(String const & fn)
+    // {
+    //     GISMO_ASSERT(fn.find_last_of(".") != String::npos, "File without extension");
+    //     GISMO_ASSERT(counter!=-1, "Error: collection has been already saved." );
+    //     // mfile << "<DataSet part=\""<<counter++<<"\" file=\""<<fn<<"\"/>\n";
+    //     addPart( fn, -1, "", counter++);
+    // }
+
+    // Adds a part in the collection, with filename \a fn with extension \a ext appended
+    GISMO_DEPRECATED void addPart(String const & fn, String const & ext)
+    {
+        GISMO_ASSERT(counter!=-1, "Error: collection has been already saved." );
+        // mfile << "<DataSet part=\""<<counter++<<"\" file=\""<<fn<<ext<<"\"/>\n";
+        addPart( fn+ext, -1, "", counter++);
+    }
+
+    // Adds a part in the collection, with filename \a fni and extension \a ext appended
+    GISMO_DEPRECATED void addPart(String const & fn, int i, String const & ext)
+    {
+        GISMO_ASSERT(counter!=-1, "Error: collection has been already saved." );
+        // mfile << "<DataSet part=\""<<i<<"\" file=\""<<fn<<i<<ext<<"\"/>\n";
+        addPart( fn+std::to_string(i)+ext, -1, "", i);
+    }
+
+    GISMO_DEPRECATED void addTimestep(String const & fn, double tstep, String const & ext)
+    {
+        // mfile << "<DataSet timestep=\""<<tstep<<"\" file=\""<<fn<<ext<<"\"/>\n";
+        addPart( fn+ext, tstep);
+    }
+
+    GISMO_DEPRECATED void addTimestep(String const & fn, int part, double tstep, String const & ext)
+    {
+        // mfile << "<DataSet part=\""<<part<<"\" timestep=\""<<tstep<<"\" file=\""<<fn<<"_"<<part<<ext<<"\"/>\n";
+        addPart( fn+"_"+std::to_string(part)+ext, tstep, "", part);
+    }
+
+    // End of deprecated functions
 
     /// @brief Adds all the files relevant to a gsParaviewDataSet, to the collection.
     /// @param dataSet The gsParaviewDataSet to be added.
@@ -159,6 +201,7 @@ public:
         f.close();
         mfile.str("");
         m_isSaved=true;
+        counter = -1;
     }
 
     /// @brief Accessor to the current options.
@@ -181,6 +224,8 @@ private:
     gsParaviewDataSet m_dataset;
 
     gsOptionList m_options;
+
+    index_t counter;
 
 private:
     // Construction without a filename is not allowed

--- a/src/gsIO/gsParaviewCollection.h
+++ b/src/gsIO/gsParaviewCollection.h
@@ -159,7 +159,7 @@ public:
     /// @brief Adds all the files relevant to a gsParaviewDataSet, to the collection.
     /// @param dataSet The gsParaviewDataSet to be added.
     /// @param time Time step (optional, else an internal integer counter is used)
-    void addDataSet(gsParaviewDataSet dataSet, real_t time=-1);
+    void addDataSet(gsParaviewDataSet & dataSet, real_t time=-1);
 
     /// @brief Creates a new time step where all information will be added to.
     /// @param geometry A gsMultiPatch of the geometry where the solution fields are defined.
@@ -167,22 +167,25 @@ public:
     void newTimeStep(gsMultiPatch<real_t> * geometry, real_t time=-1);
 
  
-    /// @brief All arguments are forwarder to gsParaviewDataSet::addField().
+    /// @brief All arguments are forwarded to gsParaviewDataSet::addField().
     template <typename... Rest>
     void addField(Rest... rest)
     {
+        GISMO_ENSURE( !m_dataset.isEmpty(), "The gsParaviewDataSet, stored internally by gsParaviewCollection, is empty! Try running newTimestep() before addField().");
         m_dataset.addField(rest...);
     }
 
-    /// @brief All arguments are forwarder to gsParaviewDataSet::addFields().
+    /// @brief All arguments are forwarded to gsParaviewDataSet::addFields().
     template <typename... Rest>
     void addFields(Rest... rest)
     {
+        GISMO_ENSURE( !m_dataset.isEmpty(), "The gsParaviewDataSet, stored internally by gsParaviewCollection, is empty! Try running newTimestep() before addFields().");
         m_dataset.addFields(rest...);
     }
 
     /// @brief The current timestep is saved and files written to disk.
     void saveTimeStep(){
+        GISMO_ENSURE( !m_dataset.isEmpty(), "The gsParaviewDataSet, stored internally by gsParaviewCollection, is empty! Try running newTimestep() before saveTimeStep().");
         addDataSet(m_dataset,m_time);
     };
 
@@ -191,17 +194,20 @@ public:
     void save()
     {
         GISMO_ASSERT(!m_isSaved, "Error: gsParaviewCollection::save() already called." );
-        mfile <<"</Collection>\n";
-        mfile <<"</VTKFile>\n";
+        if (!m_isSaved)
+        {
+            mfile <<"</Collection>\n";
+            mfile <<"</VTKFile>\n";
 
-        gsDebug << "Exporting to " << m_filename << "\n";
-        std::ofstream f( m_filename.c_str() );
-        GISMO_ASSERT(f.is_open(), "Error creating "<< m_filename );
-        f << mfile.rdbuf();
-        f.close();
-        mfile.str("");
-        m_isSaved=true;
-        counter = -1;
+            gsDebug << "Exporting to " << m_filename << "\n";
+            std::ofstream f( m_filename.c_str() );
+            GISMO_ASSERT(f.is_open(), "Error creating "<< m_filename );
+            f << mfile.rdbuf();
+            f.close();
+            mfile.str("");
+            m_isSaved=true;
+            counter = -1;
+        }
     }
 
     /// @brief Accessor to the current options.

--- a/src/gsIO/gsParaviewCollection.h
+++ b/src/gsIO/gsParaviewCollection.h
@@ -114,33 +114,20 @@ public:
         if (name != "") mfile << "name=\"" << name << "\" ";
         mfile << "file=\"" << fn <<"\"/>\n";
     }
+    // CAUTION! 
+    // The previous 3 versions of gsParaviewCollection::addPart() have been combined into the one above
+    // since they were all doing basiacally the same thing. Below you can see a 'conversion table' that
+    // can help you adapt your code to the new syntax. For questions contact C. Karampatzakis (Github @ckarampa )
+    // OLD SYNTAX ( Deprecated )                              |   NEW SYNTAX 
+    //-----------------------------------------------------------------------------------------------------------
+    // addPart(String const & fn)                             |   addPart( fn, -1, "", counter++);               |
+    //                                                                                                           |
+    // addPart(String const & fn, String const & ext)         |   addPart( fn+ext, -1, "", counter++);           |
+    //                                                                                                           |
+    // addPart(String const & fn, int i, String const & ext)  |   addPart( fn+std::to_string(i)+ext, -1, "", i); |
+    // ----------------------------------------------------------------------------------------------------------
 
     // The following functions are all deprecated, only here for backwards compatibility!
-
-    /// Adds a part in the collection, with complete filename (including extension) \a fn
-    // GISMO_DEPRECATED void addPart(String const & fn)
-    // {
-    //     GISMO_ASSERT(fn.find_last_of(".") != String::npos, "File without extension");
-    //     GISMO_ASSERT(counter!=-1, "Error: collection has been already saved." );
-    //     // mfile << "<DataSet part=\""<<counter++<<"\" file=\""<<fn<<"\"/>\n";
-    //     addPart( fn, -1, "", counter++);
-    // }
-
-    // Adds a part in the collection, with filename \a fn with extension \a ext appended
-    GISMO_DEPRECATED void addPart(String const & fn, String const & ext)
-    {
-        GISMO_ASSERT(counter!=-1, "Error: collection has been already saved." );
-        // mfile << "<DataSet part=\""<<counter++<<"\" file=\""<<fn<<ext<<"\"/>\n";
-        addPart( fn+ext, -1, "", counter++);
-    }
-
-    // Adds a part in the collection, with filename \a fni and extension \a ext appended
-    GISMO_DEPRECATED void addPart(String const & fn, int i, String const & ext)
-    {
-        GISMO_ASSERT(counter!=-1, "Error: collection has been already saved." );
-        // mfile << "<DataSet part=\""<<i<<"\" file=\""<<fn<<i<<ext<<"\"/>\n";
-        addPart( fn+std::to_string(i)+ext, -1, "", i);
-    }
 
     GISMO_DEPRECATED void addTimestep(String const & fn, double tstep, String const & ext)
     {

--- a/src/gsIO/gsParaviewCollection.h
+++ b/src/gsIO/gsParaviewCollection.h
@@ -101,8 +101,8 @@ public:
 
     /// @brief Appends a file to the Paraview collection (.pvd file).
     /// @param fn Filename to be added. Can also be a path relative to the where the collection file is. 
-    /// @param tStep Time step ( optional, else an internal integer counter is used)
-    /// @param name An optional name for this part
+    /// @param tStep Time step ( optional )
+    /// @param name An optional name for this part. This is the name that will show up  in Paraview's MultiBlock inspector for this Part. It is not the filename.
     /// @param part Part ID ( optional )
     void addPart(String const & fn, real_t tStep=-1, std::string name="", index_t part=-1)
     {   

--- a/src/gsIO/gsParaviewDataSet.cpp
+++ b/src/gsIO/gsParaviewDataSet.cpp
@@ -25,7 +25,8 @@ namespace gismo
                     :m_basename(basename),
                     m_geometry(geometry),
                     m_evaltr(eval),
-                    m_options(options)
+                    m_options(options),
+                    m_isSaved(false)
     {
         unsigned nPts = m_options.askInt("numPoints",1000);
 
@@ -65,45 +66,61 @@ namespace gismo
 
     void gsParaviewDataSet::save()
     {
-        unsigned nPts = m_options.askInt("numPoints",1000);
-        unsigned precision = m_options.askInt("precision",5);
-        bool plotElements   = m_options.askSwitch("plotElements", false);
-        bool plotControlNet = m_options.askSwitch("plotControlNet", false);
-
-        std::vector<std::string> points = toVTK(*m_geometry,nPts,precision); //m_evaltr->geoMap2vtk(*m_geometry,nPts, precision);
-        // QUESTION: Can I be certain that the ids are consecutive?
-        for ( index_t k=0; k!=m_geometry->nPieces(); k++) // For every patch.
+        GISMO_ASSERT( !m_isSaved, "gsParaviewDataSet already saved.");
+        if (!m_isSaved)
         {
-            std::ofstream file;
-            file.open(m_filenames[k].c_str(), std::ios_base::app); // Append to file 
-            file <<"</PointData>\n\n\n<!-- GEOMETRY -->\n<Points>\n";
-            file << points[k];
-            file << "</Points>\n</Piece>\n</StructuredGrid>\n</VTKFile>";
-            file.close();
-            if (plotControlNet)
-            {
-                writeSingleControlNet( m_geometry->piece(k), m_basename + "_cnet" + std::to_string(k));
-                m_filenames.push_back( m_basename + "_cnet" + std::to_string(k)+".vtp");
-            } 
-            if ( plotElements)
-            {
-                int numPoints = m_options.getInt("plotElements.resolution");
-                if (-1 == numPoints )
-                {
-                    const real_t evalPtsPerElem = 16 * (1.0 / m_geometry->piece(k).basis().numElements());
+            m_isSaved = true; 
 
-                    // copied from gsWriteParaview
-                    numPoints = cast<real_t,int>(
-                        static_cast<real_t>(math::max( m_geometry->piece(k).basis().maxDegree()-1, (short_t)1))
-                        * math::pow(evalPtsPerElem, real_t(1.0)/static_cast<real_t>(m_geometry->domainDim())) );
+            unsigned nPts = m_options.askInt("numPoints",1000);
+            unsigned precision = m_options.askInt("precision",5);
+            bool plotElements   = m_options.askSwitch("plotElements", false);
+            bool plotControlNet = m_options.askSwitch("plotControlNet", false);
+
+            std::vector<std::string> points = toVTK(*m_geometry,nPts,precision); //m_evaltr->geoMap2vtk(*m_geometry,nPts, precision);
+            // QUESTION: Can I be certain that the ids are consecutive?
+            for ( index_t k=0; k!=m_geometry->nPieces(); k++) // For every patch.
+            {
+                std::ofstream file;
+                file.open(m_filenames[k].c_str(), std::ios_base::app); // Append to file 
+                file <<"</PointData>\n\n\n<!-- GEOMETRY -->\n<Points>\n";
+                file << points[k];
+                file << "</Points>\n</Piece>\n</StructuredGrid>\n</VTKFile>";
+                file.close();
+                if (plotControlNet)
+                {
+                    writeSingleControlNet( m_geometry->piece(k), m_basename + "_cnet" + std::to_string(k));
+                    m_filenames.push_back( m_basename + "_cnet" + std::to_string(k)+".vtp");
+                } 
+                if ( plotElements)
+                {
+                    int numPoints = m_options.getInt("plotElements.resolution");
+                    if (-1 == numPoints )
+                    {
+                        const real_t evalPtsPerElem = 16 * (1.0 / m_geometry->piece(k).basis().numElements());
+
+                        // copied from gsWriteParaview
+                        numPoints = cast<real_t,int>(
+                            static_cast<real_t>(math::max( m_geometry->piece(k).basis().maxDegree()-1, (short_t)1))
+                            * math::pow(evalPtsPerElem, real_t(1.0)/static_cast<real_t>(m_geometry->domainDim())) );
+                    }
+                    gsMesh<real_t> msh( gsMultiBasis<real_t>(*m_geometry).basis(k), numPoints);
+                    static_cast<const gsGeometry<real_t>&>(m_geometry->piece(k)).evaluateMesh(msh);
+                    gsWriteParaview(msh, m_basename + "_mesh" + std::to_string(k), false);
+                    m_filenames.push_back( m_basename + "_mesh" + std::to_string(k)+".vtp");
                 }
-                gsMesh<real_t> msh( gsMultiBasis<real_t>(*m_geometry).basis(k), numPoints);
-                static_cast<const gsGeometry<real_t>&>(m_geometry->piece(k)).evaluateMesh(msh);
-                gsWriteParaview(msh, m_basename + "_mesh" + std::to_string(k), false);
-                m_filenames.push_back( m_basename + "_mesh" + std::to_string(k)+".vtp");
             }
+            // output text files for each part.
         }
-        // output text files for each part.
+    }
+
+    bool gsParaviewDataSet::isEmpty()
+    {
+        return ! static_cast<bool>(m_geometry);
+    }
+
+    bool gsParaviewDataSet::isSaved()
+    {
+        return m_isSaved;
     }
 
     void gsParaviewDataSet::initFilenames()

--- a/src/gsIO/gsParaviewDataSet.h
+++ b/src/gsIO/gsParaviewDataSet.h
@@ -189,15 +189,16 @@ private:
     /// @param precision Number of decimal points in xml output
     /// @return Vector of strings of all <DataArrays>
     template< class T>
-    static std::vector<std::string> toVTK(const gsFunctionSet<T> & funSet, unsigned nPts=1000, unsigned precision=5, std::string label="")
+    static std::vector<std::string> toVTK(const gsFunctionSet<T> & funSet, unsigned nPtsInit=1000, unsigned precision=5, std::string label="")
     {   
         std::vector<std::string> out;
         gsMatrix<T> evalPoint, xyzPoints;
+        unsigned nPts = nPtsInit;
 
         // Loop over all patches
         for ( index_t i=0; i != funSet.nPieces(); ++i )
         {
-            gsGridIterator<T,CUBE> grid(funSet.piece(i).support(), nPts);
+            gsGridIterator<T,CUBE> grid(funSet.piece(i).support(), nPtsInit);
 
             // Evaluate the MultiPatch for every parametric point of the grid iterator
             xyzPoints.resize( funSet.targetDim(), grid.numPoints() );
@@ -215,15 +216,16 @@ private:
     }
 
     template< class T>
-    static std::vector<std::string> toVTK(const gsField<T> & field, unsigned nPts=1000, unsigned precision=5, std::string label="")
+    static std::vector<std::string> toVTK(const gsField<T> & field, unsigned nPtsInit=1000, unsigned precision=5, std::string label="")
     {   
         std::vector<std::string> out;
         gsMatrix<T> evalPoint, xyzPoints;
+        unsigned nPts = nPtsInit;
 
         // Loop over all patches
         for ( index_t i=0; i != field.nPieces(); ++i )
         {
-            gsGridIterator<T,CUBE> grid(field.fields().piece(i).support(), nPts);
+            gsGridIterator<T,CUBE> grid(field.fields().piece(i).support(), nPtsInit);
 
             // Evaluate the MultiPatch for every parametric point of the grid iterator
             xyzPoints.resize( field.dim(), grid.numPoints());
@@ -247,12 +249,13 @@ private:
     /// @return Vector of strings of all <DataArrays>
     template<class E>
     std::vector<std::string> toVTK(const expr::_expr<E> & expr,
-                                            unsigned nPts=1000,
+                                            unsigned nPtsInit=1000,
                                             unsigned precision=5,
                                             std::string label="SolutionField")
     {   
         std::vector<std::string> out;
         std::stringstream dataArray;
+        unsigned nPts = nPtsInit;
         dataArray.setf( std::ios::fixed ); // write floating point values in fixed-point notation.
         dataArray.precision(precision);
         // m_exprdata->parse(expr);
@@ -265,7 +268,7 @@ private:
         for ( index_t i=0; i != n; ++i )
         {
             ab = m_evaltr->exprData()->multiBasis().piece(i).support();
-            gsGridIterator<real_t,CUBE> pt(ab, nPts);
+            gsGridIterator<real_t,CUBE> pt(ab, nPtsInit);
             m_evaltr->eval(expr, pt, i);
             nPts = pt.numPoints();
             

--- a/src/gsIO/gsParaviewDataSet.h
+++ b/src/gsIO/gsParaviewDataSet.h
@@ -40,6 +40,7 @@ private:
     const gsMultiPatch<real_t> * m_geometry;
     gsExprEvaluator<real_t> * m_evaltr;
     gsOptionList m_options;
+    bool m_isSaved;
     
 public:
     /// @brief Basic constructor
@@ -55,7 +56,8 @@ public:
     gsParaviewDataSet():m_basename(""),
                         m_geometry(nullptr),
                         m_evaltr(nullptr),
-                        m_options(defaultOptions())
+                        m_options(defaultOptions()),
+                        m_isSaved(false)
                         {}
                    
     /// @brief Evaluates an expression, and writes that data to the vtk files.
@@ -66,6 +68,7 @@ public:
     void addField(const expr::_expr<E> & expr,
                   std::string label)
     {
+        GISMO_ENSURE( !m_isSaved, "You cannot add more fields if the gsParaviewDataSet has been saved.");
         // evaluates the expression and appends it to the vts files
         //for every patch
         unsigned nPts = m_options.askInt("numPoints",1000);
@@ -114,6 +117,7 @@ public:
     template<class T>
     void addField(const gsField<T> field, std::string label)
     {
+        GISMO_ENSURE( !m_isSaved, "You cannot add more fields if the gsParaviewDataSet has been saved.");
         GISMO_ENSURE((field.parDim()  == m_geometry->domainDim() && 
                       field.geoDim()  == m_geometry->targetDim() &&
                       field.nPieces() == m_geometry->nPieces() && 
@@ -135,6 +139,7 @@ public:
             file.close(); 
         }
     }
+
     /// @brief Recursive form of addField()
     /// @tparam T 
     /// @tparam ...Rest 
@@ -155,6 +160,10 @@ public:
     const std::vector<std::string> filenames();
 
     void save();
+
+    bool isEmpty();
+
+    bool isSaved();
 
     /// @brief Accessor to the current options.
     static gsOptionList defaultOptions()

--- a/src/gsIO/gsParaviewDataSet.h
+++ b/src/gsIO/gsParaviewDataSet.h
@@ -189,16 +189,15 @@ private:
     /// @param precision Number of decimal points in xml output
     /// @return Vector of strings of all <DataArrays>
     template< class T>
-    static std::vector<std::string> toVTK(const gsFunctionSet<T> & funSet, unsigned nPtsInit=1000, unsigned precision=5, std::string label="")
+    static std::vector<std::string> toVTK(const gsFunctionSet<T> & funSet, unsigned nPts=1000, unsigned precision=5, std::string label="")
     {   
         std::vector<std::string> out;
         gsMatrix<T> evalPoint, xyzPoints;
-        unsigned nPts = nPtsInit;
 
         // Loop over all patches
         for ( index_t i=0; i != funSet.nPieces(); ++i )
         {
-            gsGridIterator<T,CUBE> grid(funSet.piece(i).support(), nPtsInit);
+            gsGridIterator<T,CUBE> grid(funSet.piece(i).support(), nPts);
 
             // Evaluate the MultiPatch for every parametric point of the grid iterator
             xyzPoints.resize( funSet.targetDim(), grid.numPoints() );
@@ -216,16 +215,15 @@ private:
     }
 
     template< class T>
-    static std::vector<std::string> toVTK(const gsField<T> & field, unsigned nPtsInit=1000, unsigned precision=5, std::string label="")
+    static std::vector<std::string> toVTK(const gsField<T> & field, unsigned nPts=1000, unsigned precision=5, std::string label="")
     {   
         std::vector<std::string> out;
         gsMatrix<T> evalPoint, xyzPoints;
-        unsigned nPts = nPtsInit;
 
         // Loop over all patches
         for ( index_t i=0; i != field.nPieces(); ++i )
         {
-            gsGridIterator<T,CUBE> grid(field.fields().piece(i).support(), nPtsInit);
+            gsGridIterator<T,CUBE> grid(field.fields().piece(i).support(), nPts);
 
             // Evaluate the MultiPatch for every parametric point of the grid iterator
             xyzPoints.resize( field.dim(), grid.numPoints());
@@ -249,13 +247,12 @@ private:
     /// @return Vector of strings of all <DataArrays>
     template<class E>
     std::vector<std::string> toVTK(const expr::_expr<E> & expr,
-                                            unsigned nPtsInit=1000,
+                                            unsigned nPts=1000,
                                             unsigned precision=5,
                                             std::string label="SolutionField")
     {   
         std::vector<std::string> out;
         std::stringstream dataArray;
-        unsigned nPts = nPtsInit;
         dataArray.setf( std::ios::fixed ); // write floating point values in fixed-point notation.
         dataArray.precision(precision);
         // m_exprdata->parse(expr);
@@ -268,11 +265,10 @@ private:
         for ( index_t i=0; i != n; ++i )
         {
             ab = m_evaltr->exprData()->multiBasis().piece(i).support();
-            gsGridIterator<real_t,CUBE> pt(ab, nPtsInit);
+            gsGridIterator<real_t,CUBE> pt(ab, nPts);
             m_evaltr->eval(expr, pt, i);
-            nPts = pt.numPoints();
             
-            vals = m_evaltr->allValues(m_evaltr->elementwise().size()/nPts, nPts);
+            vals = m_evaltr->allValues(m_evaltr->elementwise().size()/pt.numPoints(), pt.numPoints());
 
             dataArray <<"<DataArray type=\"Float32\" Name=\""<< label <<"\" format=\"ascii\" NumberOfComponents=\""<< ( vals.rows()==1 ? 1 : 3) <<"\">\n";
             if ( vals.rows()==1 )


### PR DESCRIPTION
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----

## List of changes:

- Brought back `gsParaviewCollection::addTimestep()` as `GISMO_DEPRECATED` for compatibility with older codes. The same could not be done for `gsParaviewCollection::addPart()`, because it caused ambiguity for the compiler. Instead a detailed comment on how to go about updating older codes to the new syntax has been added.

- Assertions have been added to various places, to make it a little less susceptible to user error.

- Every `<DataSet>` xml tag, gets a unique `name` attribute. This ensures that when using the Paraview MultiBlock Inspector, the visibility of each patch can be controlled independently.
