### PR TITLE
Unify indices of Dirichlet strategy in gsExprAssembler and gsAssembler

### DIFF
--- a/filedata/pde/poisson2d_bvp.xml
+++ b/filedata/pde/poisson2d_bvp.xml
@@ -43,7 +43,7 @@
 
   <!-- Assembler options -->
  <OptionList id="4">
-  <int label="DirichletStrategy" desc="Strategy related to enforcement of Dirichlet DoF values [0ignore, 1:eliminate, 2:..]" value="1"/>
+  <int label="DirichletStrategy" desc="Method for enforcement of Dirichlet BCs [11..14]" value="11"/>
   <int label="DirichletValues" desc="Method for computation of Dirichlet DoF values [100..103]" value="101"/>
   <int label="InterfaceStrategy" desc="Method of treatment of patch interfaces [0..3]" value="1"/>
   <real label="bdA" desc="Estimated nonzeros per column of the matrix: bdA*deg + bdB" value="2"/>

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -616,7 +616,7 @@ gsOptionList gsExprAssembler<T>::defaultOptions()
 {
     gsOptionList opt;
     opt.addInt("DirichletValues"  , "Method for computation of Dirichlet DoF values [100..103]", 101);// deprecated
-    opt.addInt("DirichletStrategy"  , "Strategy related to enforcement of Dirichlet DoF values [0ignore, 1:eliminate, 2:..]", 1);
+    opt.addInt("DirichletStrategy", "Method for enforcement of Dirichlet BCs [11..14]", 11 );
     opt.addReal("quA", "Number of quadrature points: quA*deg + quB", 1.0  );
     opt.addInt ("quB", "Number of quadrature points: quA*deg + quB", 1    );
     opt.addReal("bdA", "Estimated nonzeros per column of the matrix: bdA*deg + bdB", 2.0  );
@@ -750,7 +750,7 @@ void gsExprAssembler<T>::assemble(const expr &... args)
     gsVector<T> quWeights; // quadrature weights
     _eval ee(m_matrix, m_rhs, quWeights);
     const index_t elim = m_options.getInt("DirichletStrategy");
-    ee.setElim(1==elim);
+    ee.setElim(dirichlet::elimination==elim);
 
     // Note: omp thread will loop over all patches and will work on Ep/nt
     // elements, where Ep is the elements on the patch.


### PR DESCRIPTION
Currently, in the options of `gsExprAssembler` the value of `DirichletStrategy` corresponding to elimination of the dofs is `1`, while `gsAssembler` uses the values defined in `dirichlet` and therefore expects `dirichlet::elimination=11` for elimination.
This change uses `dirichlet::elimination` instead of `1` also in gsExprAssembler, in order to unify the two usages.
I searched the stable branch for all instances of DirichletStrategy and the old value 1 was not used anywhere except for the default options of `gsExprAssembler` and the poisson2 example. 

HOWEVER, this change would break people's private code in a way that is hard to debug if they explicitly set DirichletStrategy to be 1 instead of using the default options (It took me quite a while to understand this problem in my code). So I am not 100% sure how to proceed.

# Please consider the following checklist before issuing a pull request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
