### PR TITLE
Bugfix - labeled boundaries

### DIFF
--- a/src/gsPde/gsBoundaryConditions.hpp
+++ b/src/gsPde/gsBoundaryConditions.hpp
@@ -155,6 +155,7 @@ public:
             const gsXmlAttribute * att_name = child->first_attribute("name");
             if (NULL != att_name)
             {
+                boundaries.clear();
                 std::string name = att_name->value();
                 for (typename std::vector<patchSide>::const_iterator it=allboundaries.begin(); it!=allboundaries.end(); it++)
                     if (it->label()==name)
@@ -162,6 +163,12 @@ public:
             }
             else
                 getBoundaries(child, ids, boundaries);
+
+            if (boundaries.size() == 0) {
+              gsWarn << "Boundary condition without boundary to apply to. The"
+                        " following bc will be unused\n" << *child
+                     << std::endl;
+            }
 
             const gsXmlAttribute * bcat = child->first_attribute("type");
             GISMO_ASSERT(NULL != bcat, "No type provided");


### PR DESCRIPTION
# Overview
Boundaries are now cleared before adding new boundary information (patch and side). Also, a warning is printed if a label is non-existent or no boundary information is passed.

## Mini example
Taken from `poisson2d_bvp.xml`: 
```xml
<xml>
  <MultiPatch>
 ...
<boundary name="dirichlet1">
  501 4
</boundary><!-- split up into two separate boundaries -->
<boundary name="dirichlet2">
  500 3
  501 3
</boundary>
<boundary name="neumann">
  500 4
  500 1
  501 2
</boundary>
</MultiPatch>

...
<bc type="Dirichlet" function="0" unknown="0" name="dirichlet1">
</bc>
<bc type="Dirichlet" function="0" unknown="0" name="dirichlet2">
</bc><!-- Would be applied to dirichket 1 as well till now -->
<bc type="Dirichlet" function="0" unknown="0" name="dirichlet3">
</bc><!-- Will produce warning - not defined -->
```

Linking @hverhelst as we have already talked about it.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
