### PR TITLE
Add gsGeometry::insertKnot()

### DIFF
--- a/src/gsCore/gsGeometry.h
+++ b/src/gsCore/gsGeometry.h
@@ -530,6 +530,7 @@ public:
      //{ return this->basisComponent(i).degree(); };
      { return this->basis().degree(i); }
 
+    /// Inserts knot \a knot at direction \a dir, \a i times
     virtual void insertKnot( T knot, index_t dir, index_t i = 1);
 
     /// \brief Elevate the degree by the given amount \a i for the

--- a/src/gsCore/gsGeometry.h
+++ b/src/gsCore/gsGeometry.h
@@ -530,6 +530,8 @@ public:
      //{ return this->basisComponent(i).degree(); };
      { return this->basis().degree(i); }
 
+    virtual void insertKnot( T knot, index_t dir, index_t i = 1);
+
     /// \brief Elevate the degree by the given amount \a i for the
     /// direction \a dir. If \a dir is -1 then degree elevation is
     /// done for all directions. Uses \ref gsBasis<T>::degreeElevate

--- a/src/gsCore/gsGeometry.hpp
+++ b/src/gsCore/gsGeometry.hpp
@@ -348,6 +348,12 @@ std::vector<gsGeometry<T> *> gsGeometry<T>::boundary() const
 }
 
 template<class T>
+void gsGeometry<T>::insertKnot( T knot, index_t dir, index_t i)
+{
+    GISMO_NO_IMPLEMENTATION
+}
+
+template<class T>
 void gsGeometry<T>::degreeElevate(short_t const i, short_t const dir)
 {
     typename gsBasis<T>::uPtr b = m_basis->clone();


### PR DESCRIPTION
What the title says basically. The reason is that in this way, one can call `gsMultiPatch.patch(i).insertKnot()` ( no matter if it is a BSpline or NURBS)  instead of having to dynamically cast it to `gsTensorNurbs`/`gsTensorBSpline` which requires a priori knowledge for example when the multipatch is read from a file. 

---
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [x] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
