### PR TITLE
Fixes opennurbs curve

### DIFF
--- a/optional/gsOpennurbs/gsReadOpenNurbs.cpp
+++ b/optional/gsOpennurbs/gsReadOpenNurbs.cpp
@@ -335,7 +335,7 @@ bool readON_NurbsCurve( const ON_NurbsCurve * pcurve, internal::gsXmlTree & data
 	  for (int k = 0; k < pcurve->m_cv_count; k++ ) 
 	    {
 	      for (int j = 0; j < cvdim; j++ ) 
-		tmp <<" "<< P[k];
+		tmp <<" "<< P[j];
 	      P += cvdim;
 	    }
 	}


### PR DESCRIPTION
The coefficient matrix was loaded incorrectly, resulting in coefficients like
```
a a a
d d d
g g g
```
instead of 
```
a b c
d e f 
g h i
```