### PR TITLE
Update gsNurbsCreator.hpp

### DIFF
--- a/src/gsNurbs/gsNurbsCreator.hpp
+++ b/src/gsNurbs/gsNurbsCreator.hpp
@@ -785,7 +785,7 @@ gsNurbsCreator<T>::BSplineCubeGrid(int n, int m,int p,
         for(int j = 0; j < m; j++)
             for(int k = 0; k < p; k++)
         {
-            mp.addPatch(BSplineCube(r,lx + r*(T)(i) ,ly + r*(T)(j),lz+r*(T)(k))) ;
+            mp.addPatch(BSplineCube(r, r*(T)(0.5) + lx + r*(T)(i), r*(T)(0.5) + ly + r*(T)(j), r*(T)(0.5) + lz+r*(T)(k))) ;
         }
     mp.computeTopology();
     return mp;


### PR DESCRIPTION
Currently the BSplineCubeGrid function does not produce the expected domain as is call the BSplineCube function which returns a (-0.5, 0.5)^3 cube rather then a (0,1)^3 cube. This is now fixed by calling BSplineCude properly (correct translation)


Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [YES ] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ There was no documentation...] Have you documented any new codes using Doxygen comments?
- [No, tested locally ] Have you written new tests or examples for your changes?
-----
