### PR TITLE
Using correct parameter range in extensions::gsParasolid::gsWritePK_SHEET

### DIFF
--- a/optional/gsParasolid/gsWriteParasolid.hpp
+++ b/optional/gsParasolid/gsWriteParasolid.hpp
@@ -293,11 +293,13 @@ bool gsWritePK_SHEET(const gsTensorBSpline<2, T>& tp, const std::string& filenam
     PK_BSURF_t bsurf;
     createPK_BSURF<T>(tp, bsurf, false, false);
 
+    gsMatrix<T> domain = tp.parameterRange();
     PK_UVBOX_t uv_box;
-    uv_box.param[0] = 0;
-    uv_box.param[1] = 0;
-    uv_box.param[2] = 1;
-    uv_box.param[3] = 1;
+    // format: umin, vmin, umax, vmax
+    uv_box.param[0] = domain(0, 0);
+    uv_box.param[1] = domain(1, 0);
+    uv_box.param[2] = domain(0, 1);
+    uv_box.param[3] = domain(1, 1);
     PK_BODY_t body;
     err = PK_SURF_make_sheet_body(bsurf, uv_box, &body);
     PARASOLID_ERROR(PK_SURF_make_sheet_body, err);


### PR DESCRIPTION
This is a bugfix for the function `extensions::gsParasolid::gsWritePK_SHEET`.

- Old (wrong) behaviour: the function assumes that the parameter domain of the B-spline being exported is [0, 1]^2.
- New (correct) behaviour: the function reads the parameter bounds of the B-spline.

-----
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them? Yes, see above.
- [X] Have you documented any new codes using Doxygen comments? No, it is a bugfix.
- [X] Have you written new tests or examples for your changes? No.
-----
