### PR TITLE
Keep Sparsity Pattern (Mini-PR)

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -303,6 +303,12 @@ public:
 
     void clearRhs() { m_rhs.setZero(); }
 
+    /**
+     * @brief Re-Init Matrix (set zero by default)
+     *
+     * @param save_sparsety_pattern only modify values but keep sparsety
+     * information by multiplying matrix by zero in-place
+     */
     void clearMatrix(const bool& save_sparsety_pattern = true) {
       if (save_sparsety_pattern) {
         m_matrix *= 0.0;

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -303,24 +303,29 @@ public:
 
     void clearRhs() { m_rhs.setZero(); }
 
-    void clearMatrix()
-    {
-        m_matrix = gsSparseMatrix<T>(numTestDofs(), numDofs());
+    void clearMatrix(const bool& save_sparsety_pattern = false) {
+        if (save_sparsety_pattern) {
+            m_matrix *= 0.0;
+        } else {
+            m_matrix = gsSparseMatrix<T>(numTestDofs(), numDofs());
 
-        if ( 0 == m_matrix.rows() || 0 == m_matrix.cols() )
-            gsWarn << " No internal DOFs, zero sized system.\n";
-        else
-        {
-            // Pick up values from options
-            const T bdA       = m_options.getReal("bdA");
-            const index_t bdB = m_options.getInt("bdB");
-            const T bdO       = m_options.getReal("bdO");
-            T nz = 1;
-            const short_t dim = m_exprdata->multiBasis().domainDim();
-            for (short_t i = 0; i != dim; ++i)
-                nz *= bdA * static_cast<T>(m_exprdata->multiBasis().maxDegree(i)) + static_cast<T>(bdB);
+            if (0 == m_matrix.rows() || 0 == m_matrix.cols())
+              gsWarn << " No internal DOFs, zero sized system.\n";
+            else {
+              // Pick up values from options
+              const T bdA = m_options.getReal("bdA");
+              const index_t bdB = m_options.getInt("bdB");
+              const T bdO = m_options.getReal("bdO");
+              T nz = 1;
+              const short_t dim = m_exprdata->multiBasis().domainDim();
+              for (short_t i = 0; i != dim; ++i)
+                nz *= bdA * static_cast<T>(
+                                m_exprdata->multiBasis().maxDegree(i)) +
+                      static_cast<T>(bdB);
 
-            m_matrix.reservePerColumn(numBlocks()*cast<T,index_t>(nz*(1.0+bdO)) );
+              m_matrix.reservePerColumn(numBlocks() *
+                                        cast<T, index_t>(nz * (1.0 + bdO)));
+            }
         }
     }
 

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -311,7 +311,8 @@ public:
      */
     void clearMatrix(const bool& save_sparsety_pattern = true) {
       if (save_sparsety_pattern) {
-        m_matrix *= 0.0;
+        std::fill(m_matrix.valuePtr(),
+                  m_matrix.valuePtr() + m_matrix.nonZeros(), 0.);
       } else {
         m_matrix = gsSparseMatrix<T>(numTestDofs(), numDofs());
 

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -310,29 +310,30 @@ public:
      * information by multiplying matrix by zero in-place
      */
     void clearMatrix(const bool& save_sparsety_pattern = true) {
-      if (save_sparsety_pattern) {
-        std::fill(m_matrix.valuePtr(),
-                  m_matrix.valuePtr() + m_matrix.nonZeros(), 0.);
-      } else {
-        m_matrix = gsSparseMatrix<T>(numTestDofs(), numDofs());
+        if (save_sparsety_pattern) {
+            std::fill(m_matrix.valuePtr(),
+                      m_matrix.valuePtr() + m_matrix.nonZeros(), 0.);
+        } else {
+            m_matrix = gsSparseMatrix<T>(numTestDofs(), numDofs());
 
-        if (0 == m_matrix.rows() || 0 == m_matrix.cols())
-          gsWarn << " No internal DOFs, zero sized system.\n";
-        else {
-          // Pick up values from options
-          const T bdA = m_options.getReal("bdA");
-          const index_t bdB = m_options.getInt("bdB");
-          const T bdO = m_options.getReal("bdO");
-          T nz = 1;
-          const short_t dim = m_exprdata->multiBasis().domainDim();
-          for (short_t i = 0; i != dim; ++i)
-            nz *= bdA * static_cast<T>(m_exprdata->multiBasis().maxDegree(i)) +
-                  static_cast<T>(bdB);
+            if (0 == m_matrix.rows() || 0 == m_matrix.cols())
+                gsWarn << " No internal DOFs, zero sized system.\n";
+            else {
+                // Pick up values from options
+                const T bdA = m_options.getReal("bdA");
+                const index_t bdB = m_options.getInt("bdB");
+                const T bdO = m_options.getReal("bdO");
+                T nz = 1;
+                const short_t dim = m_exprdata->multiBasis().domainDim();
+                for (short_t i = 0; i != dim; ++i)
+                    nz *= bdA * static_cast<T>(
+                                    m_exprdata->multiBasis().maxDegree(i)) +
+                          static_cast<T>(bdB);
 
-          m_matrix.reservePerColumn(numBlocks() *
-                                    cast<T, index_t>(nz * (1.0 + bdO)));
+                m_matrix.reservePerColumn(numBlocks() *
+                                          cast<T, index_t>(nz * (1.0 + bdO)));
+            }
         }
-      }
     }
 
     /// \brief Initializes the right-hand side vector only

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -303,30 +303,29 @@ public:
 
     void clearRhs() { m_rhs.setZero(); }
 
-    void clearMatrix(const bool& save_sparsety_pattern = false) {
-        if (save_sparsety_pattern) {
-            m_matrix *= 0.0;
-        } else {
-            m_matrix = gsSparseMatrix<T>(numTestDofs(), numDofs());
+    void clearMatrix(const bool& save_sparsety_pattern = true) {
+      if (save_sparsety_pattern) {
+        m_matrix *= 0.0;
+      } else {
+        m_matrix = gsSparseMatrix<T>(numTestDofs(), numDofs());
 
-            if (0 == m_matrix.rows() || 0 == m_matrix.cols())
-              gsWarn << " No internal DOFs, zero sized system.\n";
-            else {
-              // Pick up values from options
-              const T bdA = m_options.getReal("bdA");
-              const index_t bdB = m_options.getInt("bdB");
-              const T bdO = m_options.getReal("bdO");
-              T nz = 1;
-              const short_t dim = m_exprdata->multiBasis().domainDim();
-              for (short_t i = 0; i != dim; ++i)
-                nz *= bdA * static_cast<T>(
-                                m_exprdata->multiBasis().maxDegree(i)) +
-                      static_cast<T>(bdB);
+        if (0 == m_matrix.rows() || 0 == m_matrix.cols())
+          gsWarn << " No internal DOFs, zero sized system.\n";
+        else {
+          // Pick up values from options
+          const T bdA = m_options.getReal("bdA");
+          const index_t bdB = m_options.getInt("bdB");
+          const T bdO = m_options.getReal("bdO");
+          T nz = 1;
+          const short_t dim = m_exprdata->multiBasis().domainDim();
+          for (short_t i = 0; i != dim; ++i)
+            nz *= bdA * static_cast<T>(m_exprdata->multiBasis().maxDegree(i)) +
+                  static_cast<T>(bdB);
 
-              m_matrix.reservePerColumn(numBlocks() *
-                                        cast<T, index_t>(nz * (1.0 + bdO)));
-            }
+          m_matrix.reservePerColumn(numBlocks() *
+                                    cast<T, index_t>(nz * (1.0 + bdO)));
         }
+      }
     }
 
     /// \brief Initializes the right-hand side vector only

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -298,7 +298,7 @@ public:
     void initMatrix()
     {
         resetDimensions();
-        clearMatrix();
+        clearMatrix(false);
     }
 
     void clearRhs() { m_rhs.setZero(); }


### PR DESCRIPTION
# Motivation
When doing multiple assemblies (e.g. in a non-linear problem, or in an optimization), accessing the sparse matrix can be a bottleneck when using the expression assembler. Whenever the `clearMatrix()` command was called, the matrix was reinitialized and the sparsity pattern was deleted.

In this suggestion, the matrix is multiplied by zero whenever clearMatrix is called to avoid re-initialization. This is also made default behavior.

With OpenMP in my optimization, it was significantly faster.