### PR TITLE
Fix xml indent

### DIFF
--- a/external/rapidxml/rapidxml_print.hpp
+++ b/external/rapidxml/rapidxml_print.hpp
@@ -47,7 +47,7 @@ namespace rapidxml
         // Copy characters from given range to given output iterator and expand
         // characters into references (&lt; &gt; &apos; &quot; &amp;)
         template<class OutIt, class Ch>
-        inline OutIt copy_and_expand_chars(const Ch *begin, const Ch *end, Ch noexpand, OutIt out)
+        inline OutIt copy_and_expand_chars(const Ch *begin, const Ch *end, Ch noexpand, OutIt out, int indent=0)
         {
             while (begin != end)
             {
@@ -59,6 +59,11 @@ namespace rapidxml
                 {
                     switch (*begin)
                     {
+                    case Ch('\n'):
+                        *out++ = Ch('\n');
+                        for (int i = 0; i < indent - (int)( begin == std::prev(end) ); ++i)
+                            *out++ = Ch(tab_);
+                        break;
                     case Ch('<'):
                         *out++ = Ch('&'); *out++ = Ch('l'); *out++ = Ch('t'); *out++ = Ch(';');
                         break;
@@ -213,7 +218,7 @@ namespace rapidxml
                 if (!child)
                 {
                     // If node has no children, only print its value without indenting
-                    out = copy_and_expand_chars(node->value(), node->value() + node->value_size(), Ch(0), out);
+                    out = copy_and_expand_chars(node->value(), node->value() + node->value_size(), Ch(0), out, indent+1);
                 }
                 else if (child->next_sibling() == 0 && child->type() == node_data)
                 {

--- a/src/gsIO/gsFileData.hpp
+++ b/src/gsIO/gsFileData.hpp
@@ -101,6 +101,11 @@ gsFileData<T>::save(std::string const & fname, bool compress)  const
                                                 GISMO_VERSION, *data);
     data->prepend_node(comment);
 
+    gsXmlNode * declNode = data->allocate_node(rapidxml::node_type::node_declaration);
+    declNode->append_attribute(data->allocate_attribute("version","1.0"));
+    declNode->append_attribute(data->allocate_attribute("encoding","UTF-8"));
+    data->prepend_node(declNode);
+
     if (compress)
     {
         saveCompressed(fname);
@@ -116,7 +121,6 @@ gsFileData<T>::save(std::string const & fname, bool compress)  const
     m_lastPath = tmp;
 
     std::ofstream fn( tmp.c_str() );
-    fn << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
     //rapidxml::print_no_indenting
     fn<< *data;
     fn.close();

--- a/src/gsIO/gsXml.hpp
+++ b/src/gsIO/gsXml.hpp
@@ -46,7 +46,7 @@ char * makeValue(const gsMatrix<T> & value, gsXmlTree & data,
 {
     std::ostringstream oss;
     // Set precision
-    oss << std::setprecision(data.getFloatPrecision());
+    oss << std::setprecision(data.getFloatPrecision()) << "\n";
 
     // Read/Write is RowMajor
     if ( transposed )


### PR DESCRIPTION
## FIXED: 
This PR fixes the (minor) issue when writing a childless node in xml ( e.g. when writing a gsMatrix of coefficients) and the indentation is messed up. 

This makes life a little easier, since when the xml is properly indented, tags can be folded automatically by most modern text editors.

### Example of previous behaviour:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!--This file was created by G+Smo 21.12.0-->
<xml>
 <Geometry type="THBSpline2" id="0">
  <Basis type="THBSplineBasis2">
   <Basis type="TensorBSplineBasis2">
    <Basis type="BSplineBasis" index="0">
     <KnotVector degree="2">0 0 0 0.2 0.4 0.6 0.8 1 1 1 </KnotVector>
    </Basis>
    <Basis type="BSplineBasis" index="1">
     <KnotVector degree="2">0 0 0 0.1317602259238049 0.3488201694428537 0.5658801129619024 0.7829400564809512 1 1 1 </KnotVector>
    </Basis>
   </Basis>
  </Basis>
  <coefs geoDim="2">2.961045487599304 39.89025206263264 
3.006386496652009 40.50107154766287 
...
-7.430870659366338 45.52249758680711 
</coefs>
...

```

### Example of new behaviour:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!--This file was created by G+Smo 23.9.0-->
<xml>
 <Geometry type="THBSpline2" id="1">
  <Basis type="THBSplineBasis2">
   <Basis type="TensorBSplineBasis2">
    <Basis type="BSplineBasis" index="0">
     <KnotVector degree="2">0 0 0 0.05555555555555555 0.1111111111111111 0.1666666666666667 0.2222222222222222 0.2777777777777778 0.3333333333333333 0.3888888888888888 0.4444444444444444 0.5 0.5555555555555556 0.611111111111111 0.6666666666666666 0.7222222222222222 0.7777777777777777 0.8333333333333333 0.8888888888888888 0.9444444444444444 1 1 1 </KnotVector>
    </Basis>
    <Basis type="BSplineBasis" index="1">
     <KnotVector degree="2">0 0 0 0.05555555555555555 0.1111111111111111 0.1666666666666667 0.2222222222222222 0.2777777777777778 0.3333333333333333 0.3888888888888888 0.4444444444444444 0.5 0.5555555555555556 0.611111111111111 0.6666666666666666 0.7222222222222222 0.7777777777777777 0.8333333333333333 0.8888888888888888 0.9444444444444444 1 1 1 </KnotVector>
    </Basis>
   </Basis>
  </Basis>
  <coefs geoDim="2">
   0 0 
   0.3929393176345383 -0.0001849332625428546 
   ...
   -6.060459161055358e-10 9.999999999707427 
  </coefs>
 </Geometry>
...
```
## IMPROVED: -
## NEW: -
## API: -

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
