### PR TITLE
Checking if the Eigen symlink already exists before creating a new one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,9 @@ endif()
 ## #################################################################
 
 #Fix for Eigen directory
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/external/gsEigen ${PROJECT_SOURCE_DIR}/external/Eigen)
+if (NOT EXISTS "${PROJECT_SOURCE_DIR}/external/Eigen")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/external/gsEigen ${PROJECT_SOURCE_DIR}/external/Eigen)
+endif()
 
 set(CMAKE_INSTALL_MESSAGE NEVER)
 


### PR DESCRIPTION
A second build configuration from the same source directory makes cmake complain and exit otherwise.

> CMake Error: failed to create symbolic link '.../gismo/external/Eigen': File exists

The commit just wraps what was introduced in f3e05c394f2828ac8d9c1eeaec473193755db4a1

New to gismo - therefore happy to discuss this :) 