### PR TITLE
Building with mpfr fails (at least) during parallel builds 

### DIFF
--- a/optional/gsOpennurbs/CMakeLists.txt
+++ b/optional/gsOpennurbs/CMakeLists.txt
@@ -348,3 +348,10 @@ endif()
 install(DIRECTORY ${PROJECT_SOURCE_DIR}
         DESTINATION include/gismo
         FILES_MATCHING PATTERN "*.h")
+
+if(TARGET gmp)
+  add_dependencies(${PROJECT_NAME} gmp)
+endif()
+if (TARGET mpfr)
+  add_dependencies(${PROJECT_NAME} mpfr)
+endif()


### PR DESCRIPTION
Building with mpfr fails (at least) during parallel builds when gsOpennurbs is built before the gmp/mpfr installation succeeded. Adding a dependency.

See #643.
