### PR TITLE
Various fixes to enable building the library with real_t = mpreal.

### DIFF
--- a/optional/gsHLBFGS/gsHLBFGS.h
+++ b/optional/gsHLBFGS/gsHLBFGS.h
@@ -25,7 +25,7 @@ namespace gismo
 
 struct gsHLBFGSObjective
 {
-    typedef double T;
+    typedef real_t T;
     typedef gsEigen::Matrix<T, gsEigen::Dynamic, 1> Vector;
     // typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Matrix;
 
@@ -123,9 +123,9 @@ public:
         this->getOptions();
         // std::function<void(index_t N, T* x, T* prev_x, T* f, T* g)>
 
-        const std::function<void(int N, double* x, double* prev_x, double* f, double* g)> wrapfunc =
-            [&](int N, double* x, double*, double* f, double* g) {
-            std::vector<double> array_x(N), array_g(N);
+        const std::function<void(int N, real_t* x, real_t* prev_x, real_t* f, real_t* g)> wrapfunc =
+            [&](int N, real_t* x, real_t*, real_t* f, real_t* g) {
+            std::vector<real_t> array_x(N), array_g(N);
 
             gsAsConstVector<real_t> u(x,N);
             *f = m_op->evalObj(u);

--- a/src/gsAssembler/gsAdaptiveMeshing.hpp
+++ b/src/gsAssembler/gsAdaptiveMeshing.hpp
@@ -349,7 +349,7 @@ T gsAdaptiveMeshing<T>::_totalError(const boxMapType & elements)
     // Accumulation operator for boxMapType
     auto accumulate_error_ptr = [](const T & val, const typename boxMapType::value_type & b)
     { return val + b.second->error(); };
-    T totalError = std::accumulate(elements.begin(),elements.end(),0.0,accumulate_error_ptr);
+    T totalError = std::accumulate(elements.begin(),elements.end(),T( 0.0 ),accumulate_error_ptr);
     return totalError;
 }
 
@@ -386,7 +386,7 @@ gsAdaptiveMeshing<T>::_markFraction_impl( const boxMapType & elements, const std
             return false;
 
         HBoxContainer siblings(sibs);
-        T siblingError = std::accumulate(sibs.begin(),sibs.end(),0.0,accumulate_error);
+        T siblingError = std::accumulate(sibs.begin(),sibs.end(),T( 0.0 ),accumulate_error);
 
         // Check all siblings if they satisfy the predicates
         if (_checkBoxes(sibs,predicates))
@@ -462,7 +462,7 @@ gsAdaptiveMeshing<T>::_markFraction_impl( const boxMapType & elements, const std
         // Get the neighborhoods
         typename HBox::Container neighborhood = HBoxUtils::toContainer(HBoxUtils::markAdmissible(*box,m_m));
         _setContainerProperties(neighborhood);
-        T neighborhoodError = std::accumulate(neighborhood.begin(),neighborhood.end(),0.0,accumulate_error);
+        T neighborhoodError = std::accumulate(neighborhood.begin(),neighborhood.end(),T( 0.0 ),accumulate_error);
 
         // if the errorMarkSum is exceeded with the current contribution, return true
         // NOTE: this can mean that this element suddenly has a large contribution! i.e., larger then the next element in lin
@@ -553,7 +553,7 @@ gsAdaptiveMeshing<T>::_markProjectedFraction_impl( const boxMapType & elements, 
             return false;
 
         HBoxContainer siblings(sibs);
-        T siblingSetBack = std::accumulate(sibs.begin(),sibs.end(),0.0,accumulate_improvement);
+        T siblingSetBack = std::accumulate(sibs.begin(),sibs.end(),T( 0.0 ),accumulate_improvement);
 
         // Check all siblings if they satisfy the predicates
         if (_checkBoxes(sibs,predicates))
@@ -643,7 +643,7 @@ gsAdaptiveMeshing<T>::_markProjectedFraction_impl( const boxMapType & elements, 
         typename HBox::Container neighborhood = HBoxUtils::toContainer(HBoxUtils::markAdmissible(*box,m_m));
         HBoxContainer neighborhoodtmp = HBoxContainer(neighborhood);
         _setContainerProperties(neighborhood);
-        T neighborhoodImprovement = std::accumulate(neighborhood.begin(),neighborhood.end(),0.0,accumulate_improvement);
+        T neighborhoodImprovement = std::accumulate(neighborhood.begin(),neighborhood.end(),T( 0.0 ),accumulate_improvement);
 
         // Check all elements in the neighborhood if they satisfy the predicates
         if (_checkBoxes(neighborhood,predicates))

--- a/src/gsAssembler/gsAdaptiveMeshing.hpp
+++ b/src/gsAssembler/gsAdaptiveMeshing.hpp
@@ -349,7 +349,7 @@ T gsAdaptiveMeshing<T>::_totalError(const boxMapType & elements)
     // Accumulation operator for boxMapType
     auto accumulate_error_ptr = [](const T & val, const typename boxMapType::value_type & b)
     { return val + b.second->error(); };
-    T totalError = std::accumulate(elements.begin(),elements.end(),T( 0.0 ),accumulate_error_ptr);
+    T totalError = std::accumulate(elements.begin(),elements.end(),(T)( 0 ),accumulate_error_ptr);
     return totalError;
 }
 
@@ -386,7 +386,7 @@ gsAdaptiveMeshing<T>::_markFraction_impl( const boxMapType & elements, const std
             return false;
 
         HBoxContainer siblings(sibs);
-        T siblingError = std::accumulate(sibs.begin(),sibs.end(),T( 0.0 ),accumulate_error);
+        T siblingError = std::accumulate(sibs.begin(),sibs.end(),(T)( 0 ),accumulate_error);
 
         // Check all siblings if they satisfy the predicates
         if (_checkBoxes(sibs,predicates))
@@ -462,7 +462,7 @@ gsAdaptiveMeshing<T>::_markFraction_impl( const boxMapType & elements, const std
         // Get the neighborhoods
         typename HBox::Container neighborhood = HBoxUtils::toContainer(HBoxUtils::markAdmissible(*box,m_m));
         _setContainerProperties(neighborhood);
-        T neighborhoodError = std::accumulate(neighborhood.begin(),neighborhood.end(),T( 0.0 ),accumulate_error);
+        T neighborhoodError = std::accumulate(neighborhood.begin(),neighborhood.end(),(T)( 0 ),accumulate_error);
 
         // if the errorMarkSum is exceeded with the current contribution, return true
         // NOTE: this can mean that this element suddenly has a large contribution! i.e., larger then the next element in lin
@@ -553,7 +553,7 @@ gsAdaptiveMeshing<T>::_markProjectedFraction_impl( const boxMapType & elements, 
             return false;
 
         HBoxContainer siblings(sibs);
-        T siblingSetBack = std::accumulate(sibs.begin(),sibs.end(),T( 0.0 ),accumulate_improvement);
+        T siblingSetBack = std::accumulate(sibs.begin(),sibs.end(),(T)( 0 ),accumulate_improvement);
 
         // Check all siblings if they satisfy the predicates
         if (_checkBoxes(sibs,predicates))
@@ -643,7 +643,7 @@ gsAdaptiveMeshing<T>::_markProjectedFraction_impl( const boxMapType & elements, 
         typename HBox::Container neighborhood = HBoxUtils::toContainer(HBoxUtils::markAdmissible(*box,m_m));
         HBoxContainer neighborhoodtmp = HBoxContainer(neighborhood);
         _setContainerProperties(neighborhood);
-        T neighborhoodImprovement = std::accumulate(neighborhood.begin(),neighborhood.end(),T( 0.0 ),accumulate_improvement);
+        T neighborhoodImprovement = std::accumulate(neighborhood.begin(),neighborhood.end(),(T)( 0 ),accumulate_improvement);
 
         // Check all elements in the neighborhood if they satisfy the predicates
         if (_checkBoxes(neighborhood,predicates))

--- a/src/gsCore/gsGeometry.hpp
+++ b/src/gsCore/gsGeometry.hpp
@@ -363,7 +363,7 @@ T gsGeometry<T>::directedHausdorffDistance(const gsGeometry & other, const index
     {
         maxDist = std::max(maxDist,other.closestPointTo(pts.col(k),tmp,accuracy,false));
     }
-    return sqrt(2*maxDist); // euclidean distance since closestPointTo uses 1/2*||x-y||^2, see gsSquaredDistance
+    return math::sqrt(2*maxDist); // euclidean distance since closestPointTo uses 1/2*||x-y||^2, see gsSquaredDistance
 }
 
 template<class T>

--- a/src/gsCore/gsGeometry.hpp
+++ b/src/gsCore/gsGeometry.hpp
@@ -363,7 +363,7 @@ T gsGeometry<T>::directedHausdorffDistance(const gsGeometry & other, const index
     {
         maxDist = std::max(maxDist,other.closestPointTo(pts.col(k),tmp,accuracy,false));
     }
-    return std::sqrt(2*maxDist); // euclidean distance since closestPointTo uses 1/2*||x-y||^2, see gsSquaredDistance
+    return sqrt(2*maxDist); // euclidean distance since closestPointTo uses 1/2*||x-y||^2, see gsSquaredDistance
 }
 
 template<class T>

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -859,7 +859,7 @@ T gsMultiPatch<T>::averageHausdorffDistance(  const gsMultiPatch<T> & other,
                                                     bool directed)
 {
     std::vector<T> distances = HausdorffDistance(other,nsamples,accuracy,directed);
-    return std::accumulate(distances.begin(), distances.end(), T( 0.0 ) ) / distances.size();
+    return std::accumulate(distances.begin(), distances.end(), (T)( 0 ) ) / distances.size();
 }
 
 template<class T>

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -859,7 +859,7 @@ T gsMultiPatch<T>::averageHausdorffDistance(  const gsMultiPatch<T> & other,
                                                     bool directed)
 {
     std::vector<T> distances = HausdorffDistance(other,nsamples,accuracy,directed);
-    return std::accumulate(distances.begin(), distances.end(), 0.0) / distances.size();
+    return std::accumulate(distances.begin(), distances.end(), T( 0.0 ) ) / distances.size();
 }
 
 template<class T>

--- a/src/gsIO/gsParaviewCollection.cpp
+++ b/src/gsIO/gsParaviewCollection.cpp
@@ -65,7 +65,7 @@ namespace gismo
             m_time += 1.0;
             time = m_time;
         }
-        else { m_time = time; }
+        else { m_time = static_cast< int >( time ); }
 
         std::string name;
         if ( m_options.askSwitch("makeSubfolder",true) )
@@ -83,7 +83,7 @@ namespace gismo
         }
 
 
-        name += "_t" + std::to_string(time);
+        name += "_t" + std::to_string( static_cast< double >( time ) );
        
         m_dataset = gsParaviewDataSet(name, geometry, m_evaluator, m_options);
     }

--- a/src/gsModeling/gsBarrierCore.h
+++ b/src/gsModeling/gsBarrierCore.h
@@ -783,7 +783,7 @@ class AndersonAcceleration {
       m_alpha(0) = 0;
       Scalar dF_squaredNorm = m_prevdF.col(m_columnIndex).squaredNorm();
       m_normalEquationMatrix(0, 0) = dF_squaredNorm;
-      Scalar dF_norm = sqrt(dF_squaredNorm);
+      Scalar dF_norm = math::sqrt(dF_squaredNorm);
 
       // For better numerical stability
       if (dF_norm > EPSILON) {

--- a/src/gsModeling/gsBarrierCore.h
+++ b/src/gsModeling/gsBarrierCore.h
@@ -760,7 +760,7 @@ class AndersonAcceleration {
 
   inline void printIterationInfo() {
     if (m_printInfo) {
-      printf(" %d         %.4e\n", m_iter, m_currResidualNorm);
+      printf(" %d         %.4e\n", m_iter, static_cast< double >( m_currResidualNorm ));
     }
   }
 
@@ -783,7 +783,7 @@ class AndersonAcceleration {
       m_alpha(0) = 0;
       Scalar dF_squaredNorm = m_prevdF.col(m_columnIndex).squaredNorm();
       m_normalEquationMatrix(0, 0) = dF_squaredNorm;
-      Scalar dF_norm = std::sqrt(dF_squaredNorm);
+      Scalar dF_norm = sqrt(dF_squaredNorm);
 
       // For better numerical stability
       if (dF_norm > EPSILON) {


### PR DESCRIPTION
This PR attempts to fix mpfr builds.

The changes mostly resolve some issues in places where real_t is assumed to be a fundamental type. 