### PR TITLE
Replace 'sprintf' by 'snprintf' as the former is marked deprecated

### DIFF
--- a/external/onurbs/opennurbs_archive.cpp
+++ b/external/onurbs/opennurbs_archive.cpp
@@ -5844,7 +5844,7 @@ bool ON_BinaryArchive::Write3dmStartSection( int version, const char* sInformati
   memset( sVersion, 0, sizeof(sVersion) );
   if ( version < 1 )
     version = ON_BinaryArchive::CurrentArchiveVersion();
-  sprintf(sVersion,"3D Geometry File Format %8d",version);
+  snprintf(sVersion,64,"3D Geometry File Format %8d",version);
   bool rc = WriteByte( 32, sVersion );
   if ( rc )
     rc = BeginWrite3dmBigChunk( TCODE_COMMENTBLOCK, 0 );
@@ -5857,7 +5857,7 @@ bool ON_BinaryArchive::Write3dmStartSection( int version, const char* sInformati
       char s[2048];
       size_t s_len = 0;
       memset( s, 0, sizeof(s) );
-      sprintf(s," 3DM I/O processor: OpenNURBS toolkit version %d",ON::Version());
+      snprintf(s,2048," 3DM I/O processor: OpenNURBS toolkit version %d",ON::Version());
       strcat(s," (compiled on ");
       strcat(s,__DATE__);
       strcat(s,")\n");

--- a/external/onurbs/opennurbs_bezier.cpp
+++ b/external/onurbs/opennurbs_bezier.cpp
@@ -1904,7 +1904,7 @@ void ON_BezierSurface::Dump( ON_TextLog& dump ) const
       if ( i > 0 )
         dump.Print("\n");
       sPreamble[0] = 0;
-      sprintf(sPreamble,"  CV[%2d]",i);
+      snprintf(sPreamble,128,"  CV[%2d]",i);
       dump.PrintPointList( m_dim, m_is_rat, 
                         m_order[1], m_cv_stride[1],
                         CV(i,0), 

--- a/external/onurbs/opennurbs_error.cpp
+++ b/external/onurbs/opennurbs_error.cpp
@@ -120,17 +120,17 @@ static bool ON_PrintErrorHeader(
   bool bPrintMessage = false;
   sMessage[0] = 0;
 
+  size_t sz = (sizeof(sMessage)/sizeof(sMessage[0])) - 1;
 #if defined(ON_COMPILER_MSC)
   // use sprintf_s() ...
-  size_t sz = (sizeof(sMessage)/sizeof(sMessage[0])) - 1;
 #define ON_SPRINTF4(s,count,fname,ln,func) sprintf_s(sMessage,sz,s,count,fname,ln,func)
 #define ON_SPRINTF3(s,count,fname,ln) sprintf_s(sMessage,sz,s,count,fname,ln)
 #define ON_SPRINTF1(s,count) sprintf_s(sMessage,sz,s,count)
 #else
   // use sprintf() ...
-#define ON_SPRINTF4(s,count,fname,ln,func) sprintf(sMessage,s,count,fname,ln,func)
-#define ON_SPRINTF3(s,count,fname,ln) sprintf(sMessage,s,count,fname,ln)
-#define ON_SPRINTF1(s,count) sprintf(sMessage,s,count)
+#define ON_SPRINTF4(s,count,fname,ln,func) snprintf(sMessage,sz,s,count,fname,ln,func)
+#define ON_SPRINTF3(s,count,fname,ln) snprintf(sMessage,sz,s,count,fname,ln)
+#define ON_SPRINTF1(s,count) snprintf(sMessage,sz,s,count)
 #endif
 
   if ( ON_DEBUG_ERROR_MESSAGE_OPTION )

--- a/external/onurbs/opennurbs_nurbssurface.cpp
+++ b/external/onurbs/opennurbs_nurbssurface.cpp
@@ -520,7 +520,7 @@ void ON_NurbsSurface::Dump( ON_TextLog& dump ) const
       if ( i > 0 )
         dump.Print("\n");
       sPreamble[0] = 0;
-      sprintf(sPreamble,"  CV[%2d]",i);
+      snprintf(sPreamble,128,"  CV[%2d]",i);
       dump.PrintPointList( m_dim, m_is_rat, 
                         m_cv_count[1], m_cv_stride[1],
                         CV(i,0), 

--- a/external/onurbs/opennurbs_textlog.cpp
+++ b/external/onurbs/opennurbs_textlog.cpp
@@ -543,7 +543,7 @@ void ON_TextLog::PrintPointGrid( int dim, int is_rat,
   if (!sPreamble || !sPreamble[0])
     sPreamble = "point";
   for ( i = 0; i < point_count0; i++ ) {
-    sprintf( s,  "%s[%2d]", sPreamble, i );
+    snprintf( s,  1024, "%s[%2d]", sPreamble, i );
     PrintPointList( dim, is_rat, point_count1, point_stride1, P + i*point_stride0, s );
   }
 }


### PR DESCRIPTION
'sprinf' is considered deprecated (at least by Apple's clang compiler) and it is suggested to replace it by 'snprintf'. This PR does exactly this for the files from opennurbs.