### PR TITLE
XML I/O labels and includes

### DIFF
--- a/external/rapidxml/rapidxml.hpp
+++ b/external/rapidxml/rapidxml.hpp
@@ -1122,10 +1122,10 @@ namespace rapidxml
         //! Appends a new child node.
         //! The appended child becomes the last child.
         //! \param child Node to append.
-        void merge_parent(xml_node<Ch> * parent)
+        void merge_sibling(xml_node<Ch> * sibl)
         {
-            if (this==parent) return;
-            xml_node<Ch> * child = parent->m_first_node;
+            if (this==sibl) return;
+            xml_node<Ch> * child = sibl->m_first_node;
             if (!child) return;
 
             if (first_node())
@@ -1138,10 +1138,11 @@ namespace rapidxml
                 child->m_prev_sibling = 0;
                 m_first_node = child;
             }
-            for (xml_node<Ch> *node = parent->m_first_node; node; node = node->m_next_sibling)
+            for (xml_node<Ch> *node = sibl->m_first_node; node; node = node->m_next_sibling)
                 node->m_parent = this;
-            m_last_node = parent->m_last_node;
-            parent->m_first_node = parent->m_last_node = 0;
+            m_last_node = sibl->m_last_node;
+            sibl->m_first_node = sibl->m_last_node = 0;
+            //sibl->m_parent->remove_node(sibl);
         }
 
         //! Inserts a new child node at specified place inside the node.

--- a/external/rapidxml/rapidxml.hpp
+++ b/external/rapidxml/rapidxml.hpp
@@ -1384,14 +1384,22 @@ namespace rapidxml
 
         inline int numNodes() const {return max_Id+1;}
 
-        void appendToRoot(xml_node<Ch> * node, int id = -1)
+        void appendToRoot(xml_node<Ch> * node, int id = -1, std::string label="")
         {
             char tmp[6];
             snprintf(tmp, 6, "%d", (unsigned short)(-1==id ? ++max_Id : id ));
             node->append_attribute(this->allocate_attribute(
             this->allocate_string("id"), this->allocate_string(tmp) ) );
+            if (label!="")
+                node->append_attribute(this->allocate_attribute(
+                this->allocate_string("label"), this->allocate_string(label.c_str()) ) );
             getRoot()->append_node(node);
             if (-1!=id) max_Id = std::max(id,max_Id);
+        }
+
+        void appendToRoot(xml_node<Ch> * node, std::string label)
+        {
+            appendToRoot(node, -1, label);
         }
 
         inline unsigned getFloatPrecision() const {return m_float_precision;}

--- a/filedata/surfaces/simple.xml
+++ b/filedata/surfaces/simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xml>
- <Geometry type="TensorBSpline2" id="0">
+ <Geometry type="TensorBSpline2" id="0" label="simplesurface">
   <Basis type="TensorBSplineBasis2">
    <Basis type="BSplineBasis" index="0">
     <KnotVector degree="3">0 0 0 0 1 1 1 1 </KnotVector>

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -287,7 +287,7 @@ public:
 
     /// Add the object to the Xml tree, same as <<, but also allows to set the XML label attribute
     template<class Object>
-    void add (const Object & obj, std::string label)
+    void addWithLabel (const Object & obj, std::string label)
     {
         add(obj, -1, label);
     }

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -305,7 +305,8 @@ public:
         data->appendToRoot(node);
     }
 
-    void addInclude( const std::string & filename, const real_t & time, const index_t & id=-1, const std::string & label="")
+    void addInclude( const std::string & filename, const real_t & time,
+                     const index_t & id=-1, const std::string & label="")
     {
         gsXmlNode* node = internal::makeNode("xmlfile", filename, *data);
         GISMO_ASSERT( filename!="", "No filename provided for include!");

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -232,6 +232,12 @@ public:
         return (bool) nd;
     }
 
+    /// Returns true if an entry of \em tag exists in the xml file
+    inline bool hasTag(std::string tag) const
+    {
+       return getAnyFirstNode(tag.c_str());
+    }
+
     /// Returns true if an Object exists in the filedata, even nested
     /// inside other objects
     template<class Object>
@@ -326,7 +332,7 @@ public:
         data->appendToRoot(node,id, label);
     }
 
-private:
+protected:
     gsFileData getInclude(index_t id, real_t time, std::string label);
 
 public:

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -305,62 +305,18 @@ public:
         data->appendToRoot(node);
     }
 
-    void addInclude( const std::string & filename, const real_t & time,
+    void addInclude( const std::string & filename, const real_t & time=-1.,
                      const index_t & id=-1, const std::string & label="")
     {
-        gsXmlNode* node = internal::makeNode("xmlfile", filename, *data);
         GISMO_ASSERT( filename!="", "No filename provided for include!");
-        node->append_attribute(internal::makeAttribute("time", std::to_string(time), *data));
+        gsXmlNode* node = internal::makeNode("xmlfile", filename, *data);
+        if (-1. != time)
+            node->append_attribute(internal::makeAttribute("time", std::to_string(time), *data));
         data->appendToRoot(node,id, label);
     }
 
 private:
-    gsFileData getInclude(index_t id, real_t time, std::string label)
-    {   
-        // Ensures that only one argument is actually provided
-        GISMO_ENSURE((id!=-1 ^  time!=-1. ^  label!="") &&
-                    !(id!=-1 && time!=-1. && label!=""),
-                    "gsFileData::getInclude("<<id<<","<<time<<","<<label<<"), too many arguments provided!");
-        std::string attr_name, attr_string;
-
-        // Attribute name and string representation, depending on pprovided input.
-        if ( id!=-1 )
-        {
-            attr_name   = "id";
-            attr_string = std::to_string(id); 
-        }
-        else if ( time!=-1)
-        {
-            attr_name   = "time";
-            attr_string = std::to_string(time);
-        }
-        else if ( label!="")
-        {
-            attr_name   = "label";
-            attr_string = label;
-        } 
-
-        bool found=false;
-        gsXmlNode * root = getXmlRoot();
-        const gsXmlAttribute * attribute;
-        for (gsXmlNode * child = root->first_node("xmlfile");
-             child; child = child->next_sibling("xmlfile"))
-        {
-            attribute = child->first_attribute(attr_name.c_str());
-
-            if (id!=-1 && attribute && atoi(attribute->value()) == id ) found=true; 
-            else if (time!=-1. && attribute && atof(attribute->value()) == time ) found=true; 
-            else if ( label!="" && attribute && attribute->value() == label) found=true; 
-
-            if (found)
-            {
-                std::string filename = gsFileManager::getPath(m_lastPath) +  child->value();
-                gsFileData res(filename);
-                return res;
-            }
-        }
-        GISMO_ERROR("Include with " << attr_name << "=" << attr_string << " does not exist!");
-    }
+    gsFileData getInclude(index_t id, real_t time, std::string label);
 
 public:
     gsFileData getInclude(index_t id)

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <string>
+#include <list>
 
 #include <gsIO/gsXml.h>
 
@@ -101,7 +102,7 @@ private:
     FileData * data;
 
     // Used to hold parsed data of native gismo XML files
-    std::vector<char> m_buffer;
+    std::list<std::vector<char> > m_buffer;
 
     // Holds the last path that was used in an I/O operation
     mutable String m_lastPath;
@@ -408,7 +409,7 @@ public:
     }
 
     /// Returns the size of the data
-    size_t bufferSize() const { return m_buffer.size(); };
+    size_t bufferSize() const { return m_buffer.front().size(); };
 
     /// Prints the XML data as a string
     std::ostream &print(std::ostream &os) const;

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -266,7 +266,7 @@ public:
 
     /// Add the object to the Xml tree, same as <<, but also allows to set the XML id attribute
     template<class Object>
-    void add (const Object & obj, int id = -1)
+    void add (const Object & obj, int id = -1, std::string label="")
     {
         gsXmlNode* node =
             internal::gsXml<Object>::put(obj, *data);
@@ -277,8 +277,15 @@ public:
         }
         else
         {
-            data->appendToRoot(node,id);
+            data->appendToRoot(node,id, label);
         }
+    }
+
+    /// Add the object to the Xml tree, same as <<, but also allows to set the XML label attribute
+    template<class Object>
+    void add (const Object & obj, std::string label)
+    {
+        add(obj, -1, label);
     }
 
     /// Add a string to the Xml tree

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -49,7 +49,7 @@ public:
      *
      * @param fn filename string
      */
-    explicit gsFileData(String const & fn);
+    explicit gsFileData(String const & fn, bool recursive=false);
 
     /**
      * Loads the contents of a file into a gsFileData object
@@ -58,7 +58,7 @@ public:
      *
      * Returns true on success, false on failure.
      */
-    bool read(String const & fn) ;
+    bool read(String const & fn, bool recursive=false) ;
 
     ~gsFileData();
 
@@ -115,13 +115,13 @@ protected:
  */
 
     /// Reads a file with xml extension
-    bool readXmlFile( String const & fn );
+    bool readXmlFile( String const & fn, bool recursive=false);
 
     /// Reads a file with xml.gz extension
-    bool readXmlGzFile( String const & fn );
+    bool readXmlGzFile( String const & fn, bool recursive=false);
 
     /// Reads Gismo's native XML file
-    bool readGismoXmlStream(std::istream & is);
+    bool readGismoXmlStream(std::istream & is, bool recursive=false);
 
     /// Reads Axel file
     bool readAxelFile(String const & fn);

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -368,7 +368,7 @@ public:
         GISMO_ERROR("String with id " << id << " does not exist!");
     }
 
-    std::string getString (const std::string & label) const
+    std::string getStringByLabel (const std::string & label) const
     {
         //GISMO_ASSERT(id < 0, "Id " << id << " should be >= 0!");
 

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -186,6 +186,21 @@ public:
         result = give(*obj);
     }
 
+    /// Searches and fetches a poitner to a Gismo object with a given label
+    template<class Object>
+    inline memory::unique_ptr<Object> getLabel(const std::string & name)  const
+    {
+        return memory::make_unique( internal::gsXml<Object>::getLabel( getXmlRoot(), name ) );
+    }
+
+    /// Searches and fetches the Gismo object with a given label
+    template<class Object>
+    inline void getLabel(const std::string & name, Object& result)  const
+    {
+        memory::unique_ptr<Object> obj = getId<Object>(name);
+        result = give(*obj);
+    }
+
     /// Prints the XML tag of a Gismo object
     template<class Object>
     inline String tag() const

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -48,6 +48,7 @@ public:
      * Initializes a gsFileData object with the contents of a file
      *
      * @param fn filename string
+     * @param recursive if true, then all referenced xml files will be read as one gsFileData object recursively
      */
     explicit gsFileData(String const & fn, bool recursive=false);
 
@@ -55,6 +56,7 @@ public:
      * Loads the contents of a file into a gsFileData object
      *
      * @param fn filename string
+     * @param recursive if true, then all referenced xml files will be read as one gsFileData object recursively
      *
      * Returns true on success, false on failure.
      */
@@ -305,6 +307,11 @@ public:
         data->appendToRoot(node);
     }
 
+    /// @brief Add a reference ( <xmlfile> tag ) to another Gismo .xml file to the xml tree
+    /// @param filename The path of the referenced file, relative to the path of the current file
+    /// @param time for time series data, optional
+    /// @param id Integer for identification purposes, optional
+    /// @param label String for identification purposes, optional
     void addInclude( const std::string & filename, const real_t & time=-1.,
                      const index_t & id=-1, const std::string & label="")
     {
@@ -319,16 +326,25 @@ private:
     gsFileData getInclude(index_t id, real_t time, std::string label);
 
 public:
+    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
+    /// @param id Index of the <xmlfile> node
+    /// @return A new gsFileData object with the contents of the referenced file
     gsFileData getInclude(index_t id)
     {
         return getInclude(id, -1., "");
     }
 
+    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
+    /// @param time Time attribute of the <xmlfile> node
+    /// @return A new gsFileData object with the contents of the referenced file
     gsFileData getInclude(real_t time)
     {
         return getInclude(-1,time, "");
     }
 
+    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
+    /// @param label Label of the <xmlfile> node
+    /// @return A new gsFileData object with the contents of the referenced file
     gsFileData getInclude(std::string label)
     {
         return getInclude(-1,-1.,label);

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -303,6 +303,65 @@ public:
         data->appendToRoot(node);
     }
 
+    void addInclude( const std::string & filename, const real_t & time, const index_t & id=-1, const std::string & label="")
+    {
+        gsXmlNode* node = internal::makeNode("xmlfile", filename, *data);
+        GISMO_ASSERT( filename!="", "No filename provided for include!");
+        node->append_attribute(internal::makeAttribute("time", std::to_string(time), *data));
+        data->appendToRoot(node,id, label);
+    }
+
+    gsFileData getInclude(index_t id)
+    {
+        gsXmlNode * root = getXmlRoot();
+        const gsXmlAttribute * id_at;
+        for (gsXmlNode * child = root->first_node("xmlfile");
+             child; child = child->next_sibling("xmlfile"))
+        {
+            id_at = child->first_attribute("id");
+            if (id_at && atoi(id_at->value()) == id )
+            {
+                gsFileData res(child->value());
+                return res;
+            }
+        }
+        GISMO_ERROR("Include with id " << id << " does not exist!");
+    }
+
+    gsFileData getInclude(real_t time)
+    {
+        gsXmlNode * root = getXmlRoot();
+        const gsXmlAttribute * time_at;
+        for (gsXmlNode * child = root->first_node("xmlfile");
+             child; child = child->next_sibling("xmlfile"))
+        {
+            time_at = child->first_attribute("time");
+            if (time_at && atof(time_at->value()) == time )
+            {
+                gsFileData res(child->value());
+                return res;
+            }
+        }
+        GISMO_ERROR("Include with time " << time << " does not exist!");
+    }
+
+    gsFileData getInclude(std::string label)
+    {
+        gsXmlNode * root = getXmlRoot();
+        const gsXmlAttribute * label_at;
+        for (gsXmlNode * child = root->first_node("xmlfile");
+             child; child = child->next_sibling("xmlfile"))
+        {
+            label_at = child->first_attribute("label");
+            if (label_at && label_at->value() == label )
+            {
+                gsFileData res( child->value());
+                return res;
+            }
+        }
+        GISMO_ERROR("Include with label " << label << " does not exist!");
+    }
+
     std::string getString () const
     {
 

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -264,7 +264,7 @@ public:
         this->add<Object>(obj);
     }
 
-    /// Add the object to the Xml tree, same as <<, but also allows to set the XML id attribute
+    /// Add the object to the Xml tree, same as <<, but also allows to set the XML id and label attributes
     template<class Object>
     void add (const Object & obj, int id = -1, std::string label="")
     {

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -197,7 +197,7 @@ public:
     template<class Object>
     inline void getLabel(const std::string & name, Object& result)  const
     {
-        memory::unique_ptr<Object> obj = getId<Object>(name);
+        memory::unique_ptr<Object> obj = getLabel<Object>(name);
         result = give(*obj);
     }
 

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -323,7 +323,7 @@ public:
     /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
     /// @param id Index of the <xmlfile> node
     /// @return A new gsFileData object with the contents of the referenced file
-    gsFileData getInclude(index_t id)
+    gsFileData getIncludeById(index_t id)
     {
         return getInclude(id, -1., "");
     }
@@ -331,7 +331,7 @@ public:
     /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
     /// @param time Time attribute of the <xmlfile> node
     /// @return A new gsFileData object with the contents of the referenced file
-    gsFileData getInclude(real_t time)
+    gsFileData getIncludeByTime(real_t time)
     {
         return getInclude(-1,time, "");
     }
@@ -339,7 +339,7 @@ public:
     /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
     /// @param label Label of the <xmlfile> node
     /// @return A new gsFileData object with the contents of the referenced file
-    gsFileData getInclude(std::string label)
+    gsFileData getIncludeByLabel(std::string label)
     {
         return getInclude(-1,-1.,label);
     }

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -264,7 +264,7 @@ public:
 
     /// Add the object to the Xml tree, same as <<, but also allows to set the XML id and label attributes
     template<class Object>
-    void add (const Object & obj, int id = -1, std::string label="")
+    void add (const Object & obj, int id = -1)
     {
         gsXmlNode* node =
             internal::gsXml<Object>::put(obj, *data);
@@ -275,7 +275,7 @@ public:
         }
         else
         {
-            data->appendToRoot(node,id, label);
+            data->appendToRoot(node,id);
         }
     }
 
@@ -283,7 +283,17 @@ public:
     template<class Object>
     void addWithLabel (const Object & obj, std::string label)
     {
-        add(obj, -1, label);
+        gsXmlNode* node =
+            internal::gsXml<Object>::put(obj, *data);
+        if ( ! node )
+        {
+            gsInfo<<"gsFileData: Trouble inserting "<<internal::gsXml<Object>::tag()
+                         <<" to the XML tree. is \"put\" implemented ??\n";
+        }
+        else
+        {
+            data->appendToRoot(node,-1,label);
+        }
     }
 
     /// Add a string to the Xml tree

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -228,14 +228,8 @@ public:
     {
         gsXmlNode * root = getXmlRoot();
         const gsXmlAttribute * id_at;
-        for (gsXmlNode * child = root->first_node();
-             child; child = child->next_sibling())
-        {
-            id_at = child->first_attribute("id");
-            if (id_at && atoi(id_at->value()) == id )
-                return true;
-        }
-        return false;
+        gsXmlNode * nd = internal::searchId(id, root);
+        return (bool) nd;
     }
 
     /// Returns true if an Object exists in the filedata, even nested
@@ -365,14 +359,11 @@ public:
 
         gsXmlNode * root = getXmlRoot();
         const gsXmlAttribute * id_at;
-        for (gsXmlNode * child = root->first_node();
-             child; child = child->next_sibling())
+        gsXmlNode * nd = internal::searchId(id, root, "string");
+        if (nd)
         {
-            id_at = child->first_attribute("id");
-            if (id_at && atoi(id_at->value()) == id ) {
-                std::string res(child->value());
-                return res;
-            }
+            std::string res(nd->value());
+            return res;
         }
         GISMO_ERROR("String with id " << id << " does not exist!");
     }
@@ -383,14 +374,11 @@ public:
 
         gsXmlNode * root = getXmlRoot();
         const gsXmlAttribute * id_at;
-        for (gsXmlNode * child = root->first_node();
-             child; child = child->next_sibling())
+        gsXmlNode * nd = internal::searchNode( root, "label", label, "string");
+        if (nd)
         {
-            id_at = child->first_attribute("label");
-            if (id_at && id_at->value() == label ) {
-                std::string res(child->value());
-                return res;
-            }
+            std::string res(nd->value());
+            return res;
         }
         GISMO_ERROR("String with label " << label << " does not exist!");
     }

--- a/src/gsIO/gsFileData.h
+++ b/src/gsIO/gsFileData.h
@@ -333,31 +333,31 @@ public:
     }
 
 protected:
-    gsFileData getInclude(index_t id, real_t time, std::string label);
+    void getInclude(gsFileData & res, index_t id, real_t time, std::string label);
 
 public:
-    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
+    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it in the gsFileData \em res object
+    /// @param res The gsFileData object where the referenced file will be loaded into
     /// @param id Index of the <xmlfile> node
-    /// @return A new gsFileData object with the contents of the referenced file
-    gsFileData getIncludeById(index_t id)
+    void getIncludeById(gsFileData & res, index_t id)
     {
-        return getInclude(id, -1., "");
+        return getInclude(res, id, -1., "");
     }
 
-    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
+    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it in the gsFileData \em res object
+    /// @param res The gsFileData object where the referenced file will be loaded into
     /// @param time Time attribute of the <xmlfile> node
-    /// @return A new gsFileData object with the contents of the referenced file
-    gsFileData getIncludeByTime(real_t time)
+    void getIncludeByTime(gsFileData & res, real_t time)
     {
-        return getInclude(-1,time, "");
+        return getInclude(res, -1,time, "");
     }
 
-    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it and returns it as a new gsFileData object
+    /// @brief Looks for a referenced Gismo .xml file ( <xmlfile> tag ) in the current xml tree, parses it in the gsFileData \em res object
+    /// @param res The gsFileData object where the referenced file will be loaded into
     /// @param label Label of the <xmlfile> node
-    /// @return A new gsFileData object with the contents of the referenced file
-    gsFileData getIncludeByLabel(std::string label)
+    void getIncludeByLabel(gsFileData & res, std::string label)
     {
-        return getInclude(-1,-1.,label);
+        return getInclude(res, -1,-1.,label);
     }
 
     std::string getString () const

--- a/src/gsIO/gsFileData.hpp
+++ b/src/gsIO/gsFileData.hpp
@@ -287,6 +287,54 @@ bool gsFileData<T>::readGismoXmlStream(std::istream & is)
     return true;
 }
 
+template<class T>
+gsFileData<T> gsFileData<T>::getInclude(index_t id, real_t time, std::string label)
+{   
+    // Ensures that only one argument is actually provided
+    GISMO_ENSURE((id!=-1 ^  time!=-1. ^  label!="") &&
+                !(id!=-1 && time!=-1. && label!=""),
+                "gsFileData::getInclude("<<id<<","<<time<<","<<label<<"), too many arguments provided!");
+    std::string attr_name, attr_string;
+
+    // Attribute name and string representation, depending on pprovided input.
+    if ( id!=-1 )
+    {
+        attr_name   = "id";
+        attr_string = std::to_string(id); 
+    }
+    else if ( time!=-1)
+    {
+        attr_name   = "time";
+        attr_string = std::to_string(time);
+    }
+    else if ( label!="")
+    {
+        attr_name   = "label";
+        attr_string = label;
+    } 
+
+    bool found=false;
+    gsXmlNode * root = getXmlRoot();
+    const gsXmlAttribute * attribute;
+    for (gsXmlNode * child = root->first_node("xmlfile");
+            child; child = child->next_sibling("xmlfile"))
+    {
+        attribute = child->first_attribute(attr_name.c_str());
+
+        if (id!=-1 && attribute && atoi(attribute->value()) == id ) found=true; 
+        else if (time!=-1. && attribute && atof(attribute->value()) == time ) found=true; 
+        else if ( label!="" && attribute && attribute->value() == label) found=true; 
+
+        if (found)
+        {
+            std::string filename = gsFileManager::getPath(m_lastPath) +  child->value();
+            gsFileData res(filename);
+            return res;
+        }
+    }
+    GISMO_ERROR("Include with " << attr_name << "=" << attr_string << " does not exist!");
+}
+
 /*---------- Axl file */
 
 template<class T>

--- a/src/gsIO/gsFileData.hpp
+++ b/src/gsIO/gsFileData.hpp
@@ -321,21 +321,13 @@ gsFileData<T> gsFileData<T>::getInclude(index_t id, real_t time, std::string lab
     bool found=false;
     gsXmlNode * root = getXmlRoot();
     const gsXmlAttribute * attribute;
-    for (gsXmlNode * child = root->first_node("xmlfile");
-            child; child = child->next_sibling("xmlfile"))
+
+    gsXmlNode * nd = internal::searchNode(root, attr_name, attr_string, "xmlfile");
+    if (nd)
     {
-        attribute = child->first_attribute(attr_name.c_str());
-
-        if (id!=-1 && attribute && atoi(attribute->value()) == id ) found=true; 
-        else if (time!=-1. && attribute && atof(attribute->value()) == time ) found=true; 
-        else if ( label!="" && attribute && attribute->value() == label) found=true; 
-
-        if (found)
-        {
-            std::string filename = gsFileManager::getPath(m_lastPath) +  child->value();
-            gsFileData res(filename);
-            return res;
-        }
+        std::string filename = gsFileManager::getPath(m_lastPath) +  nd->value();
+        gsFileData res(filename);
+        return res;
     }
     GISMO_ERROR("Include with " << attr_name << "=" << attr_string << " does not exist!");
 }

--- a/src/gsIO/gsFileData.hpp
+++ b/src/gsIO/gsFileData.hpp
@@ -264,36 +264,23 @@ bool gsFileData<T>::readGismoXmlStream(std::istream & is)
     {
         gsWarn<< "gsFileData: Problem with file "<<m_lastPath
               <<": Invalid XML file, no root tag <xml> found.\n";
-        assert( root ) ;
+        assert( ln ) ;
     }
     std::list<std::string> ifn;
     for (gsXmlNode * child = ln->first_node("xmlfile") ;
          child; child = child->next_sibling("xmlfile") )
     {
         ifn.push_back( child->value() );
-        gsInfo<< "#xmlfile "<< child->value() <<"\n";
+        //ln->remove_node(child);
     }
 
     gsXmlNode * root = data->getRoot();
-    root->merge_parent(ln);
-    for (gsXmlNode * child = root->first_node("xmlfile") ;
-         child; child = child->next_sibling("xmlfile") )
-    {
-        gsInfo<< "+xmlfile "<< child->value() <<"\n";
-    }
-
-    std::string cfn;
+    root->merge_sibling(ln);
+    data->remove_node(ln);
+    std::string cfn = gsFileManager::getPath(m_lastPath);
     for (auto & f : ifn)
     {
-        cfn = gsFileManager::getPath(m_lastPath);
-        cfn += f;
-        gsInfo<< "xmlfile "<< cfn <<"\n";
-        readXmlFile(cfn);
-        for (gsXmlNode * child = root->first_node("xmlfile") ;
-             child; child = child->next_sibling("xmlfile") )
-        {
-            gsInfo<< "#xmlfile "<< child->value() <<"\n";
-        }
+        readXmlFile(cfn + f);
     }
 
     // TO DO: Check if it contains unknown tags...

--- a/src/gsIO/gsFileData.hpp
+++ b/src/gsIO/gsFileData.hpp
@@ -293,7 +293,7 @@ bool gsFileData<T>::readGismoXmlStream(std::istream & is, bool recursive)
 }
 
 template<class T>
-gsFileData<T> gsFileData<T>::getInclude(index_t id, real_t time, std::string label)
+void gsFileData<T>::getInclude(gsFileData<T> & res, index_t id, real_t time, std::string label)
 {   
     // Ensures that only one argument is actually provided
     GISMO_ENSURE((id!=-1 ^  time!=-1. ^  label!="") &&
@@ -326,8 +326,9 @@ gsFileData<T> gsFileData<T>::getInclude(index_t id, real_t time, std::string lab
     if (nd)
     {
         std::string filename = gsFileManager::getPath(m_lastPath) +  nd->value();
-        gsFileData res(filename);
-        return res;
+        res.clear();
+        res.read(filename);
+        return;
     }
     GISMO_ERROR("Include with " << attr_name << "=" << attr_string << " does not exist!");
 }

--- a/src/gsIO/gsXml.h
+++ b/src/gsIO/gsXml.h
@@ -223,25 +223,6 @@ public:
     static Object * getLabel(gsXmlNode * node, const std::string & label);
 };
 
-/// Helper to read an object by a given \em label :
-/// \param node parent node, we check his children to get the given \em label
-/// \param label
-template<class Object>
-Object * getByLabel(gsXmlNode * node, const std::string & label)
-{
-    std::string tag = internal::gsXml<Object>::tag();
-    for (gsXmlNode * child = node->first_node(tag.c_str()); //note: gsXmlNode object in use
-         child; child = child->next_sibling(tag.c_str()))
-    {
-        const gsXmlAttribute * label_at = child->first_attribute("label");
-        if (label_at && !strcmp(label_at->value(),label.c_str()) )
-            return internal::gsXml<Object>::get(child);
-    }
-    std::cerr<<"gsXmlUtils Warning: "<< internal::gsXml<Object>::tag()
-             <<" with label="<<label<<" not found.\n";
-    return NULL;
-}
-
 /// Helper to fetch a node with a certain \em attribute value.
 /// \param root parent node, we check if it's children attribute value matches the given \em value
 /// \param attr_name Attribute's name
@@ -258,6 +239,31 @@ inline gsXmlNode * searchNode(gsXmlNode * root,const std::string & attr_name, co
     gsWarn <<"gsXmlUtils: No object with attribute '"<<attr_name<<" = "<< value<<"' found.\n";
     return NULL;
 }
+
+/// Helper to read an object by a given \em label :
+/// \param node parent node, we check his children to get the given \em label
+/// \param label
+template<class Object>
+Object * getByLabel(gsXmlNode * node, const std::string & label)
+{
+    std::string tag = internal::gsXml<Object>::tag();
+    gsXmlNode * nd  = searchNode(node, "label", label);
+    if (nd)
+    {
+        return internal::gsXml<Object>::get(nd);
+    }
+    // for (gsXmlNode * child = node->first_node(tag.c_str()); //note: gsXmlNode object in use
+    //      child; child = child->next_sibling(tag.c_str()))
+    // {
+    //     const gsXmlAttribute * label_at = child->first_attribute("label");
+    //     if (label_at && !strcmp(label_at->value(),label.c_str()) )
+    //         return internal::gsXml<Object>::get(child);
+    // }
+    std::cerr<<"gsXmlUtils Warning: "<< internal::gsXml<Object>::tag()
+             <<" with label="<<label<<" not found.\n";
+    return NULL;
+}
+
 
 
 /// Helper to read an object by a given \em id value:

--- a/src/gsIO/gsXml.h
+++ b/src/gsIO/gsXml.h
@@ -50,7 +50,7 @@ namespace rapidxml
     { return get(anyByTag(tag(), node)); }      \
     static  obj * getId (gsXmlNode * node, int id) \
     { return getById< obj >(node, id); }                            \
-    static  obj * getLabel(gsXmlNode * node, std::string & label) \
+    static  obj * getLabel(gsXmlNode * node, const std::string & label) \
     { return getByLabel< obj >(node, label); }
 
 #define GSXML_GET_POINTER(obj)          \
@@ -220,14 +220,14 @@ public:
     //static void     getAny_into   (gsXmlNode * node);
     static Object * getId    (gsXmlNode * node, int id);
     //static void     getId_into   (gsXmlNode * node, int id, Object & result);
-    static Object * getLabel(gsXmlNode * node, std::string & label);
+    static Object * getLabel(gsXmlNode * node, const std::string & label);
 };
 
 /// Helper to read an object by a given \em id value:
 /// \param node parent node, we check his children to get the given \em id
 /// \param label
 template<class Object>
-Object * getByLabel(gsXmlNode * node, std::string & label)
+Object * getByLabel(gsXmlNode * node, const std::string & label)
 {
     std::string tag = internal::gsXml<Object>::tag();
     for (gsXmlNode * child = node->first_node(tag.c_str()); //note: gsXmlNode object in use

--- a/src/gsIO/gsXml.h
+++ b/src/gsIO/gsXml.h
@@ -243,18 +243,19 @@ Object * getByLabel(gsXmlNode * node, const std::string & label)
 }
 
 /// Helper to fetch a node with a certain \em attribute value.
-/// \param root parent node, we check his children for the given \em id
-/// \param id the ID number which is seeked for
-inline gsXmlNode * searchNode(const std::string & name, const std::string & value, gsXmlNode * root)
+/// \param root parent node, we check if it's children attribute value matches the given \em value
+/// \param attr_name Attribute's name
+/// \param value the attribute's value number which is seeked for
+inline gsXmlNode * searchNode(gsXmlNode * root,const std::string & attr_name, const std::string & value)
 {
     for (gsXmlNode * child = root->first_node();
          child; child = child->next_sibling())
     {
-        const gsXmlAttribute * id_at = child->first_attribute(value.c_str());
-        if ( id_at &&  !strcmp(id_at->value(),value.c_str()) )
+        const gsXmlAttribute * attribute = child->first_attribute(attr_name.c_str());
+        if ( attribute &&  !strcmp(attribute->value(),value.c_str()) )
             return child;
     }
-    gsWarn <<"gsXmlUtils: No object with property '"<<name<<" = "<< value<<"' found.\n";
+    gsWarn <<"gsXmlUtils: No object with attribute '"<<attr_name<<" = "<< value<<"' found.\n";
     return NULL;
 }
 

--- a/src/gsIO/gsXml.h
+++ b/src/gsIO/gsXml.h
@@ -223,8 +223,8 @@ public:
     static Object * getLabel(gsXmlNode * node, const std::string & label);
 };
 
-/// Helper to read an object by a given \em id value:
-/// \param node parent node, we check his children to get the given \em id
+/// Helper to read an object by a given \em label :
+/// \param node parent node, we check his children to get the given \em label
 /// \param label
 template<class Object>
 Object * getByLabel(gsXmlNode * node, const std::string & label)
@@ -233,8 +233,8 @@ Object * getByLabel(gsXmlNode * node, const std::string & label)
     for (gsXmlNode * child = node->first_node(tag.c_str()); //note: gsXmlNode object in use
          child; child = child->next_sibling(tag.c_str()))
     {
-        const gsXmlAttribute * id_at = child->first_attribute("label");
-        if (id_at && !strcmp(id_at->value(),label.c_str()) )
+        const gsXmlAttribute * label_at = child->first_attribute("label");
+        if (label_at && !strcmp(label_at->value(),label.c_str()) )
             return internal::gsXml<Object>::get(child);
     }
     std::cerr<<"gsXmlUtils Warning: "<< internal::gsXml<Object>::tag()


### PR DESCRIPTION
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# The commit description must be structured as a list follows:
With this PR more flexibility is added to the way we use xml files. We can now label any xml tag (object) and also retrieve it by label when reading a file. Furthermore, it is possible now to include other gismo `.xml` files by reference. This is useful when e.g. one might want to use the same geometry for multiple problems, or for time-series data.

## NEW:
- `gsFileData::getLabel`, same concept as `::getId` but querying with a string
- `gsFileData::addInclude(filename, time, id, label)`,  adds a reference(include) to the provided file with the new `<xmlfile>` tag, with the optional time, id, label attributes.
- `gsFileData::getIncludeById/Time/Label()`, looks for an `<xmlfile>` tag which matches the provided argument ( you can only query by one currently), parses the referenced file and returns a new `gsFileData` object.
- `recursive` argument in the `gsFileData` constructor. If set to true, it looks for all referenced files, parses them and returns everything as a single `gsFileData`. By default false.

## IMPROVED: 
- `gsFileData::addWithLabel(object, label)`, same as `::add(object, id)` but writes the label attribute instead.

FIXED: ...
API:...

For each new/improved/fixed/api change use a new line with the
respective word prefix in capital.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [x] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
