### PR TITLE
Replace sprintf by snprintf as the former is marked deprecated

### DIFF
--- a/external/onurbs/opennurbs_nurbsvolume.cpp
+++ b/external/onurbs/opennurbs_nurbsvolume.cpp
@@ -724,7 +724,7 @@ void ON_NurbsCage::Dump( ON_TextLog& dump ) const
         if ( i > 0 || j > 0)
           dump.Print("\n");
         sPreamble[0] = 0;
-        sprintf(sPreamble,"  CV[%2d][%2d]",i,j);
+        snprintf(sPreamble,128,"  CV[%2d][%2d]",i,j);
         dump.PrintPointList( m_dim, m_is_rat, 
                           m_cv_count[2], m_cv_stride[2],
                           CV(i,j,0), 


### PR DESCRIPTION
Replace sprintf by snprintf as the former is marked deprecated