### PR TITLE
Make hard-coded short_t a compile-time parameter

### DIFF
--- a/cmake/gsConfig.cmake
+++ b/cmake/gsConfig.cmake
@@ -45,9 +45,18 @@ if(NOT GISMO_INDEX_TYPE)
    set (GISMO_INDEX_TYPE "int" CACHE STRING
    #math(EXPR BITSZ_VOID_P "8*${CMAKE_SIZEOF_VOID_P}")
    #set (GISMO_INDEX_TYPE "int${BITSZ_VOID_P}_t" CACHE STRING
-   "Index type(int, int32_t, int64_t, long, long long)" FORCE)
+   "Index type(int, int8_t, int16_t, int32_t, int64_t, long, long long)" FORCE)
    set_property(CACHE GISMO_INDEX_TYPE PROPERTY STRINGS
-   "int" "int32_t" "int64_t" "long" "long long" )
+   "int" "int8_t" "int16_t" "int32_t" "int64_t" "long" "long long" )
+endif()
+
+if(NOT GISMO_SHORT_TYPE)
+   set (GISMO_SHORT_TYPE "int" CACHE STRING
+   #math(EXPR BITSZ_VOID_P "8*${CMAKE_SIZEOF_VOID_P}")
+   #set (GISMO_SHORT_TYPE "int${BITSZ_VOID_P}_t" CACHE STRING
+   "Index type(int, int8_t, int16_t, int32_t, int64_t, long, long long)" FORCE)
+   set_property(CACHE GISMO_SHORT_TYPE PROPERTY STRINGS
+   "int" "int8_t" "int16_t" "int32_t" "int64_t" "long" "long long" )
 endif()
 
 # Set a default build type if none was specified

--- a/cmake/gsOptions.cmake
+++ b/cmake/gsOptions.cmake
@@ -25,6 +25,7 @@ message ("  CMAKE_CXX_STANDARD      ${CMAKE_CXX_STANDARD}")
 
 message ("  GISMO_COEFF_TYPE        ${GISMO_COEFF_TYPE}")
 message ("  GISMO_INDEX_TYPE        ${GISMO_INDEX_TYPE}")
+message ("  GISMO_SHORT_TYPE        ${GISMO_SHORT_TYPE}")
 
 ## #################################################################
 ## Options list: Standard options

--- a/src/gsCore/gsConfig.h.in
+++ b/src/gsCore/gsConfig.h.in
@@ -32,7 +32,7 @@
 #define index_t          @GISMO_INDEX_TYPE@
 
 /** Define default dimension type. */
-#define short_t          int //short
+#define short_t          @GISMO_SHORT_TYPE@
 
 /** Define the file data directory. */
 #define GISMO_DATA_DIR "@GISMO_DATA_DIR@"


### PR DESCRIPTION
This PR makes the hard-coded short_t = int a CMake parameter, namely, GISMO_SHORT_TYPE that can be set at compile time.
