### PR TITLE
Hotfix in buckling solver of Spectra

### DIFF
--- a/optional/gsSpectra/examples/spectra_test01.cpp
+++ b/optional/gsSpectra/examples/spectra_test01.cpp
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
     gsInfo << "General Symmetric Shift solver, Cayley (BEsorting):\n";
     gsInfo << "Eigenvalues A*x=lambda*B*x (shift=1):\n" << Csolver.eigenvalues().transpose() <<"\n\n";
 
-    gsSpectraGenSymShiftSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::Buckling> Bsolver(B,A,math::floor(sz/2),sz,1);
+    gsSpectraGenSymShiftSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::Buckling> Bsolver(A,B,N,2*N,1);
     Bsolver.compute(Spectra::SortRule::SmallestAlge,1000,1e-3,Spectra::SortRule::SmallestMagn);
     gsInfo << "General Symmetric Shift solver, Buckling:\n";
     gsInfo << "Eigenvalues B*x=lambda*A*x (!) (shift=1):\n" << Bsolver.eigenvalues().transpose() <<"\n\n";

--- a/optional/gsSpectra/examples/spectra_test01.cpp
+++ b/optional/gsSpectra/examples/spectra_test01.cpp
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
     gsInfo << "General Symmetric Shift solver, Cayley (BEsorting):\n";
     gsInfo << "Eigenvalues A*x=lambda*B*x (shift=1):\n" << Csolver.eigenvalues().transpose() <<"\n\n";
 
-    gsSpectraGenSymShiftSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::Buckling> Bsolver(A,B,N,2*N,1);
+    gsSpectraGenSymShiftSolver<gsSparseMatrix<real_t>,Spectra::GEigsMode::Buckling> Bsolver(A,B,math::floor(sz/2),sz,1e-3);
     Bsolver.compute(Spectra::SortRule::SmallestAlge,1000,1e-3,Spectra::SortRule::SmallestMagn);
     gsInfo << "General Symmetric Shift solver, Buckling:\n";
     gsInfo << "Eigenvalues B*x=lambda*A*x (!) (shift=1):\n" << Bsolver.eigenvalues().transpose() <<"\n\n";

--- a/optional/gsSpectra/gsSpectra.h
+++ b/optional/gsSpectra/gsSpectra.h
@@ -388,6 +388,7 @@ protected:
 };
 
 /// For GEigsMode::RegularInverse
+/// NOTE: A must be symmetric and B positive semi-definite
 template <class MatrixType>
 class SpectraOps<MatrixType,Spectra::GEigsMode::RegularInverse>
 {
@@ -400,6 +401,7 @@ public:
 };
 
 /// For GEigsMode::ShiftInvert and GEigsMode::Cayley
+/// NOTE: A must be symmetric and B positive semi-definite
 template <class MatrixType, Spectra::GEigsMode GEigsMode = Spectra::GEigsMode::ShiftInvert>
 class SpectraShiftOps
 {
@@ -414,6 +416,7 @@ public:
 };
 
 /// Specialization for GEigsMode::Buckling
+/// NOTE: A must be positive semi-definite and B symmetric
 template <class MatrixType>
 class SpectraShiftOps<MatrixType,Spectra::GEigsMode::Buckling>
 {
@@ -422,7 +425,7 @@ public:
     typedef SpectraSymShiftInvert<MatrixType> InvOp;
     typedef SpectraSymMatProd<MatrixType>     ProdOp;
 
-    SpectraShiftOps(const MatrixType & A, const MatrixType & B) : opA(B,A), opB(B) { }
+    SpectraShiftOps(const MatrixType & A, const MatrixType & B) : opA(A,B), opB(A) { }
     InvOp  opA;
     ProdOp opB;
 };


### PR DESCRIPTION
Improving the buckling solver in Spectra. The matrices were swapped in [gsSpectra.h, l. 428](https://github.com/gismo/gismo/blob/4f4ba0de57a53af028060730e2aee779f162d013/optional/gsSpectra/gsSpectra.h#L428). 

NEW:

IMPROVED: 

FIXED:
Buckling solver is correctly implemented for Ax=vBx, with B symmetric and A non-negative. 

API:
