### PR TITLE
Fix linking of MPFR with gcc

### DIFF
--- a/external/gsMpfr.cmake
+++ b/external/gsMpfr.cmake
@@ -57,7 +57,7 @@ set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${MPFR_INCLUDE_DIR}
   CACHE INTERNAL "gismo include directories" FORCE)
 
 # Link G+Smo to GMP, GMPXX and MPFR libraries (either dynamically or statically)
-set(gismo_LINKER ${gismo_LINKER} ${MPFR_LIBRARY}
+set(gismo_LINKER ${MPFR_LIBRARY} ${gismo_LINKER}
     CACHE INTERNAL "Gismo extra linker objects")
 
 set(GISMO_EXTERNALS ${GISMO_EXTERNALS} "gsMpfr"


### PR DESCRIPTION
Hi,

I had an issue linking mpfr into gismo using these commands and gcc 13.2.1 20231130 [revision 741743c028dc00f27b9c8b1d5211c1f602f2fddd].
```sh
git clone https://github.com/gismo/gismo.git
cd gismo/
mkdir build
cd build
cmake -DGISMO_COEFF_TYPE=mpfr::mpreal ..
make -j 6 gismo
```

The order in which object files and libraries are specified on the linker command line matters.
Files using a dependency should be specified first, then the libraries they depend on.
See the [gcc documentation](https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html#index-l) and [this StackOverflow question](https://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc).

This MR changes the order of linker arguments such that mpfr is specified before gmp, fixing the build issue with gcc.
