### PR TITLE
Detection of CPUID for ARM

### DIFF
--- a/cmake/ofa/AutodetectArm.cmake
+++ b/cmake/ofa/AutodetectArm.cmake
@@ -46,11 +46,27 @@ macro(OFA_AutodetectArm)
       message(WARNING "Auto-detection of optimization flags failed and will use the generic CPU settings.")
     endif()
 
-    # TODO: Windows, FreeBSD, ...
-    
   else()
+
+    # Try to retrieve CPUID directly
+    try_run(_exit _ok
+      ${CMAKE_CURRENT_BINARY_DIR}
+      ${CMAKE_SOURCE_DIR}/cmake/ofa/cpuinfo_arm.c
+      RUN_OUTPUT_VARIABLE _cpuinfo)
+
+    message(${_cpuinfo})
     
-    message(FATAL_ERROR "OptimizeForArchitecture.cmake does not implement support for CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+    if(_ok AND ${_exit} EQUAL 0)    
+      string(REGEX REPLACE ".*implementer[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1" _cpu_implementer "${_cpuinfo}")
+      string(REGEX REPLACE ".*architecture[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1" _cpu_architecture "${_cpuinfo}")
+      string(REGEX REPLACE ".*variant[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1" _cpu_variant "${_cpuinfo}")
+      string(REGEX REPLACE ".*part[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1" _cpu_part "${_cpuinfo}")
+      string(REGEX REPLACE ".*revision[ \t]*:[ \t]+([^\n]+).*" "\\1" _cpu_revision "${_cpuinfo}")
+
+    else()
+      
+      message(FATAL_ERROR "OptimizeForArchitecture.cmake does not implement support for CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+    endif()
   endif()
 
   # Determine CPU from CPUID

--- a/cmake/ofa/AutodetectArm.cmake
+++ b/cmake/ofa/AutodetectArm.cmake
@@ -54,8 +54,6 @@ macro(OFA_AutodetectArm)
       ${CMAKE_SOURCE_DIR}/cmake/ofa/cpuinfo_arm.c
       RUN_OUTPUT_VARIABLE _cpuinfo)
 
-    message(${_cpuinfo})
-    
     if(_ok AND ${_exit} EQUAL 0)    
       string(REGEX REPLACE ".*implementer[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1" _cpu_implementer "${_cpuinfo}")
       string(REGEX REPLACE ".*architecture[ \t]*:[ \t]+([a-zA-Z0-9_-]+).*" "\\1" _cpu_architecture "${_cpuinfo}")

--- a/cmake/ofa/cpuinfo_arm.c
+++ b/cmake/ofa/cpuinfo_arm.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdlib.h>
+
+sigjmp_buf go_here;
+
+void sigill_handler(int signum) {
+  (void)signum;
+  siglongjmp(go_here, 1);
+}
+
+int main(void) {
+  struct sigaction sa;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sa.sa_handler = sigill_handler;
+  if (sigaction(SIGILL, &sa, NULL) < 0) {
+    perror("sigaction");
+    exit(2);
+  }
+
+  do {
+    if (sigsetjmp(go_here, 1)) {
+      exit(-1);
+    } else {
+      unsigned long ret;
+      asm("mrs %0, MIDR_EL1" : "=r" (ret));
+      
+      printf("%s 0x%02lX\n", "CPU implementer :", (ret >> 24) & 0xFF);
+      printf("%s 0x%01lX\n", "CPU architecture:", (ret >> 16) & 0xF);
+      printf("%s 0x%01lX\n", "CPU variant     :", (ret >> 20) & 0xF);
+      printf("%s 0x%03lX\n", "CPU part        :", (ret >>  4) & 0xFFF);
+      printf("%s %ld\n",    "CPU revision    :",  ret        & 0xF);
+    }
+  } while (0);
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds `cpuinfo_arm.c` which extracts the CPUID from the MIDR register. This script is only used when the OS is not Linux or Darwin (macOS) and no other mechanism to detect the CPUID is available. Note it is not yet clear if this script works under Windows ARM.