### PR TITLE
Fix `as_parameterization_example.py` for BRep input

### DIFF
--- a/python_examples/as_parameterization_example.py
+++ b/python_examples/as_parameterization_example.py
@@ -54,7 +54,8 @@ geodim = mp.targetDim()
 if (isBRep | pardim != geodim):
     springInitializer = gs.modelling.gsSpringPatch(mp)
     mp.clear()
-    mp = springInitializer.result()
+    springInitializer.compute()
+    mp.addPatch(springInitializer.result())
 #! [construct a initial parameterization if the input data is B-Rep]
 
 #! [align the orientations of a multi-patch parameterization]

--- a/src/gsModeling/gsSpringPatch_.cpp
+++ b/src/gsModeling/gsSpringPatch_.cpp
@@ -31,8 +31,8 @@ void pybind11_init_gsSpringPatch(py::module &m)
     .def(py::init<const gsMultiPatch<real_t> &>()) //default arguments
 
     // Member functions
-    .def("compute", &Class::compute, "Computes the spring patch.")
-    .def("result", &Class::result, "Get the resulting spring patch.")
+    .def("compute", &Class::compute, "Computes the spring patch.", py::return_value_policy::reference_internal)
+    .def("result", &Class::result, "Get the resulting spring patch.", py::return_value_policy::reference_internal)
     ;
 }
 #endif


### PR DESCRIPTION
This PR includes 2 fixes.

**FIXED:** update return value policy for `gsSpringPatch`
```python
RuntimeError: return_value_policy = copy, but type is non-copyable! (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)
```
as both `compute()` and `result()` returns a member variable, I've set them to reference_internal. More options [here](https://pybind11.readthedocs.io/en/stable/advanced/functions.html#return-value-policies).


**FIXED:** `springInitializer` in as_parameterization_example.py
Infamous *segmentaion fault*. Fixed by calling `compute()` first. Also, as it returns a single patch, it is added to `mp`. 



## Checklist
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----

Regarding the third point in checklist: here's a 2D-BRep multipatch I've used to test.
```xml
<xml>
  <MultiPatch id="0" parDim="1">
    <patches type="id_range">100 103</patches>
    <interfaces>100 1 102 1 0 0
100 2 103 1 0 1
101 1 102 2 0 1
101 2 103 2 0 0</interfaces>
  </MultiPatch>
  <Geometry id="100" type="BSpline">
    <Basis type="BSplineBasis">
      <KnotVector degree="2" format="ASCII">0.0 0.0 0.0 0.5 1.0 1.0 1.0</KnotVector>
    </Basis>
    <coefs format="ASCII" geoDim="2">73.0 108.0
87.5 108.0
113.0 96.75
124.0 85.5</coefs>
  </Geometry>
  <Geometry id="101" type="BSpline">
    <Basis  type="BSplineBasis">
      <KnotVector degree="2" format="ASCII">0.0 0.0 0.0 0.5 1.0 1.0 1.0</KnotVector>
    </Basis>
    <coefs format="ASCII" geoDim="2">479.0 676.0
391.0 676.0
215.0 676.0
127.0 676.0</coefs>
  </Geometry>
  <Geometry id="102" type="BSpline">
    <Basis  type="BSplineBasis">
      <KnotVector degree="2" format="ASCII">0.0 0.0 0.0 0.5 1.0 1.0 1.5 2.0 2.0 2.5 3.0 3.0 3.5 4.0 4.0 4.5 5.0 5.0 5.5 6.0 6.0 6.5 7.0 7.0 7.5 8.0 8.0 8.5 9.0 9.0 9.5 10.0 10.0 10.5 11.0 11.0 11.5 12.0 12.0 12.0</KnotVector>
    </Basis>
    <coefs format="ASCII" geoDim="2">73.0 108.0
59.0 108.0
34.5 97.25
24.0 86.5
13.5 75.75
3.0 50.5
3.0 36.0
3.0 21.0
9.1875 -6.0
15.375 -18.0
21.5625 -30.0
40.125 -51.0
52.5 -60.0
64.875 -69.0
92.6875 -82.5
108.125 -87.0
123.5625 -91.5
157.5 -96.0
176.0 -96.0
228.5 -96.0
308.25 -68.0
335.5 -40.0
362.75 -12.0
390.0 69.5
390.0 123.0
390.0 232.0
390.0 450.0
390.0 559.0
390.0 586.0
398.25 621.5
406.5 630.0
414.75 638.5
451.0 649.0
479.0 651.0
479.0 657.25
479.0 669.75
479.0 676.0</coefs>
  </Geometry>
  <Geometry id="103" type="BSpline">
    <Basis  type="BSplineBasis">
      <KnotVector degree="2" format="ASCII">0.0 0.0 0.0 0.5 1.0 1.0 1.5 2.0 2.0 2.5 3.0 3.0 3.5 4.0 4.0 4.5 5.0 5.0 5.5 6.0 6.0 6.5 7.0 7.0 7.5 8.0 8.0 8.5 9.0 9.0 9.5 10.0 10.0 10.5 11.0 11.0 11.5 12.0 12.0 12.0</KnotVector>
    </Basis>
    <coefs format="ASCII" geoDim="2">124.0 85.5
135.0 74.25
146.0 48.0
146.0 33.0
146.0 23.5
139.25 5.25
132.5 -3.5
125.75 -12.25
119.0 -26.0
119.0 -31.0
119.0 -38.0
125.25 -49.5
131.5 -54.0
137.75 -58.5
154.0 -63.0
164.0 -63.0
181.0 -63.0
205.5 -52.75
213.0 -42.5
220.5 -32.25
228.0 1.0
228.0 24.0
228.0 47.63
228.0 94.89
228.0 118.52
228.0 233.89
228.0 464.63
228.0 580.0
228.0 600.0
218.0 627.25
208.0 634.5
198.0 641.75
157.5 650.0
127.0 651.0
127.0 657.25
127.0 669.75
127.0 676.0</coefs>
  </Geometry>
</xml>
```
