### PR TITLE
Fix compile error in header-only mode and real_t differ from `double`

### DIFF
--- a/src/gsCore/gsFunction.h
+++ b/src/gsCore/gsFunction.h
@@ -240,12 +240,12 @@ public:
                       bool withSupport = true, 
                       const T accuracy = 1e-6,
                       int max_loop = 100,
-                      double damping_factor = 1) const;
+                      T damping_factor = 1) const;
 
     gsMatrix<T> argMin(const T accuracy = 1e-6,//index_t coord = 0
                        int max_loop = 100,
                        gsMatrix<T> init = gsMatrix<T>(),
-                       double damping_factor = 1) const;
+                       T damping_factor = 1) const;
 
     /// Recovers a point on the (geometry) together with its parameters
     /// \a uv, assuming that the \a k-th coordinate of the point \a
@@ -301,7 +301,7 @@ private:
         const gsVector<T> & value,
         gsVector<T> & arg, bool withSupport = true,
         const T accuracy = 1e-6, int max_loop = 100,
-        double damping_factor = 1, T scale = 1.0) const;
+        T damping_factor = 1, T scale = 1.0) const;
 
     gsVector<T> _argMinOnGrid(index_t numpts = 20) const;
 

--- a/src/gsCore/gsFunction.hpp
+++ b/src/gsCore/gsFunction.hpp
@@ -280,7 +280,7 @@ int gsFunction<T>::newtonRaphson_impl(
     bool withSupport,
     const T accuracy,
     int max_loop,
-    double damping_factor, T scale) const
+    T damping_factor, T scale) const
 {
     const index_t n = value.rows();
     const bool squareJac = (n == domainDim());//assumed for _Dim!=-1
@@ -302,7 +302,7 @@ int gsFunction<T>::newtonRaphson_impl(
     int iter = 1;
     T rnorm[2]; rnorm[0]=1e100;
     //T alpha=.5, beta=.5;
-    gsFuncData<> fd(0==mode?(NEED_VALUE|NEED_DERIV):(NEED_DERIV|NEED_HESSIAN));
+    gsFuncData<T> fd(0==mode?(NEED_VALUE|NEED_DERIV):(NEED_DERIV|NEED_HESSIAN));
 
     do {
         this->compute(arg,fd);
@@ -340,7 +340,7 @@ int gsFunction<T>::newtonRaphson_impl(
                         gsMatrix<T>::Identity(n,n)) * residual;
 
         const T rr = ( 1==iter ? (T)1.51 : rnorm[(iter-1)%2]/rnorm[iter%2] ); //important to start with small step
-        damping_factor = rr<1.5 ? math::max(0.1 + (rr/99),(rr-0.5)*damping_factor) : math::min((T)1,rr*damping_factor);
+        damping_factor = rr<1.5 ? math::max((T)0.1 + (rr/99),(rr-(T)0.5)*damping_factor) : math::min((T)1,rr*damping_factor);
 
         //Line search
         /*
@@ -438,7 +438,7 @@ int gsFunction<T>::newtonRaphson(const gsVector<T> & value,
                                  bool withSupport,
                                  const T accuracy,
                                  int max_loop,
-                                 double damping_factor) const
+                                 T damping_factor) const
 {
     GISMO_ASSERT( value.rows() == targetDim(),
                   "Invalid input values:"<< value.rows()<<"!="<<targetDim());
@@ -450,7 +450,7 @@ template <class T>
 gsMatrix<T> gsFunction<T>::argMin(const T accuracy,
                                   int max_loop,
                                   gsMatrix<T> init,
-                                  double damping_factor) const
+                                  T damping_factor) const
 {
     GISMO_ASSERT(1==targetDim(), "Currently argMin works for scalar functions");
     gsVector<T> result;

--- a/src/gsModeling/gsBarrierCore.h
+++ b/src/gsModeling/gsBarrierCore.h
@@ -865,3 +865,7 @@ class AndersonAcceleration {
 }
 
 }// namespace gismo
+
+#ifndef GISMO_BUILD_LIB
+#include GISMO_HPP_HEADER(gsBarrierCore.hpp)
+#endif (edited) 


### PR DESCRIPTION
This PR fixes a missing hpp-file include when compiled in header-only mode and a problem when compiled with `real_t` different from `double`.