### PR TITLE
Fix bug in doxygen documentation

### DIFF
--- a/doc/Examples.dox
+++ b/doc/Examples.dox
@@ -56,9 +56,9 @@ In the gismo/examples sub-directory we find:
 
 - \subpage pMultiGrid_example
 
-@cond DOXYGEN_EXCLUDE
+<!--
 - \subpage poisson_example
-@endcond
+-->
 
 - \subpage poisson2_example
 


### PR DESCRIPTION
FIXED: All examples are displayed in the documentation

Currently, in the list of examples in the doxygen documentation, all examples after "pMultiGrid_example.cpp" are missing, see [here](https://gismo.github.io/Examples.html).
It seems that this is due to the way how the old "poisson_example" is commented out in Examples.dox. I changed it to a html comment (as described [here](https://www.doxygen.nl/manual/htmlcmds.html)) and now the whole list of examples is generated again.