### PR TITLE
Hotfixes to remove warnings in GCC and Clang

### DIFF
--- a/external/gsEigen/src/Core/AssignEvaluator.h
+++ b/external/gsEigen/src/Core/AssignEvaluator.h
@@ -327,7 +327,10 @@ struct dense_assignment_loop<Kernel, AllAtOnceTraversal, Unrolling>
 {
   EIGEN_DEVICE_FUNC static void EIGEN_STRONG_INLINE run(Kernel& /*kernel*/)
   {
+    //G+Smo
+#ifndef EIGEN_NO_DEBUG
     typedef typename Kernel::DstEvaluatorType::XprType DstXprType;
+#endif
     EIGEN_STATIC_ASSERT(int(DstXprType::SizeAtCompileTime) == 0,
       EIGEN_INTERNAL_ERROR_PLEASE_FILE_A_BUG_REPORT)
   }

--- a/optional/gsSpectra/CMakeLists.txt
+++ b/optional/gsSpectra/CMakeLists.txt
@@ -32,27 +32,7 @@ set (GISMO_INCLUDE_DIRS ${GISMO_INCLUDE_DIRS} ${SPECTRA_INCLUDE_DIR}
 add_library(${PROJECT_NAME} INTERFACE)
 target_sources(${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_HEADERS}>)
 
-#target_include_directories(${PROJECT_NAME} INTERFACE
-#  $<BUILD_INTERFACE:${gismo_SOURCE_DIR}/external/Spectra
-#  #$<INSTALL_INTERFACE:gismo/gsSpectra>
-#)
-
 add_dependencies(${PROJECT_NAME} Spectra)
-
-#set_target_properties(${PROJECT_NAME} PROPERTIES
-#    COMPILE_DEFINITIONS gismo_EXPORTS
-#    POSITION_INDEPENDENT_CODE ON
-#    LINKER_LANGUAGE CXX
-#    CXX_VISIBILITY_PRESET hidden
-#    VISIBILITY_INLINES_HIDDEN ON
-#    FOLDER "G+Smo extensions"
-#    )
-
-#set(gismo_EXTENSIONS ${gismo_EXTENSIONS} $<TARGET_OBJECTS:${PROJECT_NAME}>
-#    CACHE INTERNAL "${PROJECT_NAME} extensions to be included")
-
-#set(gismo_LINKER ${gismo_LINKER} ${PROJECT_NAME}
-#    CACHE INTERNAL "${PROJECT_NAME} extra linker objects")
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}
         DESTINATION include/gismo

--- a/optional/gsXBraid/examples/gsXBraidMultigrid.h
+++ b/optional/gsXBraid/examples/gsXBraidMultigrid.h
@@ -934,12 +934,12 @@ namespace gismo {
       space u_n = ex.getTestSpace(v_n , basesL);
       u_n.setInterfaceCont(0);
       if (Base::typeBCHandling == 1)
-        {
-	  v_n.setup(*m_bcInfo_ptr, dirichlet::l2Projection, 0);
-	  u_n.setup(*m_bcInfo_ptr, dirichlet::l2Projection, 0);
-          //#v_n.addBc(m_bcInfo_ptr->get("Dirichlet"));
-          //#u_n.addBc(m_bcInfo_ptr->get("Dirichlet"));
-        }
+      {
+        v_n.setup(*m_bcInfo_ptr, dirichlet::l2Projection, 0);
+        u_n.setup(*m_bcInfo_ptr, dirichlet::l2Projection, 0);
+        //#v_n.addBc(m_bcInfo_ptr->get("Dirichlet"));
+        //#u_n.addBc(m_bcInfo_ptr->get("Dirichlet"));
+      }
       ex.setIntegrationElements(basesH);
       ex.initSystem();
       ex.assemble(u_n*meas(G) * v_n.tr()); 

--- a/optional/gsXBraid/gsXBraid.h
+++ b/optional/gsXBraid/gsXBraid.h
@@ -19,7 +19,7 @@
 #define braid_SEQUENTIAL 1
 #endif
 
-#include <braid.hpp>
+#include <XBraid/braid/braid.hpp>
 
 namespace gismo {
 

--- a/optional/gsXBraid/gsXBraid.h
+++ b/optional/gsXBraid/gsXBraid.h
@@ -15,7 +15,7 @@
 
 #include <gismo.h>
 
-#if !defined(GISMO_WITH_MPI)
+#ifndef GISMO_WITH_MPI
 #define braid_SEQUENTIAL 1
 #endif
 

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -445,7 +445,9 @@ private:
         {
             auto u = ee.rowVar();
             auto v = ee.colVar();
+#ifndef NDEBUG
             const bool m = E::isMatrix();
+#endif
             GISMO_ASSERT(v.isValid(), "The row space is not valid");
             GISMO_ASSERT(!m || u.isValid(), "The column space is not valid");
             GISMO_ASSERT(m || (ea.numDofs()==ee.rhs().size()), "The right-hand side vector is not initialized");

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -650,8 +650,6 @@ public:
     /// Copy the coefficients of another gsGeometryMap to this one, if they are compatible.
     void copyCoefs( const gsGeometryMap<T> & other) const
     {
-        const index_t dim = m_fs->domainDim();
-
         GISMO_ASSERT( dynamic_cast<const gsMultiPatch<T>*>( this->m_fs ), "error");
         const gsMultiPatch<T> & thisMP  = static_cast<const gsMultiPatch<T>&>(*this->m_fs );
         GISMO_ASSERT( dynamic_cast<const gsMultiPatch<T>*>( other.m_fs ), "error");
@@ -1588,7 +1586,6 @@ public:
     // insert g-coefficients to the solution vector
     void insert(const gsGeometry<T> & g, const index_t p = 0) const
     {
-        const index_t dim = _u.dim();
         const gsMatrix<T> & cf = g.coefs();
         gsMatrix<T> & sol = *_Sv;
         //gsMatrix<T> & fixedPart = _u.fixedPart();

--- a/src/gsAssembler/gsGenericAssembler.h
+++ b/src/gsAssembler/gsGenericAssembler.h
@@ -108,9 +108,7 @@ public:
     const gsSparseMatrix<T> & assembleMass2()
     {
         typedef typename gsExprAssembler<T>::geometryMap geometryMap;
-        typedef typename gsExprAssembler<T>::variable    variable;
         typedef typename gsExprAssembler<T>::space       space;
-        typedef typename gsExprAssembler<T>::solution    solution;
 
         // Elements used for numerical integration
         gsExprAssembler<T> A(1,1);

--- a/src/gsCore/gsFunctionSet.h
+++ b/src/gsCore/gsFunctionSet.h
@@ -262,7 +262,7 @@ public:
      of definition is the whole of \f$R^{domainDim}\f$
     */
     virtual gsMatrix<T> support() const;
-    virtual gsMatrix<T> support(index_t i) const;
+    virtual gsMatrix<T> support(const index_t & i) const;
 
     /**
       @brief Indices of active (non-zero) function(s) for each point.

--- a/src/gsCore/gsFunctionSet.h
+++ b/src/gsCore/gsFunctionSet.h
@@ -130,6 +130,13 @@
         __DEC0(type, clone, void) { return new type(*this); } \
         __DEF0(type, clone, void)
 
+// Declaration, definition and implementation of clone function which overrides
+// 1st: return type
+#define GISMO_OVERRIDE_CLONE_FUNCTION(type) \
+        __DEC0(type, clone, void) override { return new type(*this); } \
+        __DEF0(type, clone, void)
+
+
 namespace gismo {
 
 /**

--- a/src/gsCore/gsFunctionSet.hpp
+++ b/src/gsCore/gsFunctionSet.hpp
@@ -51,7 +51,7 @@ gsMatrix<T> gsFunctionSet<T>::support() const
 }
 
 template <class T>
-gsMatrix<T> gsFunctionSet<T>::support(index_t i) const
+gsMatrix<T> gsFunctionSet<T>::support(const index_t & i) const
 {
     GISMO_NO_IMPLEMENTATION
 }

--- a/src/gsCore/gsRationalBasis.h
+++ b/src/gsCore/gsRationalBasis.h
@@ -142,6 +142,9 @@ public:
     size_t numElements(boxSide const & s) const { return m_src->numElements(s); }
     //using Base::numElements; //unhide
 
+    /// See \ref gsBasis for a description
+    size_t elementIndex(const gsVector<T> & u ) const { return m_src->elementIndex(u); }
+
     void active_into(const gsMatrix<T> & u, gsMatrix<index_t>& result) const
     { m_src->active_into(u, result); }
     

--- a/src/gsHSplines/gsHDomain.h
+++ b/src/gsHSplines/gsHDomain.h
@@ -26,8 +26,8 @@ class gsHDomainIterator;
 template<class T>
 class gsSegment;
 
-template <short_t d, class Z>
-class gsKdNode;
+// template <short_t d, class Z>
+// class gsKdNode;
 
 template <class T>
 class gsVSegment;

--- a/src/gsIO/gsFileManager.cpp
+++ b/src/gsIO/gsFileManager.cpp
@@ -190,6 +190,7 @@ bool gsFileManager::isExplicitlyRelative(const std::string& fn)
 
 namespace {
 
+#if defined _WIN32
 inline void _replace_with_native_separator(std::string & str)
 {
     for (size_t i = 1; i < gsFileManager::getValidPathSeparators().length(); ++i)
@@ -199,6 +200,7 @@ inline void _replace_with_native_separator(std::string & str)
             gsFileManager::getNativePathSeparator());
     }
 }
+#endif
 
 inline bool _addSearchPaths(const std::string& in, std::vector<std::string>& out)
 {

--- a/src/gsMSplines/gsMappedBasis.h
+++ b/src/gsMSplines/gsMappedBasis.h
@@ -227,6 +227,20 @@ public:
      */
     gsMultiPatch<T> exportToPatches(gsMatrix<T> const & localCoef) const;
 
+private:
+    // Avoid warnings for hidden overloads w.r.t gsFunctionSet
+    void active_into(const gsMatrix<T> & u,gsMatrix<index_t>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void eval_into(const gsMatrix<T> & u,gsMatrix<T>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void deriv_into(const gsMatrix<T> & u,gsMatrix<T>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void deriv2_into(const gsMatrix<T> & u,gsMatrix<T>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void evalAllDers_into(const gsMatrix<T> & u, const index_t n,
+                          std::vector<gsMatrix<T> >& result ) const
+    { GISMO_NO_IMPLEMENTATION; }
+
 public:
     //////////////////////////////////////////////////
     // functions for evaluating and derivatives

--- a/src/gsMSplines/gsMappedSingleBasis.h
+++ b/src/gsMSplines/gsMappedSingleBasis.h
@@ -104,7 +104,7 @@ public:
     }
 
     /// Returns the number of active (nonzero) basis functions at points \a u in \a result.
-    void numActive_into(const gsMatrix<T> & u, gsVector<unsigned>& result) const
+    void numActive_into(const gsMatrix<T> & u, gsVector<index_t>& result) const
     {
         // Assuming all patches have the same degree
         m_basis->numActive_into(m_index,u,result);

--- a/src/gsMSplines/gsMappedSpline.h
+++ b/src/gsMSplines/gsMappedSpline.h
@@ -167,10 +167,24 @@ public:
     gsMultiPatch<T> exportToPatches() const;
 
     // support (domain of definition)
-    gsMatrix<T> support(index_t k) const
+    gsMatrix<T> support(const index_t & k) const
     { return m_mbases->getBase(k).support(); }
 
     gsGeometry<T> * exportPatch(int i,gsMatrix<T> const & localCoef) const;
+
+private:
+    // Avoid warnings for hidden overloads w.r.t gsFunctionSet
+    void active_into(const gsMatrix<T> & u,gsMatrix<index_t>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void eval_into(const gsMatrix<T> & u,gsMatrix<T>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void deriv_into(const gsMatrix<T> & u,gsMatrix<T>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void deriv2_into(const gsMatrix<T> & u,gsMatrix<T>& result) const
+    { GISMO_NO_IMPLEMENTATION; }
+    void evalAllDers_into(const gsMatrix<T> & u, const index_t n,
+                          std::vector<gsMatrix<T> >& result ) const
+    { GISMO_NO_IMPLEMENTATION; }
 
 public:
     //////////////////////////////////////////////////

--- a/src/gsMesh2/IO_poly.cpp
+++ b/src/gsMesh2/IO_poly.cpp
@@ -63,10 +63,15 @@ bool read_poly(gsSurfMesh& mesh, const std::string& filename)
     gsSurfMesh::Vertex_property<Point>                                  point = mesh.vertex_property<Point>("v:point",Point(0,0,0));
 
     // read properties from file
-    (void)fread((char*)vconn.data(), sizeof(gsSurfMesh::Vertex_connectivity),   nv, in);
-    (void)fread((char*)hconn.data(), sizeof(gsSurfMesh::Halfedge_connectivity), nh, in);
-    (void)fread((char*)fconn.data(), sizeof(gsSurfMesh::Face_connectivity),     nf, in);
-    (void)fread((char*)point.data(), sizeof(Point),                               nv, in);
+    size_t result;
+    result = fread((char*)vconn.data(), sizeof(gsSurfMesh::Vertex_connectivity),   nv, in);
+    GISMO_ENSURE(result==sizeof(gsSurfMesh::Vertex_connectivity),"Vertex connectivity reading error");
+    result = fread((char*)hconn.data(), sizeof(gsSurfMesh::Halfedge_connectivity), nh, in);
+    GISMO_ENSURE(result==sizeof(gsSurfMesh::Halfedge_connectivity),"Vertex connectivity reading error");
+    result = fread((char*)fconn.data(), sizeof(gsSurfMesh::Face_connectivity),     nf, in);
+    GISMO_ENSURE(result==sizeof(gsSurfMesh::Face_connectivity),"Vertex connectivity reading error");
+    result = fread((char*)point.data(), sizeof(Point),                               nv, in);
+    GISMO_ENSURE(result==sizeof(Point),"Vertex connectivity reading error");
 
     fclose(in);
     return true;

--- a/src/gsModeling/gsBarrierCore.hpp
+++ b/src/gsModeling/gsBarrierCore.hpp
@@ -1117,8 +1117,8 @@ gsBarrierCore<d, T>::computePDEPatch(const gsMultiPatch<T> &mp,
   int preconditionerType = options.askInt("AAPreconditionType", 0);
   switch (preconditionerType) {
     case 1:
-      Jacobian = [&Residual, &assembler, &mapper, &mpSubstitute, &space1](
-          gsVector<T> const &x) {
+      Jacobian = [&assembler, &mapper, &mpSubstitute, &space1](gsVector<T> const &x)
+      {
         // diagonal Jacobian matrix as a preconditioner
         convertFreeVectorToMultiPatch<T>(x, mapper, mpSubstitute);
         geometryMap G = assembler.getMap(mpSubstitute);
@@ -1132,8 +1132,8 @@ gsBarrierCore<d, T>::computePDEPatch(const gsMultiPatch<T> &mp,
       break;
 
     case 2:
-      Jacobian = [&Residual, &assembler, &mapper, &mpSubstitute, &space1](
-          gsVector<T> const &x) {
+      Jacobian = [&assembler, &mapper, &mpSubstitute, &space1](gsVector<T> const &x)
+      {
         // diagonal-block Jacobian matrix as a preconditioner
         convertFreeVectorToMultiPatch<T>(x, mapper, mpSubstitute);
         geometryMap G = assembler.getMap(mpSubstitute);
@@ -1148,8 +1148,8 @@ gsBarrierCore<d, T>::computePDEPatch(const gsMultiPatch<T> &mp,
 
     default:
       // analytical Jacobian matrix as a preconditioner
-      Jacobian = [&assembler, &mapper, &mpSubstitute, &space1](
-          gsVector<T> const &x) {
+      Jacobian = [&assembler, &mapper, &mpSubstitute, &space1](gsVector<T> const &x)
+      {
         convertFreeVectorToMultiPatch<T>(x, mapper, mpSubstitute);
         geometryMap G = assembler.getMap(mpSubstitute);
 
@@ -1168,14 +1168,13 @@ gsBarrierCore<d, T>::computePDEPatch(const gsMultiPatch<T> &mp,
   param.epsilon = 1e-5;
 
   preAApp::AndersonAcceleration<T> AASolver(param);
-  gsVector<T> solVector = AASolver.compute(initialGuessVector,
-                                           Residual, Jacobian);
+  gsVector<T> solVector = AASolver.compute(initialGuessVector,Residual, Jacobian);
 
-  if (options.askSwitch("needPDEH1", true)) {
-    verboseLog("\nStart parameterization improvement by H1 discrezation...",
-               options.askInt("Verbose", 0));
-    Residual = [&assembler, &mapper, &mpSubstitute, &space1](
-        gsVector<T> const &x) {
+  if (options.askSwitch("needPDEH1", true))
+  {
+    verboseLog("\nStart parameterization improvement by H1 discrezation...",options.askInt("Verbose", 0));
+    Residual = [&assembler, &mapper, &mpSubstitute, &space1](gsVector<T> const &x)
+    {
       // H1 discretization
       convertFreeVectorToMultiPatch<T>(x, mapper, mpSubstitute);
       geometryMap G = assembler.getMap(mpSubstitute);
@@ -1192,8 +1191,8 @@ gsBarrierCore<d, T>::computePDEPatch(const gsMultiPatch<T> &mp,
     preconditionerType = options.askInt("AAPreconditionType", 0);
     switch (preconditionerType) {
       case 1:
-        Jacobian = [&assembler, &mapper, &mpSubstitute, &mb, &space1](
-            gsVector<T> const &x) {
+        Jacobian = [&assembler, &mapper, &mpSubstitute, &space1](gsVector<T> const &x)
+        {
           // diagonal block Jacobian matrix as a preconditioner
           convertFreeVectorToMultiPatch<T>(x, mapper, mpSubstitute);
           geometryMap G = assembler.getMap(mpSubstitute);
@@ -1208,8 +1207,8 @@ gsBarrierCore<d, T>::computePDEPatch(const gsMultiPatch<T> &mp,
         break;
 
       default:
-        Jacobian = [&assembler, &mapper, &mpSubstitute,
-            &space1](gsVector<T> const &x) {
+        Jacobian = [&assembler, &mapper, &mpSubstitute,&space1](gsVector<T> const &x)
+        {
           // analytical Jacobian matrix as a preconditioner
           convertFreeVectorToMultiPatch<T>(x, mapper, mpSubstitute);
           geometryMap G = assembler.getMap(mpSubstitute);

--- a/src/gsNurbs/gsBSpline.h
+++ b/src/gsNurbs/gsBSpline.h
@@ -382,6 +382,11 @@ public:
 
     void swapDirections(const unsigned i, const unsigned j);
     
+private:
+
+    // Avoid hidden overloads w.r.t. gsGeometry
+    using Base::insertKnot;
+
 protected:
     
     using Base::m_coefs;

--- a/src/gsNurbs/gsBSpline_.cpp
+++ b/src/gsNurbs/gsBSpline_.cpp
@@ -35,7 +35,11 @@ void pybind11_init_gsBSpline(py::module &m)
 
     // Member functions
     .def("degree", &Class::degree,py::arg("direction") = 0, "Returns the degree of the B-Spline")
-    .def("insertKnot", &Class::insertKnot, "Insert a knot")
+    .def("insertKnot", static_cast<void (Class::*)(real_t,int)> (&Class::insertKnot),
+          py::arg("knot"),
+          py::arg("i") = 1,
+          "Insert a knot with multiplicity i without changing the curve")
+
     .def("degreeElevate", &Class::degreeElevate, "Elevate the degree")
     .def("coefDim", &Class::coefDim, "Returns the number of coefficients defining this B-Spline")
     .def("knots", static_cast<gsKnotVector<real_t>& (Class::*)(int)> (&Class::knots),

--- a/src/gsNurbs/gsNurbs.h
+++ b/src/gsNurbs/gsNurbs.h
@@ -231,6 +231,10 @@ protected:
     // TODO Check function
     // check function: check the coefficient number, degree, knot vector ...
 
+private:
+
+    // Avoid hidden overloads w.r.t. gsGeometry
+    using Base::insertKnot;
 
 // Data members
 private:

--- a/src/gsNurbs/gsNurbsBasis.h
+++ b/src/gsNurbs/gsNurbsBasis.h
@@ -159,8 +159,9 @@ public:
     }
   
     /// Refine the basis uniformly by inserting \a numKnots new knots per knot span.
-    void uniformRefine(int numKnots = 1, int mul=1)
+    void uniformRefine(int numKnots = 1, int mul=1, int dir = -1)
     { 
+        GISMO_UNUSED(dir);
         // TO DO ; replace this with global refinemnt by
         // Lane-Riesenfeld-like  Algorithm
         std::vector<T> newKnots;
@@ -175,7 +176,7 @@ public:
         //m_knots->degreeElevate(i);
         //m_knots->uniformRefine();
     };
-  
+
 }; // class gsNurbsBasis
 
 

--- a/src/gsNurbs/gsTensorNurbsBasis.h
+++ b/src/gsNurbs/gsTensorNurbsBasis.h
@@ -239,6 +239,12 @@ public:
         return new BoundaryBasisType(bb.release(), give(ww));// note: constructor consumes the pointer
     }
 
+    void matchWith(const boundaryInterface & bi, const gsBasis<T> & other,
+                   gsMatrix<index_t> & bndThis, gsMatrix<index_t> & bndOther) const
+    {
+        this->matchWith(bi,other,bndThis,bndOther,0);
+    }
+
     // see gsBasis for documentation
     void matchWith(const boundaryInterface & bi, const gsBasis<T> & other,
                    gsMatrix<index_t> & bndThis, gsMatrix<index_t> & bndOther, index_t offset) const

--- a/src/gsParallel/gsMpiComm.h
+++ b/src/gsParallel/gsMpiComm.h
@@ -22,7 +22,6 @@ namespace gismo
 typedef int MPI_Comm;
 typedef int MPI_Group;
 typedef int MPI_Request;
-struct MPI_Status {};
 #endif
 
 /**
@@ -150,6 +149,7 @@ inline std::ostream& operator<<(std::ostream& os, const gsSerialGroup& obj)
 class GISMO_EXPORT gsSerialStatus
 {
 public:
+    struct MPI_Status {};
     /**
        @brief Returns the rank of the status
     */
@@ -500,7 +500,7 @@ public:
      * @param[in] tag Specifies the message ID
      */
     template<typename T>
-    static int recv (T*, int, int, int = 0, const MPI_Status* = NULL)
+    static int recv (T*, int, int, int = 0, const void* = NULL)
     {
         return 0;
     }

--- a/src/gsTensor/gsTensorBasis.hpp
+++ b/src/gsTensor/gsTensorBasis.hpp
@@ -733,13 +733,11 @@ void gsTensorBasis<d,T>::deriv2_into(const gsMatrix<T> & u,
     std::vector< gsMatrix<T> >values[d];
     gsVector<unsigned, d> v, nb_cwise;
 
-    unsigned nb = 1;
     for (short_t i = 0; i < d; ++i)
     {
         m_bases[i]->evalAllDers_into( u.row(i), 2, values[i]); 
         const int num_i = values[i].front().rows();
         nb_cwise[i] = num_i;
-        nb     *= num_i;
     }
 
     deriv2_tp(values, nb_cwise, result);


### PR DESCRIPTION
NEW:
`GISMO_OVERRIDE_CLONE_FUNCTION` macro in `gsFunctionSet` for generating the clone function with an `override` keyword

IMPROVED:
Loads of hidden overloads with slightly different arguments. The most breaking one is `gsFunctionSet::support(index_t i)` changing to `gsFunctionSet::support(const index_t & i)`

FIXED:
Issue #692 by adding `elementIndex` to `gsRationalBasis`. Tested it

API:

 ---------

Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
