### PR TITLE
Change return type of gsTensorNurbs::weights() const to be a const reference

### DIFF
--- a/src/gsNurbs/gsTensorNurbs.h
+++ b/src/gsNurbs/gsTensorNurbs.h
@@ -263,7 +263,7 @@ public:
     T & weight(int i) const { return this->basis().weight(i); }
 
     /// Returns the NURBS weights
-    gsMatrix<T> & weights() const { return this->basis().weights(); }
+    const gsMatrix<T> & weights() const { return this->basis().weights(); }
 
     /// Returns the NURBS weights as non-const reference
     gsMatrix<T> & weights() { return this->basis().weights(); }


### PR DESCRIPTION
FIXED: The const method `gsTensorNurbs::weights() const` now returns `const gsMatrix<T> &` instead of `gsMatrix<T> &`.
