### PR TITLE
Bsplinecurve intersection

### DIFF
--- a/examples/bSplineCurve_example.cpp
+++ b/examples/bSplineCurve_example.cpp
@@ -20,11 +20,13 @@ using namespace gismo;
 int main(int argc, char *argv[])
 {
     bool plot = false; // If set to true, paraview file is generated and launched on exit
-    bool trim = false; // If set to true, paraview file is generated and launched on exit
+    bool trim = false; // If set to true, trim/merge operations are displayed
+    bool intersect = false; // If set to true, intersection example is displayed
 
     gsCmdLine cmd("Tutorial 01 shows the use of BSpline curves.");
     cmd.addSwitch("plot", "Plot result in ParaView format", plot);
     cmd.addSwitch("trim", "Basic trim/merge operations", trim);
+    cmd.addSwitch("intersect", "Intersection operations", intersect);
 
     try { cmd.getValues(argc,argv); } catch (int rv) { return rv; }
 
@@ -89,6 +91,32 @@ int main(int argc, char *argv[])
     }
     else
       gsInfo << "Done. Re-run with --trim to learn basic trim/merge operations\n";
+
+    // Basic intersection operations between two BSpline curves - @Ye
+    if (intersect){
+      gsMatrix<real_t> ctrPts1(4, 2);
+      ctrPts1 << 0,0, 1,1, 2,1, 3,1;
+      gsBSpline<real_t> bsp1(0, 1, 0, 3, ctrPts1);
+      gsMatrix<real_t> ctrPts2(4, 2);
+      ctrPts2 << 0,0, 1,2, 2,2, 3,0;
+      gsBSpline<real_t> bsp2(0, 1, 0, 3, ctrPts2);
+
+      auto intersectPts = bsp1.intersect(bsp2, 1e-5);
+
+      gsInfo << intersectPts.size() << " intersections are found!" << "\n";
+      gsMatrix<> iPts(bsp1.geoDim(), intersectPts.size());
+      for (int j = 0; j < intersectPts.size(); ++j) {
+        iPts.col(j) = intersectPts[j].getPoint();
+      }
+      if (!intersectPts.empty()) {
+        gsWriteParaviewPoints(iPts, "intersect");
+      }
+
+      gsWriteParaview(bsp1, "bsp1", 2000);
+      gsWriteParaview(bsp2, "bsp2", 2000);
+    }
+    else
+      gsInfo << "Done. Re-run with --intersect to learn intersection operations\n";
 
     return 0;
 }

--- a/examples/bSplineCurve_example.cpp
+++ b/examples/bSplineCurve_example.cpp
@@ -82,12 +82,8 @@ int main(int argc, char *argv[])
       gsWriteParaview( mergedCurve, "mergedCurve", 100);
 
       // convert it into bezier segments
-      std::vector<gsBSpline<>> bezSegments = mergedCurve.toBezier();
-      gsMultiPatch<> bezierContainer;
-      for (const gsBSpline<>& bezSegment:bezSegments) {
-        bezierContainer.addPatch(bezSegment);
-      }
-      gsWriteParaview( bezierContainer, "bezierContainer", 100);
+      gsMultiPatch<> bezSegments = mergedCurve.toBezier();
+      gsWriteParaview(bezSegments, "bezierContainer", 100);
     }
     else
       gsInfo << "Done. Re-run with --trim to learn basic trim/merge operations\n";

--- a/examples/bSplineCurve_example.cpp
+++ b/examples/bSplineCurve_example.cpp
@@ -78,6 +78,14 @@ int main(int argc, char *argv[])
       mergedCurve.merge(&segmentRight);
       gsInfo << "The merged curve: " << mergedCurve << "\n";
       gsWriteParaview( mergedCurve, "mergedCurve", 100);
+
+      // convert it into bezier segments
+      std::vector<gsBSpline<>> bezSegments = mergedCurve.toBezier();
+      gsMultiPatch<> bezierContainer;
+      for (const gsBSpline<>& bezSegment:bezSegments) {
+        bezierContainer.addPatch(bezSegment);
+      }
+      gsWriteParaview( bezierContainer, "bezierContainer", 100);
     }
     else
       gsInfo << "Done. Re-run with --trim to learn basic trim/merge operations\n";

--- a/src/gismo.h
+++ b/src/gismo.h
@@ -98,6 +98,7 @@ namespace internal
 #include <gsNurbs/gsTensorNurbsBasis.h>
 #include <gsNurbs/gsTensorNurbs.h>
 #include <gsNurbs/gsNurbsCreator.h>
+#include <gsNurbs/gsCurveCurveIntersection.h>
 
 /* ----------- HSplines ----------- */
 #include <gsHSplines/gsHBSplineBasis.h>

--- a/src/gsNurbs/gsBSpline.h
+++ b/src/gsNurbs/gsBSpline.h
@@ -210,6 +210,11 @@ public:
     /// \param tolerance proximity of the segment boundaries and B-spline knots to treat them as equal
     void splitAt(T u0, gsBSpline<T>& left,  gsBSpline<T>& right, T tolerance=1e-15) const;
 
+    /// Convert BSpline curve into Bezier segments
+    /// \param tolerance proximity of the segment boundaries and B-spline knots to treat them as equal
+    /// @note: parameter range do NOT change, extra knot().affineTransform() needed
+    std::vector<gsBSpline<T>> toBezier(T tolerance=1e-15) const;
+
     /// Insert the given new knot (multiplicity \a i) without changing
     /// the curve.
     void insertKnot( T knot, index_t i = 1);

--- a/src/gsNurbs/gsBSpline.h
+++ b/src/gsNurbs/gsBSpline.h
@@ -22,6 +22,7 @@
 
 #include <gsUtils/gsPointGrid.h>
 
+#include <gsNurbs/gsCurveCurveIntersection.h>
 
 namespace gismo
 {
@@ -212,8 +213,16 @@ public:
 
     /// Convert BSpline curve into Bezier segments
     /// \param tolerance proximity of the segment boundaries and B-spline knots to treat them as equal
-    /// @note: parameter range do NOT change, extra knot().affineTransform() needed
+    /// @note: parameter range do NOT change, extra knots().affineTransform() needed
     std::vector<gsBSpline<T>> toBezier(T tolerance=1e-15) const;
+
+    /// Compute all intersections with another B-Spline curve
+    std::vector<internal::gsCurveIntersectionResult<T>> intersect(const gsBSpline<T>& other, T tolerance = 1e-5) const;
+
+    /// calculates curvature approximation for a B-spline curve by dividing
+    /// the total length of the polyline formed by its control points by
+    /// the direct distance between the first and last control point
+    T pseudoCurvature() const;
 
     /// Insert the given new knot (multiplicity \a i) without changing
     /// the curve.

--- a/src/gsNurbs/gsBSpline.h
+++ b/src/gsNurbs/gsBSpline.h
@@ -23,6 +23,14 @@
 #include <gsUtils/gsPointGrid.h>
 
 #include <gsNurbs/gsCurveCurveIntersection.h>
+namespace gismo {
+namespace internal {
+
+template<class T>
+struct gsCurveIntersectionResult;
+
+} // namespace internal
+} // namespace gismo
 
 namespace gismo
 {

--- a/src/gsNurbs/gsBSpline.h
+++ b/src/gsNurbs/gsBSpline.h
@@ -22,6 +22,7 @@
 
 #include <gsUtils/gsPointGrid.h>
 
+#include <gsCore/gsMultiPatch.h>
 #include <gsNurbs/gsCurveCurveIntersection.h>
 namespace gismo {
 namespace internal {
@@ -222,7 +223,7 @@ public:
     /// Convert BSpline curve into Bezier segments
     /// \param tolerance proximity of the segment boundaries and B-spline knots to treat them as equal
     /// @note: parameter range do NOT change, extra knots().affineTransform() needed
-    std::vector<gsBSpline<T>> toBezier(T tolerance=1e-15) const;
+    gsMultiPatch<T> toBezier(T tolerance=1e-15) const;
 
     /// Compute all intersections with another B-Spline curve
     std::vector<internal::gsCurveIntersectionResult<T>> intersect(const gsBSpline<T>& other, T tolerance = 1e-5) const;

--- a/src/gsNurbs/gsBSpline.h
+++ b/src/gsNurbs/gsBSpline.h
@@ -22,8 +22,6 @@
 
 #include <gsUtils/gsPointGrid.h>
 
-#include <gsCore/gsMultiPatch.h>
-#include <gsNurbs/gsCurveCurveIntersection.h>
 namespace gismo {
 namespace internal {
 
@@ -226,7 +224,12 @@ public:
     gsMultiPatch<T> toBezier(T tolerance=1e-15) const;
 
     /// Compute all intersections with another B-Spline curve
-    std::vector<internal::gsCurveIntersectionResult<T>> intersect(const gsBSpline<T>& other, T tolerance = 1e-5) const;
+    /// \param other the other B-Spline curve
+    /// \param tolerance the tolerance for computing the intersection
+    /// \param curvatureTolerance the curvature tolerance for the splitting stage
+    /// @note curvatureTolerance should be slightly greater than 1.0, e.g., 1+1e-6
+    /// \return a vector of intersection results
+    std::vector<internal::gsCurveIntersectionResult<T>> intersect(const gsBSpline<T>& other, T tolerance = 1e-5, T curvatureTolerance=1+1e-6) const;
 
     /// calculates curvature approximation for a B-spline curve by dividing
     /// the total length of the polyline formed by its control points by

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -18,6 +18,8 @@
 #include <gsIO/gsXml.h>
 #include <gsIO/gsXmlGenericUtils.hpp>
 
+#include <gsNurbs/gsCurveCurveIntersection.h>
+
 namespace gismo
 {
 

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -163,7 +163,7 @@ std::vector<internal::gsCurveIntersectionResult<T>> gsBSpline<T>::intersect(cons
     uv(1, 0) = 0.5 * (crv2.domainStart() + crv2.domainEnd());
     T distance = obj.compute(uv, tolerance);
 
-    if (distance < math::max(1e-10, tolerance)) {
+    if (distance < math::max((T)1e-10, tolerance)) {
       internal::gsCurveIntersectionResult<T> result(uv(0), uv(1), 0.5 * (crv1.eval(uv.row(0)) + crv2.eval(uv.row(1))));
       results.push_back(result);
     }

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -149,8 +149,8 @@ gsMultiPatch<T> gsBSpline<T>::toBezier(T tolerance) const {
 
 template<class T>
 std::vector<internal::gsCurveIntersectionResult<T>> gsBSpline<T>::intersect(const gsBSpline<T>& other,
-                                                    T tolerance) const {
-  std::vector<internal::gsBoundingBoxPair<T>> hulls = internal::getPotentialIntersectionRanges<T>(*this, other);
+                                                    T tolerance, T curvatureTolerance) const {
+  std::vector<internal::gsBoundingBoxPair<T>> hulls = internal::getPotentialIntersectionRanges<T>(*this, other, curvatureTolerance);
 
   std::vector<internal::gsCurveIntersectionResult<T>> results;
   for (const auto &hull : hulls) {

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -129,6 +129,24 @@ gsBSpline<T> gsBSpline<T>::segmentFromTo(T u0, T u1, T tolerance) const
 }
 
 template<class T>
+std::vector<gsBSpline<T>> gsBSpline<T>::toBezier(T tolerance) const {
+  std::vector<gsBSpline<T>> bezierSegments;
+  const size_t numSegments = this->knots(0).size() - 1; // Assuming this is valid
+  bezierSegments.reserve(numSegments);
+
+  gsBSpline<T> currentSegment(*this);
+  gsBSpline<T> leftPart;
+
+  for (auto iter = this->knots().ubegin() + 1; iter != this->knots().uend() - 1; ++iter) {
+    currentSegment.splitAt(*iter, leftPart, currentSegment, tolerance);
+    bezierSegments.push_back(std::move(leftPart));
+  }
+
+  bezierSegments.push_back(std::move(currentSegment)); // Add the last segment
+  return bezierSegments;
+}
+
+template<class T>
 void gsBSpline<T>::insertKnot( T knot, index_t dir, index_t i)
 {
     GISMO_UNUSED(dir);

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -113,7 +113,8 @@ gsBSpline<T> gsBSpline<T>::segmentFromTo(T u0, T u1, T tolerance) const
   // find the number of coefs left from u1
   index_t nL2 = knots.uFind(u1).firstAppearance();
   bool isEnd = math::abs(u1 - this->domainEnd()) < tolerance;
-  if ( isEnd ) { nL2 += 1; }       // Adjust for end parameter
+//  if ( isEnd ) { nL2 += 1; }       // Adjust for end parameter
+  if ( isEnd ) { nL2 = copy.numCoefs(); }       // Adjust for end parameter
 
   // Prepare control points for new geometry
   gsMatrix<T> coefRes = coefs.block(nL, 0, nL2-nL, tDim);

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -18,6 +18,7 @@
 #include <gsIO/gsXml.h>
 #include <gsIO/gsXmlGenericUtils.hpp>
 
+#include <gsCore/gsMultiPatch.h>
 #include <gsNurbs/gsCurveCurveIntersection.h>
 
 namespace gismo
@@ -131,20 +132,18 @@ gsBSpline<T> gsBSpline<T>::segmentFromTo(T u0, T u1, T tolerance) const
 }
 
 template<class T>
-std::vector<gsBSpline<T>> gsBSpline<T>::toBezier(T tolerance) const {
-  std::vector<gsBSpline<T>> bezierSegments;
-  const size_t numSegments = this->knots(0).size() - 1; // Assuming this is valid
-  bezierSegments.reserve(numSegments);
+gsMultiPatch<T> gsBSpline<T>::toBezier(T tolerance) const {
+  gsMultiPatch<T> bezierSegments;
 
   gsBSpline<T> currentSegment(*this);
   gsBSpline<T> leftPart;
 
   for (auto iter = this->knots().ubegin() + 1; iter != this->knots().uend() - 1; ++iter) {
     currentSegment.splitAt(*iter, leftPart, currentSegment, tolerance);
-    bezierSegments.push_back(std::move(leftPart));
+    bezierSegments.addPatch(leftPart);
   }
 
-  bezierSegments.push_back(std::move(currentSegment)); // Add the last segment
+  bezierSegments.addPatch(currentSegment); // Add the last segment
   return bezierSegments;
 }
 

--- a/src/gsNurbs/gsBSpline.hpp
+++ b/src/gsNurbs/gsBSpline.hpp
@@ -162,7 +162,7 @@ std::vector<internal::gsCurveIntersectionResult<T>> gsBSpline<T>::intersect(cons
     uv(1, 0) = 0.5 * (crv2.domainStart() + crv2.domainEnd());
     T distance = obj.compute(uv, tolerance);
 
-    if (distance < std::max(1e-10, tolerance)) {
+    if (distance < math::max(1e-10, tolerance)) {
       internal::gsCurveIntersectionResult<T> result(uv(0), uv(1), 0.5 * (crv1.eval(uv.row(0)) + crv2.eval(uv.row(1))));
       results.push_back(result);
     }

--- a/src/gsNurbs/gsCurveCurveIntersection.h
+++ b/src/gsNurbs/gsCurveCurveIntersection.h
@@ -43,8 +43,9 @@ template<class T>
 int orientationxx(const gsPoint2d<T> &p, const gsPoint2d<T> &q, const gsPoint2d<T> &r) {
   // See https://www.geeksforgeeks.org/orientation-3-ordered-points/
   // for details of below formula.
-  double val = (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
+  T val = (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
 
+  // Caution: numerically val is almost never exactly zero
   if (val == 0) return 0;  // collinear
 
   return (val > 0) ? 1 : 2; // clock or counterclock wise

--- a/src/gsNurbs/gsCurveCurveIntersection.h
+++ b/src/gsNurbs/gsCurveCurveIntersection.h
@@ -1,0 +1,360 @@
+/** @file gsCurveCurveIntersection.h
+
+    @brief Implementation of B Spline Curve/Curve intersection
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): Ye Ji
+*/
+
+#pragma once
+
+#include <gsCore/gsLinearAlgebra.h>
+
+namespace gismo{
+
+namespace internal {
+
+#define EPSILON ( 100*std::numeric_limits<T>::epsilon() )
+
+template<class T=real_t>
+struct gsPoint2d{
+  gsPoint2d(T xCoord, T yCoord) {
+    pt.x() = xCoord;
+    pt.y() = yCoord;
+  }
+
+  inline T x() const { return pt.x();}
+  inline T y() const { return pt.y();}
+
+  gsPoint<2,T> pt;
+};
+
+// To find orientation of ordered triplet (p, q, r).
+// The function returns following values
+// 0 --> p, q and r are collinear
+// 1 --> Clockwise
+// 2 --> Counterclockwise
+template<class T>
+int orientationxx(const gsPoint2d<T> &p, const gsPoint2d<T> &q, const gsPoint2d<T> &r) {
+  // See https://www.geeksforgeeks.org/orientation-3-ordered-points/
+  // for details of below formula.
+  double val = (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
+
+  if (val == 0) return 0;  // collinear
+
+  return (val > 0) ? 1 : 2; // clock or counterclock wise
+}
+
+// Given three collinear points p, q, r, the function checks if
+// point q lies on the line segment 'pr'
+template<class T>
+bool onSegment(const gsPoint2d<T> &p, const gsPoint2d<T> &q, const gsPoint2d<T> &r) {
+  if (q.x() <= std::max(p.x(), r.x()) && q.x() >= std::min(p.x(), r.x()) &&
+      q.y() <= std::max(p.y(), r.y()) && q.y() >= std::min(p.y(), r.y()))
+    return true;
+
+  return false;
+}
+
+// The main function that returns true if line segment 'p1q1'
+// and 'p2q2' intersect.
+template<class T>
+bool doIntersect(const gsPoint2d<T> &p1, const gsPoint2d<T> &q1,
+                 const gsPoint2d<T> &p2, const gsPoint2d<T> &q2) {
+  // Find the four orientations needed for general and special cases
+  int o1 = orientationxx(p1, q1, p2);
+  int o2 = orientationxx(p1, q1, q2);
+  int o3 = orientationxx(p2, q2, p1);
+  int o4 = orientationxx(p2, q2, q1);
+
+  // General case
+  if (o1 != o2 && o3 != o4)
+    return true;
+
+  // Special Cases
+  // p1, q1 and p2 are collinear and p2 lies on segment p1q1
+  if (o1 == 0 && onSegment(p1, p2, q1)) return true;
+
+  // p1, q1 and q2 are collinear and q2 lies on segment p1q1
+  if (o2 == 0 && onSegment(p1, q2, q1)) return true;
+
+  // p2, q2 and p1 are collinear and p1 lies on segment p2q2
+  if (o3 == 0 && onSegment(p2, p1, q2)) return true;
+
+  // p2, q2 and q1 are collinear and q1 lies on segment p2q2
+  if (o4 == 0 && onSegment(p2, q1, q2)) return true;
+
+  return false; // Doesn't fall in any of the above cases
+}
+
+/** \brief
+    Curve/Curve intersection result class.
+
+    This is the geometry type associated with gsBSplineBasis.
+
+    \tparam T coefficient type
+
+    \param m_paramOnCurve1 intersection parameter on Curve1
+    \param m_paramOnCurve2 intersection parameter on Curve2
+    \param m_point physical coordinate of intersection point
+*/
+template<class T=real_t>
+struct gsCurveIntersectionResult {
+  // Explicit constructor for direct initialization
+  explicit gsCurveIntersectionResult(T paramOnCurve1, T paramOnCurve2, gsVector<T> pt)
+      : m_paramOnCurve1(paramOnCurve1), m_paramOnCurve2(paramOnCurve2), m_point(std::move(pt)) {}
+
+  // Equality operators
+  bool operator==(const gsCurveIntersectionResult& other) const {
+    return m_paramOnCurve1 == other.paramOnCurve1 &&
+        m_paramOnCurve2 == other.paramOnCurve2 &&
+        m_point == other.point;
+  }
+
+  bool operator!=(const gsCurveIntersectionResult& other) const {
+    return !(*this == other);
+  }
+
+  T getParamOnCurve1() const { return m_paramOnCurve1; }
+  T getParamOnCurve2() const { return m_paramOnCurve2; }
+  gsVector<T> getPoint() const { return m_point; }
+
+ private:
+  T m_paramOnCurve1{};
+  T m_paramOnCurve2{};
+  gsVector<T> m_point{};
+};
+
+/// Managing an interval defined by a minimum and maximum value
+template<class T=real_t>
+class gsInterval {
+ public:
+  gsInterval(T min, T max) : m_min(min), m_max(max) {}
+
+  bool almostEqual(T a, T b, T tolerance = EPSILON) const {
+    return std::abs(a - b) <= tolerance;
+  }
+
+  bool operator==(const gsInterval<T> &other) const {
+    return almostEqual(m_min, other.getMin()) && almostEqual(m_max, other.getMax());
+  }
+
+  T getMin() const { return m_min; }
+  T getMax() const { return m_max; }
+
+  void setMin(T mmin) { m_min = mmin; }
+  void setMax(T mmax) { m_min = mmax; }
+
+ private:
+  T m_min{0}, m_max{0};
+};
+
+/// representing and manipulating bounding boxes for gsBSpline object
+template<class T=real_t>
+class gsCurveBoundingBox {
+ public:
+  explicit gsCurveBoundingBox(const gsBSpline<T> &curve)
+      : range(curve.domainStart(), curve.domainEnd()) {
+    low.resize( curve.geoDim() );
+    high.resize(curve.geoDim() );
+    for (int i = 0; i != curve.geoDim(); ++i) {
+      low[i] = std::numeric_limits<T>::max();
+      high[i] = std::numeric_limits<T>::lowest();
+    }
+    // compute min / max from control points
+    for (int ipt = 0; ipt != curve.coefsSize(); ++ipt) {
+      const auto &p = curve.coef(ipt); // Access once per iteration
+      for (int i = 0; i != curve.geoDim(); ++i) {
+        high[i] = std::max(high[i], p(i));
+        low[i] = std::min(low[i], p(i));
+      }
+    }
+  }
+
+  [[nodiscard]] bool intersect(const gsCurveBoundingBox<T> &other,
+                                T eps = EPSILON) const {
+    assert( this->getLow().size() == other.getLow().size() );
+    for (int i = 0; i != other.getLow().size(); ++i) {
+      if (std::max(low[i], other.low[i]) > std::min(high[i], other.high[i]) + eps) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  gsVector<T> getLow() const { return low; }
+  gsVector<T> getHigh() const { return high; }
+  gsInterval<T> getRange() const { return range; }
+
+ private:
+  gsVector<T> low{}, high{};
+  gsInterval<T> range{};
+};
+
+template<class T=real_t>
+struct gsBoundingBoxPair {
+  gsBoundingBoxPair(const gsCurveBoundingBox<T> &i1, const gsCurveBoundingBox<T> &i2)
+      : b1(i1), b2(i2) {}
+
+  gsCurveBoundingBox<T> b1{};
+  gsCurveBoundingBox<T> b2{};
+};
+
+/// compute potential intersection range by recursively subdividing curves
+/// and bounding box intersection detection
+template<class T=real_t>
+std::vector<gsBoundingBoxPair<T>> getPotentialIntersectionRanges(const gsBSpline<T> &curve1,
+                                                                 const gsBSpline<T> &curve2) {
+  gsCurveBoundingBox<T> h1(curve1);
+  gsCurveBoundingBox<T> h2(curve2);
+
+  // Bounding boxes do not intersect. No intersection possible
+  if (!h1.intersect(h2)) {
+    return {};
+  }
+
+  T crv1Curvature = curve1.pseudoCurvature();
+  T crv2Curvature = curve2.pseudoCurvature();
+  constexpr T MAX_CURVATURE = 1.0 + 5e-6;
+
+  // Check for intersection between endpoint line segments if curves are linear enough
+  if (crv1Curvature <= MAX_CURVATURE && crv2Curvature <= MAX_CURVATURE) {
+    if ( curve1.geoDim() == 2 ) {
+      // line segment intersection check for the planar case
+      gsPoint2d<T> pt1(curve1.coef(0).x(), curve1.coef(0).y());
+      gsPoint2d<T> pt2(curve1.coef(curve1.coefsSize() - 1).x(), curve1.coef(curve1.coefsSize() - 1).y());
+      gsPoint2d<T> pt3(curve2.coef(0).x(), curve2.coef(0).y());
+      gsPoint2d<T> pt4(curve2.coef(curve2.coefsSize() - 1).x(), curve2.coef(curve2.coefsSize() - 1).y());
+      if (doIntersect(pt1, pt2, pt3, pt4)) {
+        return {gsBoundingBoxPair<T>(h1, h2)};
+      }
+    } else {
+      return {gsBoundingBoxPair<T>(h1, h2)};
+    }
+    return {};
+  }
+
+  // Recursive subdividing for curves with high curvature
+  if (crv1Curvature > MAX_CURVATURE && crv2Curvature > MAX_CURVATURE) {
+    // Subdivide both curves by splitting them in the parametric center
+    T curve1MidParm = 0.5 * (curve1.domainStart() + curve1.domainEnd());
+    T curve2MidParm = 0.5 * (curve2.domainStart() + curve2.domainEnd());
+
+    gsBSpline<T> c11, c12, c21, c22;
+    curve1.splitAt(curve1MidParm, c11, c12);
+    curve2.splitAt(curve2MidParm, c21, c22);
+
+    auto result1 = getPotentialIntersectionRanges<T>(c11, c21);
+    auto result2 = getPotentialIntersectionRanges<T>(c11, c22);
+    auto result3 = getPotentialIntersectionRanges<T>(c12, c21);
+    auto result4 = getPotentialIntersectionRanges<T>(c12, c22);
+
+    // append all results
+    result1.insert(result1.end(), result2.begin(), result2.end());
+    result1.insert(result1.end(), result3.begin(), result3.end());
+    result1.insert(result1.end(), result4.begin(), result4.end());
+
+    return result1;
+  } else if (crv1Curvature <= MAX_CURVATURE && MAX_CURVATURE < crv2Curvature) {
+    // Subdivide only curve 2
+    T curve2MidParm = 0.5 * (curve2.domainStart() + curve2.domainEnd());
+    gsBSpline<T> c21, c22;
+    curve2.splitAt(curve2MidParm, c21, c22);
+
+    auto result1 = getPotentialIntersectionRanges<T>(curve1, c21);
+    auto result2 = getPotentialIntersectionRanges<T>(curve1, c22);
+
+    result1.insert(result1.end(), result2.begin(), result2.end());
+    return result1;
+  } else if (crv2Curvature <= MAX_CURVATURE && MAX_CURVATURE < crv1Curvature) {
+    // Subdivide only curve 1
+    T curve1MidParm = 0.5 * (curve1.domainStart() + curve1.domainEnd());
+    gsBSpline<T> c11, c12;
+    curve1.splitAt(curve1MidParm, c11, c12);
+
+    auto result1 = getPotentialIntersectionRanges<T>(c11, curve2);
+    auto result2 = getPotentialIntersectionRanges<T>(c12, curve2);
+
+    result1.insert(result1.end(), result2.begin(), result2.end());
+    return result1;
+  }
+
+  return {};
+}
+
+/// Refine the intersection by using Projected Gauss-Newton method
+template<class T=real_t>
+class gsCurveCurveDistanceSystem {
+ public:
+  gsCurveCurveDistanceSystem(const gsBSpline<T> &crv1, const gsBSpline<T> &crv2)
+      : m_crv1(crv1), m_crv2(crv2) {
+    assert(crv1.geoDim() == crv2.geoDim());
+  }
+
+  void Values(const gsMatrix<T, 2, 1> &uv,
+              gsMatrix<T> &funcVal,
+              gsMatrix<T> &invJac) const {
+    std::vector<gsMatrix<>> crv1Der = m_crv1.evalAllDers(uv.row(0), 1);
+    std::vector<gsMatrix<>> crv2Der = m_crv2.evalAllDers(uv.row(1), 1);
+
+    funcVal = crv1Der[0] - crv2Der[0];
+
+    gsMatrix<T> jac(m_crv1.geoDim(), 2);
+    jac.col(0) =  crv1Der[1];
+    jac.col(1) = -crv2Der[1];
+    invJac = jac.completeOrthogonalDecomposition().pseudoInverse();
+  }
+
+  /// Projected Gauss-Newton method
+  T compute(gsMatrix<T,2,1> &uv, T tolerance = 1e-5, size_t maxIter = 20) const
+  {
+    gsMatrix<T> funVal;
+    gsMatrix<T> invJac;
+    Values(uv, funVal, invJac); // Assumes Values correctly inverts the Jacobian
+    T currentResidual = funVal.norm();
+
+    gsMatrix<T, 2, 1> deltaUv = invJac * funVal;
+    gsMatrix<T, 2, 1> newUv;
+    for (size_t iter = 1; iter != maxIter; ++iter) {
+      uv -= deltaUv; // update uv
+
+      // project uv into its parameter range
+      newUv(0, 0) = std::min(std::max(uv(0, 0), m_crv1.domainStart()), m_crv1.domainEnd());
+      newUv(1, 0) = std::min(std::max(uv(1, 0), m_crv2.domainStart()), m_crv2.domainEnd());
+      // using C++17 standard
+//      newUv(0, 0) = std::clamp(newUv(0, 0), m_crv1.domainStart(), m_crv1.domainEnd());
+//      newUv(1, 0) = std::clamp(newUv(1, 0), m_crv2.domainStart(), m_crv2.domainEnd());
+
+      T delta = (uv - newUv).norm();
+      uv = newUv;
+      if (delta > EPSILON) {
+        Values(uv, funVal, invJac); // Re-evaluate funVal and invJac
+        currentResidual = funVal.norm();
+        break;
+      }
+
+      Values(uv, funVal, invJac); // Re-evaluate funVal and invJac
+      currentResidual = funVal.norm();
+      if (currentResidual < tolerance) break;
+
+      deltaUv = invJac * funVal;
+      if (deltaUv.norm() < 1e-3*tolerance) break;
+
+//      gsInfo << "iter. = " << iter << ", residual = " << currentResidual << "\n";
+    }
+    return currentResidual;
+  }
+
+ private:
+  const gsBSpline<T> m_crv1{}, m_crv2{};
+};
+
+} // namespace internal
+
+} // namespace gismo
+

--- a/src/gsNurbs/gsCurveCurveIntersection.h
+++ b/src/gsNurbs/gsCurveCurveIntersection.h
@@ -208,9 +208,15 @@ struct gsBoundingBoxPair {
 
 /// compute potential intersection range by recursively subdividing curves
 /// and bounding box intersection detection
+/// @param curve1 first B-Spline curve
+/// @param curve2 second B-Spline curve
+/// @param MAX_CURVATURE maximum curvature for recursive subdivision
+/// @note MAX_CURVATURE should be set to a value slightly larger than 1.0, say, 1.0+1e-6
+/// @return a list of potential intersection ranges for the two input
 template<class T=real_t>
 std::vector<gsBoundingBoxPair<T>> getPotentialIntersectionRanges(const gsBSpline<T> &curve1,
-                                                                 const gsBSpline<T> &curve2) {
+                                                                 const gsBSpline<T> &curve2,
+                                                                 const T MAX_CURVATURE) {
   gsCurveBoundingBox<T> h1(curve1);
   gsCurveBoundingBox<T> h2(curve2);
 
@@ -221,7 +227,7 @@ std::vector<gsBoundingBoxPair<T>> getPotentialIntersectionRanges(const gsBSpline
 
   T crv1Curvature = curve1.pseudoCurvature();
   T crv2Curvature = curve2.pseudoCurvature();
-  static const T MAX_CURVATURE = 1.0 + 5e-6;
+//  static const T MAX_CURVATURE = 1.0 + 5e-6;
 
   // Check for intersection between endpoint line segments if curves are linear enough
   if (crv1Curvature <= MAX_CURVATURE && crv2Curvature <= MAX_CURVATURE) {
@@ -250,10 +256,10 @@ std::vector<gsBoundingBoxPair<T>> getPotentialIntersectionRanges(const gsBSpline
     curve1.splitAt(curve1MidParm, c11, c12);
     curve2.splitAt(curve2MidParm, c21, c22);
 
-    auto result1 = getPotentialIntersectionRanges<T>(c11, c21);
-    auto result2 = getPotentialIntersectionRanges<T>(c11, c22);
-    auto result3 = getPotentialIntersectionRanges<T>(c12, c21);
-    auto result4 = getPotentialIntersectionRanges<T>(c12, c22);
+    auto result1 = getPotentialIntersectionRanges<T>(c11, c21, MAX_CURVATURE);
+    auto result2 = getPotentialIntersectionRanges<T>(c11, c22, MAX_CURVATURE);
+    auto result3 = getPotentialIntersectionRanges<T>(c12, c21, MAX_CURVATURE);
+    auto result4 = getPotentialIntersectionRanges<T>(c12, c22, MAX_CURVATURE);
 
     // append all results
     result1.insert(result1.end(), result2.begin(), result2.end());
@@ -267,8 +273,8 @@ std::vector<gsBoundingBoxPair<T>> getPotentialIntersectionRanges(const gsBSpline
     gsBSpline<T> c21, c22;
     curve2.splitAt(curve2MidParm, c21, c22);
 
-    auto result1 = getPotentialIntersectionRanges<T>(curve1, c21);
-    auto result2 = getPotentialIntersectionRanges<T>(curve1, c22);
+    auto result1 = getPotentialIntersectionRanges<T>(curve1, c21, MAX_CURVATURE);
+    auto result2 = getPotentialIntersectionRanges<T>(curve1, c22, MAX_CURVATURE);
 
     result1.insert(result1.end(), result2.begin(), result2.end());
     return result1;
@@ -278,8 +284,8 @@ std::vector<gsBoundingBoxPair<T>> getPotentialIntersectionRanges(const gsBSpline
     gsBSpline<T> c11, c12;
     curve1.splitAt(curve1MidParm, c11, c12);
 
-    auto result1 = getPotentialIntersectionRanges<T>(c11, curve2);
-    auto result2 = getPotentialIntersectionRanges<T>(c12, curve2);
+    auto result1 = getPotentialIntersectionRanges<T>(c11, curve2, MAX_CURVATURE);
+    auto result2 = getPotentialIntersectionRanges<T>(c12, curve2, MAX_CURVATURE);
 
     result1.insert(result1.end(), result2.begin(), result2.end());
     return result1;

--- a/src/gsNurbs/gsCurveCurveIntersection.h
+++ b/src/gsNurbs/gsCurveCurveIntersection.h
@@ -19,7 +19,7 @@ namespace gismo{
 
 namespace internal {
 
-#define EPSILON ( 100*std::numeric_limits<T>::epsilon() )
+#define EPSILON_CCI ( 100*std::numeric_limits<T>::epsilon() )
 
 template<class T=real_t>
 struct gsPoint2d{
@@ -136,7 +136,7 @@ class gsInterval {
  public:
   gsInterval(T min, T max) : m_min(min), m_max(max) {}
 
-  bool almostEqual(T a, T b, T tolerance = EPSILON) const {
+  bool almostEqual(T a, T b, T tolerance = EPSILON_CCI) const {
     return std::abs(a - b) <= tolerance;
   }
 
@@ -177,7 +177,7 @@ class gsCurveBoundingBox {
   }
 
   [[nodiscard]] bool intersect(const gsCurveBoundingBox<T> &other,
-                                T eps = EPSILON) const {
+                                T eps = EPSILON_CCI) const {
     assert( this->getLow().size() == other.getLow().size() );
     for (int i = 0; i != other.getLow().size(); ++i) {
       if (std::max(low[i], other.low[i]) > std::min(high[i], other.high[i]) + eps) {
@@ -332,7 +332,7 @@ class gsCurveCurveDistanceSystem {
 
       T delta = (uv - newUv).norm();
       uv = newUv;
-      if (delta > EPSILON) {
+      if (delta > EPSILON_CCI) {
         Values(uv, funVal, invJac); // Re-evaluate funVal and invJac
         currentResidual = funVal.norm();
         break;

--- a/src/gsNurbs/gsCurveCurveIntersection.h
+++ b/src/gsNurbs/gsCurveCurveIntersection.h
@@ -54,8 +54,8 @@ int orientationxx(const gsPoint2d<T> &p, const gsPoint2d<T> &q, const gsPoint2d<
 // point q lies on the line segment 'pr'
 template<class T>
 bool onSegment(const gsPoint2d<T> &p, const gsPoint2d<T> &q, const gsPoint2d<T> &r) {
-  if (q.x() <= std::max(p.x(), r.x()) && q.x() >= std::min(p.x(), r.x()) &&
-      q.y() <= std::max(p.y(), r.y()) && q.y() >= std::min(p.y(), r.y()))
+  if (q.x() <= math::max(p.x(), r.x()) && q.x() >= math::min(p.x(), r.x()) &&
+      q.y() <= math::max(p.y(), r.y()) && q.y() >= math::min(p.y(), r.y()))
     return true;
 
   return false;
@@ -170,8 +170,8 @@ class gsCurveBoundingBox {
     for (int ipt = 0; ipt != curve.coefsSize(); ++ipt) {
       const auto &p = curve.coef(ipt); // Access once per iteration
       for (int i = 0; i != curve.geoDim(); ++i) {
-        high[i] = std::max(high[i], p(i));
-        low[i] = std::min(low[i], p(i));
+        high[i] = math::max(high[i], p(i));
+        low[i] = math::min(low[i], p(i));
       }
     }
   }
@@ -180,7 +180,7 @@ class gsCurveBoundingBox {
                                 T eps = EPSILON_CCI) const {
     assert( this->getLow().size() == other.getLow().size() );
     for (int i = 0; i != other.getLow().size(); ++i) {
-      if (std::max(low[i], other.low[i]) > std::min(high[i], other.high[i]) + eps) {
+      if (math::max(low[i], other.low[i]) > math::min(high[i], other.high[i]) + eps) {
         return false;
       }
     }
@@ -324,8 +324,8 @@ class gsCurveCurveDistanceSystem {
       uv -= deltaUv; // update uv
 
       // project uv into its parameter range
-      newUv(0, 0) = std::min(std::max(uv(0, 0), m_crv1.domainStart()), m_crv1.domainEnd());
-      newUv(1, 0) = std::min(std::max(uv(1, 0), m_crv2.domainStart()), m_crv2.domainEnd());
+      newUv(0, 0) = math::min(math::max(uv(0, 0), m_crv1.domainStart()), m_crv1.domainEnd());
+      newUv(1, 0) = math::min(math::max(uv(1, 0), m_crv2.domainStart()), m_crv2.domainEnd());
       // using C++17 standard
 //      newUv(0, 0) = std::clamp(newUv(0, 0), m_crv1.domainStart(), m_crv1.domainEnd());
 //      newUv(1, 0) = std::clamp(newUv(1, 0), m_crv2.domainStart(), m_crv2.domainEnd());

--- a/src/gsNurbs/gsCurveCurveIntersection.h
+++ b/src/gsNurbs/gsCurveCurveIntersection.h
@@ -220,7 +220,7 @@ std::vector<gsBoundingBoxPair<T>> getPotentialIntersectionRanges(const gsBSpline
 
   T crv1Curvature = curve1.pseudoCurvature();
   T crv2Curvature = curve2.pseudoCurvature();
-  constexpr T MAX_CURVATURE = 1.0 + 5e-6;
+  static const T MAX_CURVATURE = 1.0 + 5e-6;
 
   // Check for intersection between endpoint line segments if curves are linear enough
   if (crv1Curvature <= MAX_CURVATURE && crv2Curvature <= MAX_CURVATURE) {


### PR DESCRIPTION
New feature for efficiently computing all intersections bewteen two arbitrary-dimensional B-Spline curves in `gsBSpline` class

![BSpline_intersections](https://github.com/gismo/gismo/assets/50975528/075a5a53-44c6-44cf-9ef4-a071e1370600)

# The commit description must be structured as a list follows:

NEW: 
1. `T gsBSpline<>::pseudoCurvature() const` for calculating curvature approximation for a B-spline curve by dividing the total length of the polyline formed by its control points by the direct distance between the first and last control point;
2. `std::vector<internal::gsCurveIntersectionResult<T>> gsBSpline<>::intersect(const gsBSpline<T>& other, T tolerance = 1e-5) const` for computing all intersections with another B-Spline curve;
3. std::vector<gsBSpline<T>> gsBSpline<>::toBezier(T tolerance=1e-15) const for converting a BSpline curve into Bezier segments;
4. `gsCurveCurveIntersection.h` for functions and classes used for `gsBSpline::intersect`.

IMPROVED: 
none

FIXED: 

1. Fix one bug in `gsBSpline<T> gsBSpline<T>::segmentFromTo(T u0, T u1, T tolerance) const`

API:
none

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
