### PR TITLE
Replacing GISMO_UNUSED with EIGEN_UNUSED_VARIABLE in gsEigen

### DIFF
--- a/external/gsEigen/src/Core/PlainObjectBase.h
+++ b/external/gsEigen/src/Core/PlainObjectBase.h
@@ -802,8 +802,8 @@ class PlainObjectBase : public internal::dense_xpr_base<Derived>::type
     EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE void _init2(Index rows, Index cols, typename internal::enable_if<Base::SizeAtCompileTime!=2,T0>::type* = 0)
     {
-      const bool t0_is_integer_alike = internal::is_valid_index_type<T0>::value; GISMO_UNUSED(t0_is_integer_alike);
-      const bool t1_is_integer_alike = internal::is_valid_index_type<T1>::value; GISMO_UNUSED(t1_is_integer_alike);
+      const bool t0_is_integer_alike = internal::is_valid_index_type<T0>::value; EIGEN_UNUSED_VARIABLE(t0_is_integer_alike);
+      const bool t1_is_integer_alike = internal::is_valid_index_type<T1>::value; EIGEN_UNUSED_VARIABLE(t1_is_integer_alike);
       EIGEN_STATIC_ASSERT(t0_is_integer_alike &&
                           t1_is_integer_alike,
                           FLOATING_POINT_ARGUMENT_PASSED__INTEGER_WAS_EXPECTED)


### PR DESCRIPTION
# Changes
FIXED: I have replaced `GISMO_UNUSED` with `EIGEN_UNUSED_VARIABLE` in **external/gsEigen**.

## TL;DR
With the `GISMO_UNUSED` I cannot use solution 5 from #566 anymore.

## Longer explanation
I am compiling an application that depends both G+Smo and another library that also uses Eigen. In order to prevent issues from having two copies of Eigen, the following solution has worked great in the past:

1. install G+Smo with `make install`,
2. compile the other library `-I`-ing the content of the gsEigen that G+Smo made in step 1,
3. compile my application linking to the results of steps 1 and 2.

Step 2. currently fails due to `GISMO_UNUSED` not being defined. After replacing it with `EIGEN_UNUSED_VARIABLE`, step 2 works without problems. In my view, the content of the _external/gsEigen_ should generally not depend on anything G+Smo specific.

# The checklist
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them? Yes, see above.
- [X] Have you documented any new codes using Doxygen comments? No, I don't think it is necessary.
- [X] Have you written new tests or examples for your changes? No, I don't think it is necessary.
-----
