### PR TITLE
fix warning: compare signed with unsigend

### DIFF
--- a/examples/bSplineCurve_example.cpp
+++ b/examples/bSplineCurve_example.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 
       gsInfo << intersectPts.size() << " intersections are found!" << "\n";
       gsMatrix<> iPts(bsp1.geoDim(), intersectPts.size());
-      for (int j = 0; j < intersectPts.size(); ++j) {
+      for (size_t j = 0; j < intersectPts.size(); ++j) {
         iPts.col(j) = intersectPts[j].getPoint();
       }
       if (!intersectPts.empty()) {


### PR DESCRIPTION
FIXED: a for loop in bsplineCurve_example is indexed by an int, but the end is of type size_t giving a warning at compilation time