### PR TITLE
fix linker error: undefined reference

### DIFF
--- a/src/gsMSplines/gsWeightMapperUtils.hpp
+++ b/src/gsMSplines/gsWeightMapperUtils.hpp
@@ -98,7 +98,7 @@ void combineMappers (const std::vector<gsWeightMapper<T>*> &mappers, bool needSh
     index_t startingGlobal=0;
     for (size_t m=0;m<mappers.size();++m)
     {
-        copyToBlock( mappers[m]->asMatrix(), resultMatrix, shifts[m], startingGlobal);
+        copyToBlock( *mappers[m], resultMatrix, shifts[m], startingGlobal);
         if (needShifting)
            startingGlobal+= mappers[m]->getNrOfTargets();
     }

--- a/src/gsMSplines/gsWeightMapper_.cpp
+++ b/src/gsMSplines/gsWeightMapper_.cpp
@@ -26,9 +26,12 @@ namespace gismo
 
     //Utils
 
-    GISMO_EXPORT index_t reorderMapperTarget (gsWeightMapper<real_t> &mapper, const std::vector<index_t>& permutation, gsPermutationMatrix* permMatrix=NULL);
-    GISMO_EXPORT  gsWeightMapper<real_t>* combineMappers (const std::vector<gsWeightMapper<real_t>*> &mappers, std::vector<index_t> &shifts, bool needShifting=true);
-    GISMO_EXPORT  void combineMappers (const std::vector<gsWeightMapper<real_t>*> &mappers, bool needShifting, std::vector<index_t> &shifts, gsWeightMapper<real_t>& result);
+    TEMPLATE_INST
+    index_t reorderMapperTarget (gsWeightMapper<real_t> &mapper, const std::vector<index_t>& permutation, gsPermutationMatrix* permMatrix=NULL);
+    TEMPLATE_INST
+    gsWeightMapper<real_t>* combineMappers (const std::vector<gsWeightMapper<real_t>*> &mappers, std::vector<index_t> &shifts, bool needShifting=true);
+    TEMPLATE_INST
+    void combineMappers (const std::vector<gsWeightMapper<real_t>*> &mappers, bool needShifting, std::vector<index_t> &shifts, gsWeightMapper<real_t>& result);
 
 
 } // end namespace gismo

--- a/src/gsMSplines/gsWeightMapper_.cpp
+++ b/src/gsMSplines/gsWeightMapper_.cpp
@@ -27,9 +27,9 @@ namespace gismo
     //Utils
 
     TEMPLATE_INST
-    index_t reorderMapperTarget (gsWeightMapper<real_t> &mapper, const std::vector<index_t>& permutation, gsPermutationMatrix* permMatrix=NULL);
+    index_t reorderMapperTarget (gsWeightMapper<real_t> &mapper, const std::vector<index_t>& permutation, gsPermutationMatrix* permMatrix);
     TEMPLATE_INST
-    gsWeightMapper<real_t>* combineMappers (const std::vector<gsWeightMapper<real_t>*> &mappers, std::vector<index_t> &shifts, bool needShifting=true);
+    gsWeightMapper<real_t>* combineMappers (const std::vector<gsWeightMapper<real_t>*> &mappers, std::vector<index_t> &shifts, bool needShifting);
     TEMPLATE_INST
     void combineMappers (const std::vector<gsWeightMapper<real_t>*> &mappers, bool needShifting, std::vector<index_t> &shifts, gsWeightMapper<real_t>& result);
 


### PR DESCRIPTION
FIXED: the combineMappers templated function with real_t was not instantiated in the library causing linker errors

instantiating revealed a different error that is also fixed

FIXED: an error in the combineMappers templated function that called copyBlockTo passing a matrix instead of a gsWeightMapper

