### PR TITLE
Avoids compilation error.

### DIFF
--- a/src/gsModeling/gsTemplate.h
+++ b/src/gsModeling/gsTemplate.h
@@ -585,7 +585,7 @@ public:
         return os; 
     }
 
-    short_t parDim() const { return dim; }
+    short_t parDim() const { return dim(); }
 
     /// Number of patches    
     index_t nPatches() const { return this->size(); }


### PR DESCRIPTION
FIXED: https://github.com/gismo/gismo/issues/705

For some reason we are returning a method's name instead of calling it.
