### PR TITLE
Update gsBarrierCore.h

### DIFF
--- a/src/gsModeling/gsBarrierCore.h
+++ b/src/gsModeling/gsBarrierCore.h
@@ -98,7 +98,7 @@ void setOptimizerOptions(gsHLBFGS<T> &optimizer, const gsOptionList &options) {
 #endif
 
 /// helper function to verbose log
-void verboseLog(const std::string &message, const index_t &verbose) {
+inline void verboseLog(const std::string &message, const index_t &verbose) {
   if (verbose > 0) { gsInfo << message << "\n"; }
 }
 


### PR DESCRIPTION
Function `void verboseLog` does not have `inline` and as a consequence this symbol ends up multiple times in a library that consists of multiple object files that include `gismo.h`.
