### PR TITLE
Tiny bugfix in gsParaviewCollection

### DIFF
--- a/src/gsIO/gsParaviewCollection.h
+++ b/src/gsIO/gsParaviewCollection.h
@@ -89,8 +89,17 @@ public:
                         m_options(gsParaviewDataSet::defaultOptions()),
                         counter(0)
     {
-        m_filename = gsFileManager::getPath(m_filename) + gsFileManager::getBasename(m_filename) + ".pvd";
-        gsFileManager::mkdir( gsFileManager::getPath(m_filename) );
+        std::string path = gsFileManager::getPath(m_filename);
+
+        // If the path does not start with ./ or / , it is assumed to be a relative path
+        if ( (!gsFileManager::isExplicitlyRelative(path) && !gsFileManager::isFullyQualified(path)) )
+        {
+            path = "./" + path;
+        }
+
+        m_filename = path + gsFileManager::getBasename(m_filename) + ".pvd";
+        gsFileManager::mkdir( path );
+
         // if ( "" != m_filename.parent_path())
         // GISMO_ENSURE( fsystem::exists( m_filename.parent_path() ), 
         //     "The specified folder " << m_filename.parent_path() << " does not exist, please create it first.");  


### PR DESCRIPTION

Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the stable branch should be clean, well-documented
and free of bugs.

# The commit description must be structured as a list follows:

NEW: -
IMPROVED: -
FIXED:
* gsParaviewCollection did not handle paths that were not explicitly relative (i.e. starting with `./`) or absolute (i.e. starting with `/`) . Since people seem to use it with such paths ( as in `linear_elasticity_example`) it now assumes these paths to be relative to the cwd.
API:-

For each new/improved/fixed/api change use a new line with the
respective word prefix in capital.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
