### PR TITLE
Hotfix `gsDirichletValues`

### DIFF
--- a/src/gsAssembler/gsDirichletValues.h
+++ b/src/gsAssembler/gsDirichletValues.h
@@ -367,7 +367,7 @@ void gsDirichletValuesByL2Projection( const expr::gsFeSpace<T> & u,
                   // If the condition is homogeneous then fill with zeros
                   if (iter->isHomogeneous())
                   {
-                    rhsVals.setZero(u.dim(), md.points.size());
+                    rhsVals.setZero((com==-1) ? u.dim() : 1, md.points.size());
                   }
                   else
                   {


### PR DESCRIPTION
A problem that I found via the unit tests of [`gsKLShell`](https://github.com/gismo/gsKLShell).

If we have a homogeneous boundary condition applied to a component `!=1`, e.g.
```
bc.addCondition(boundary::south, condition_type::dirichlet, 0, 0, false, 0 );
```
the assertion in  [`gsDirichletValues` line 386](https://github.com/gismo/gismo/blob/5d90b3398b01a1b08be72e0c77827e6a601d7541/src/gsAssembler/gsDirichletValues.h#L386) is triggered, since the RHS is resized to `u.dim()` in [`gsDirichletValues` line 370](https://github.com/gismo/gismo/blob/5d90b3398b01a1b08be72e0c77827e6a601d7541/src/gsAssembler/gsDirichletValues.h#L370).

The problem is that `rhsVals` should have `u.dim()` rows if and only if `com==-1`.

-------

NEW:

IMPROVED: 

FIXED: 
`gsDirichletValues.h`, resize of `rhsVals` for homogeneous components.
API:
