### PR TITLE
Add a function that outputs matrices as .csv files. 

### DIFF
--- a/examples/inputOutput_example.cpp
+++ b/examples/inputOutput_example.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
     if ( output.empty() )
     {
         gsInfo << "Call program with option -o <basename> to write data to files\n";
-        gsInfo << "<basename>Paraview.vtp, <basename>Paraview.pvd, <basename>.xml\n";
+        gsInfo << "<basename>Paraview.vtp, <basename>Paraview.pvd, <basename>.xml, <basename>ControlPoints.csv\n";
         return EXIT_SUCCESS;
     }
 
@@ -81,6 +81,15 @@ int main(int argc, char* argv[])
     fd.save(output);
     gsInfo << "Wrote G+Smo file:     " << output << ".xml \n";
     //! [Write geometry]
+
+    //! [Write control points to .csv]
+    // writing a .csv file
+    if (pGeom->targetDim()==2)
+        gsWriteCsv(output+".csv", pGeom->coefs(), {"X","Y"});
+    else if (pGeom->targetDim()==3)
+        gsWriteCsv(output+".csv", pGeom->coefs(), {"X","Y","Z"});
+    gsInfo << "Wrote CSV file:       " << output+".csv \n";
+    //! [Write control points to .csv]
 
     return EXIT_SUCCESS;
 }

--- a/src/gismo.h
+++ b/src/gismo.h
@@ -207,6 +207,7 @@ namespace internal
 #include <gsIO/gsReadFile.h>
 #include <gsUtils/gsPointGrid.h>
 #include <gsIO/gsXmlUtils.h>
+#include <gsIO/gsCsv.h>
 
 /* ----------- Parallel ----------- */
 #include <gsParallel/gsMpi.h>

--- a/src/gsIO/gsCsv.h
+++ b/src/gsIO/gsCsv.h
@@ -1,0 +1,53 @@
+/** @file gsWriteParaview.h
+
+    @brief Provides declaration of functions writing .csv files.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): C. Karampatzakis
+*/
+
+#include <gsCore/gsForwardDeclarations.h>
+
+#include <fstream>
+
+#pragma once
+
+
+namespace gismo {
+
+
+template<class T>
+void gsWriteCsv(std::string const & filename, const gsMatrix<T> & matrix, const std::vector<std::string> & headers = std::vector<std::string>() )
+{
+    // Define format of .csv file.
+    const static gsEigen::IOFormat CSVFormat(gsEigen::FullPrecision, gsEigen::Aligned, ", ", "\n");
+
+    std::ofstream csv_file;
+    csv_file.open(filename);
+    GISMO_ASSERT( (headers.empty() ||  headers.size() == matrix.cols()), "The column headers should be as many as the columns of the matrix provided." );
+
+    // If column headers are provided, write to file
+    if (! headers.empty())
+    {
+        for ( index_t j=0 ; j <  headers.size() ; j++)
+        {
+            csv_file << headers[j];
+            if (headers.size()-1 == j) 
+                csv_file << CSVFormat.rowSeparator;
+            else
+                csv_file << CSVFormat.coeffSeparator ;
+        }
+    }
+    // write matrix entries to file 
+    csv_file << matrix.format(CSVFormat);
+    csv_file.close();
+}
+
+
+
+} // namespace gismo

--- a/src/gsIO/gsCsv.h
+++ b/src/gsIO/gsCsv.h
@@ -1,6 +1,6 @@
-/** @file gsWriteParaview.h
+/** @file gsCsv.h
 
-    @brief Provides declaration of functions writing .csv files.
+    @brief Provides functions writing .csv files.
 
     This file is part of the G+Smo library. 
 
@@ -20,7 +20,13 @@
 
 namespace gismo {
 
-
+/// @brief Export a \a gsMatrix to a .csv (comma separated values) file
+/// @tparam T 
+/// @param filename path of output file
+/// @param matrix a \a gsMatrix to be written to the file
+/// @param headers optionally, a vector of strings to be used as column headers 
+///
+/// \ingroup IO
 template<class T>
 void gsWriteCsv(std::string const & filename, const gsMatrix<T> & matrix, const std::vector<std::string> & headers = std::vector<std::string>() )
 {
@@ -47,7 +53,6 @@ void gsWriteCsv(std::string const & filename, const gsMatrix<T> & matrix, const 
     csv_file << matrix.format(CSVFormat);
     csv_file.close();
 }
-
 
 
 } // namespace gismo


### PR DESCRIPTION
## NEW:
- Pretty much as the title says, a function that exports `gsMatrix` as `.csv` files has been added.
- Optionally column headers can be specified

IMPROVED:
- (my quality of life)
- `inputOutput_example.cpp` now also exports the geometry's coefficients to a `.csv` file, as an example.

FIXED: ...
API:...


# Please consider the following checklist before issuing a pull request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [x] Have you documented any new codes using Doxygen comments?
- [x] Have you written new tests or examples for your changes? 
-----