### PR TITLE
Installs a simple pkg-config file.

### DIFF
--- a/cmake/gsInstall.cmake
+++ b/cmake/gsInstall.cmake
@@ -178,13 +178,13 @@ endif(GISMO_BUILD_LIB)
 # Install pkg-config file
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   # FreeBSD uses ${PREFIX}/libdata/pkgconfig
-  set(GISMO_PKGCONFIG_INSTALLDIR "libdata/pkgconfig")
+  set(GISMO_PKGCONFIG_INSTALL_DIR "libdata/pkgconfig")
 else()
-  set(GISMO_PKGCONFIG_INSTALLDIR "${LIB_INSTALL_DIR}/pkgconfig")
+  set(GISMO_PKGCONFIG_INSTALL_DIR "${LIB_INSTALL_DIR}/pkgconfig")
 endif()
 
 install(FILES "${PROJECT_BINARY_DIR}/gismo.pc"
-  DESTINATION "${GISMO_PKGCONFIG_INSTALLDIR}/"
+  DESTINATION "${GISMO_PKGCONFIG_INSTALL_DIR}/"
   RENAME "${PROJECT_NAME}.pc")
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/cmake/ofa"

--- a/cmake/gsInstall.cmake
+++ b/cmake/gsInstall.cmake
@@ -163,9 +163,22 @@ install(FILES
 #install(EXPORT gismoTargets DESTINATION
 #  "${CMAKE_INSTALL_DIR}" COMPONENT devel)
 
+# Produce pkg-config file
+configure_file ("${PROJECT_SOURCE_DIR}/gismo_lib.pc.in"
+                "${PROJECT_BINARY_DIR}/gismo.pc" @ONLY)
+
 else(GISMO_BUILD_LIB)
-   message ("Configure with -DGISMO_BUILD_LIB=ON to compile the library")
+  message ("Configure with -DGISMO_BUILD_LIB=ON to compile the library")
+
+# Produce pkg-config file
+  configure_file ("${PROJECT_SOURCE_DIR}/gismo_nolib.pc.in"
+                  "${PROJECT_BINARY_DIR}/gismo.pc" @ONLY)
 endif(GISMO_BUILD_LIB)
+
+# Install pkg-config file
+install(FILES "${PROJECT_BINARY_DIR}/gismo.pc"
+  DESTINATION "lib/pkgconfig/"
+  RENAME "${PROJECT_NAME}.pc")
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/cmake/ofa"
         COMPONENT devel

--- a/cmake/gsInstall.cmake
+++ b/cmake/gsInstall.cmake
@@ -176,8 +176,15 @@ else(GISMO_BUILD_LIB)
 endif(GISMO_BUILD_LIB)
 
 # Install pkg-config file
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  # FreeBSD uses ${PREFIX}/libdata/pkgconfig
+  set(GISMO_PKGCONFIG_INSTALLDIR "libdata/pkgconfig")
+else()
+  set(GISMO_PKGCONFIG_INSTALLDIR "${LIB_INSTALL_DIR}/pkgconfig")
+endif()
+
 install(FILES "${PROJECT_BINARY_DIR}/gismo.pc"
-  DESTINATION "${LIB_INSTALL_DIR}/pkgconfig/"
+  DESTINATION "${GISMO_PKGCONFIG_INSTALLDIR}/"
   RENAME "${PROJECT_NAME}.pc")
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/cmake/ofa"

--- a/cmake/gsInstall.cmake
+++ b/cmake/gsInstall.cmake
@@ -177,7 +177,7 @@ endif(GISMO_BUILD_LIB)
 
 # Install pkg-config file
 install(FILES "${PROJECT_BINARY_DIR}/gismo.pc"
-  DESTINATION "lib/pkgconfig/"
+  DESTINATION "${LIB_INSTALL_DIR}/pkgconfig/"
   RENAME "${PROJECT_NAME}.pc")
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/cmake/ofa"

--- a/gismo_lib.pc.in
+++ b/gismo_lib.pc.in
@@ -1,0 +1,12 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${prefix}/@LIB_INSTALL_DIR@
+includedir=${prefix}/@INCLUDE_INSTALL_DIR@
+project_name=@PROJECT_NAME@
+
+Name: G+Smo
+Description: G+Smo (Geometry + Simulation Modules, pronounced "gismo") is an open-source C++ library that brings together mathematical tools for geometric design and numerical simulation.
+URL: https://gismo.github.io/
+Version: @gismo_VERSION@
+Libs: -L${libdir} -l${project_name}
+Cflags: -I${includedir} -I${includedir}/${project_name}

--- a/gismo_nolib.pc.in
+++ b/gismo_nolib.pc.in
@@ -1,0 +1,11 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${prefix}/@LIB_INSTALL_DIR@
+includedir=${prefix}/@INCLUDE_INSTALL_DIR@
+project_name=@PROJECT_NAME@
+
+Name: G+Smo
+Description: G+Smo (Geometry + Simulation Modules, pronounced "gismo") is an open-source C++ library that brings together mathematical tools for geometric design and numerical simulation.
+URL: https://gismo.github.io/
+Version: @gismo_VERSION@
+Cflags: -I${includedir} -I${includedir}/${project_name}


### PR DESCRIPTION
NEW: Installs a pkg-config file to be used by build systems that are not cmake.

FIXED: https://github.com/gismo/gismo/issues/734

A `gismo.pc` file is installed to `lib/pkgconfig/`.
In meson, for example, in order to compile and link to an installed G+Smo package, you just have to add `dependency('gismo')` to your list of dependencies.