### PR TITLE
Update gsSysInfo.cpp

### DIFF
--- a/src/gsCore/gsSysInfo.cpp
+++ b/src/gsCore/gsSysInfo.cpp
@@ -18,6 +18,9 @@
 
 #if defined(_WIN32) || defined(_WIN64)
 #   include <windows.h>
+#ifdef __MINGW32__
+#   include <intrin.h>
+#endif
 #elif __APPLE__
 #   include <sys/utsname.h>
 #   include <sys/sysctl.h>


### PR DESCRIPTION
I added the include intrin.h for the MinGW compiler on Windows


FIXED: Included intrin.h for MinGW compiler 
Fixes #733 


