### PR TITLE
Add character replacement for sub-modules with special characters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,8 +297,11 @@ foreach(gssm ${GISMO_OPTIONAL})
   string(STRIP ${gssm} SUBMODULE)
   #message("Fetch ${SUBMODULE}")
   gismo_fetch_module(${SUBMODULE})
-  set(CONFIGEXT_H "${CONFIGEXT_H}#define ${SUBMODULE}_ENABLED\n")
+  # Prevent special characters to be used in the variable name
+  string(REGEX REPLACE ["\.\,\!\@\#\$\%\^\&\*\+\-\="] "_" SUBMODULE_NAME ${SUBMODULE})
+  set(CONFIGEXT_H "${CONFIGEXT_H}#define ${SUBMODULE_NAME}_ENABLED\n")
 endforeach()
+
 foreach(gssm ${GISMO_EXTERNALS})
   string(STRIP ${gssm} EXTMOD)
   #message("Fetch ext: ${EXTMOD}")


### PR DESCRIPTION
Add character replacement for sub-modules with special characters in their name (e.g. Gismo.jl), such that their `submodule_ENABLED` flag is assigned correctly. Before, adding the submodule `Gismo.jl` in `GISMO_OPTIONAL` would give a warning on the name of the flag `Gismo.jl_ENABLED`.
This PR replaces `Gismo.jl_ENABLED` with `Gismo_jl_ENABLED`. In a broader sense, it replaces special characters with the `_`.

-------

The commit description must be structured as a list follows:

NEW: 
IMPROVED: 
FIXED:
Add character replacement for sub-modules with special characters (CMakeLists.txt)
API: