### PR TITLE
Add cast operators to DScalar1 and DScalar2 types

### DIFF
--- a/external/exprtk.hpp
+++ b/external/exprtk.hpp
@@ -29189,7 +29189,7 @@ namespace exprtk
               (vector_size <= T(0)) ||
               std::not_equal_to<T>()
               (T(0),vector_size - details::numeric::trunc(vector_size)) ||
-              (static_cast<std::size_t>(details::numeric::to_int32(vector_size)) > max_vector_size)
+              (static_cast<std::size_t>(vector_size) > max_vector_size)
             )
          {
             set_error(make_error(
@@ -29205,7 +29205,7 @@ namespace exprtk
 
          typename symbol_table_t::vector_holder_ptr vec_holder = typename symbol_table_t::vector_holder_ptr(0);
 
-         const std::size_t vec_size = static_cast<std::size_t>( details::numeric::to_int32(vector_size));
+         const std::size_t vec_size = static_cast<std::size_t>(details::numeric::to_int32(vector_size));
 
          scope_element& se = sem_.get_element(vec_name);
 

--- a/external/gsAutoDiff.h
+++ b/external/gsAutoDiff.h
@@ -466,6 +466,9 @@ public:
     friend bool operator==(const Scalar s1, const DScalar1 & s2) { return  s1 == s2.value; }
     friend bool operator!=(const Scalar s1, const DScalar1 & s2) { return  s1 != s2.value; }
 
+    template <typename T>
+    inline operator T() const { return static_cast<T>(value); }
+
     /// @}
     // ======================================================================
 
@@ -1081,6 +1084,9 @@ public:
     friend bool operator<=(const Scalar s1, const DScalar2 & s2) { return  s1 <= s2.value; }
     friend bool operator==(const Scalar s1, const DScalar2 & s2) { return  s1 == s2.value; }
     friend bool operator!=(const Scalar s1, const DScalar2 & s2) { return  s1 != s2.value; }
+
+    template <typename T>
+    inline operator T() const { return static_cast<T>(value); }
 
     /// @}
     // ======================================================================


### PR DESCRIPTION
This should cleanly resolve the compilation diagnostic seen due to the lack of conversion operator on the DScalar1/2 types.

PR also reverts the previous change to ExprTk from the following commit: https://github.com/gismo/gismo/commit/64b6edaea7c946a13972c71a5aefd10d1bf2a889

