### PR TITLE
Tiny PR removing some warnings, prints and errors

### DIFF
--- a/src/gsAssembler/gsBiharmonicExprAssembler.hpp
+++ b/src/gsAssembler/gsBiharmonicExprAssembler.hpp
@@ -603,9 +603,6 @@ void gsBiharmonicExprAssembler<T>::_getDirichletNeumannValuesL2Projection(
                                                                         const expr::gsFeSpace<T> & u
                                                                         )
 {
-    gsDebugVar(bc.dirichletSides().size());
-    gsDebugVar(bc.neumannSides().size());
-
     if (bc.dirichletSides().size()==0 && bc.neumannSides().size()==0)
         return;
     if (const gsMappedBasis<2,T> * bb2 = dynamic_cast<const gsMappedBasis<2,T> *>(&spaceBasis))

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -1020,6 +1020,7 @@ std::map< std::array<size_t, 4>, internal::ElementBlock> gsMultiPatch<T>::Bezier
     for (size_t p=0; p<nPatches(); ++p)
     {
         gsBasis<T> * basis = & patch(p).basis();
+        // index_t NN; // Number of control points of the Bezier element // @hverhelst this is not used anywhere
 
         // Create the Bezier Basis
         gsKnotVector<T> kv1;
@@ -1036,7 +1037,7 @@ std::map< std::array<size_t, 4>, internal::ElementBlock> gsMultiPatch<T>::Bezier
         typename gsNewtonCotesRule<T>::uPtr QuRule;
         QuRule = gsNewtonCotesRule<T>::make(numNodes);
 
-        // Initialize an iterator over all the elements of the given basi
+        // Initialize an iterator over all the elements of the given basis
         typename gsBasis<T>::domainIter domIt = basis->makeDomainIterator();
 
 
@@ -1059,7 +1060,7 @@ std::map< std::array<size_t, 4>, internal::ElementBlock> gsMultiPatch<T>::Bezier
             key[1] = basis->degree(0);
             key[2] = basis->degree(1);
             key[3] = 0; // TODO: if implemented for trivariates fix this
-            NN = localActives.size();
+            // NN = localActives.size(); // @hverhelst: this is not used anywhere
             ElementBlocks[key].numElements += 1;                  // Increment the Number of Elements contained in the ElementBlock
             ElementBlocks[key].actives.push_back(globalActives);  // Append the active basis functions ( = the Node IDs ) for this element.
             ElementBlocks[key].PR = basis->degree(0);

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -494,7 +494,7 @@ void gsMultiPatch<T>::fixOrientation()
           it != m_patches.end(); ++it )
         if ( -1 == (*it)->orientation() )
             (*it)->toggleOrientation();
-    
+
     if (this->nInterfaces() || this->nBoundary() )
         this->computeTopology();
 }
@@ -1011,7 +1011,6 @@ std::map< std::array<size_t, 4>, internal::ElementBlock> gsMultiPatch<T>::Bezier
     // of each Bezier element
     std::map<std::array<size_t, 4>, internal::ElementBlock> ElementBlocks;
 
-    index_t NN; // Number of control points of the Bezier element
     gsMatrix<index_t> localActives, globalActives; // Active basis functions
     gsDofMapper mapper = getMapper((T)1e-7);
 
@@ -1030,7 +1029,7 @@ std::map< std::array<size_t, 4>, internal::ElementBlock> gsMultiPatch<T>::Bezier
         gsTensorBSplineBasis<2,T> bezBasis(kv1,kv2);
         gsMatrix<> res;
 
-        // Initialize the quadrature rule that will be used for fitting 
+        // Initialize the quadrature rule that will be used for fitting
         // the given basis with the Bezier basis
         gsVector<index_t, 2> numNodes;
         numNodes << basis->degree(0)+1, basis->degree(1)+1 ;
@@ -1069,7 +1068,7 @@ std::map< std::array<size_t, 4>, internal::ElementBlock> gsMultiPatch<T>::Bezier
 
             // Map the quadrature points to the current element.
             QuRule->mapTo( domIt->lowerCorner(), domIt->upperCorner(), quPoints, quWeights);
-            basis->source().eval_into(quPoints, values); // Evaluate given basis at the mapped quadrature points 
+            basis->source().eval_into(quPoints, values); // Evaluate given basis at the mapped quadrature points
             // Append the local Bezier Extraction matrix to the ElementBlock.coefVectors
             ElementBlocks[key].coefVectors.push_back(solver.solve(values.transpose()).transpose());
         }
@@ -1079,7 +1078,7 @@ std::map< std::array<size_t, 4>, internal::ElementBlock> gsMultiPatch<T>::Bezier
 }
 
 
-template<class T> 
+template<class T>
 gsMultiPatch<T> gsMultiPatch<T>::extractBezier() const
 {
     GISMO_ENSURE( 2==domainDim(), "Anything other than bivariate splines is not yet supported!");
@@ -1096,7 +1095,7 @@ gsMultiPatch<T> gsMultiPatch<T>::extractBezier() const
     globalWeights.setOnes();
 
     // Loop over all patches
-    for (index_t p = 0; p != this->nPatches(); p++)
+    for (size_t p = 0; p != this->nPatches(); p++)
     {
         for (index_t i=0; i != this->patch(p).coefs().rows(); ++i) // For every control point
         {
@@ -1111,7 +1110,7 @@ gsMultiPatch<T> gsMultiPatch<T>::extractBezier() const
     {
         internal::ElementBlock ElBlock = pair.second;
 
-        gsKnotVector<> kv1(0,1,0,ElBlock.PR+1); 
+        gsKnotVector<> kv1(0,1,0,ElBlock.PR+1);
         gsKnotVector<> kv2(0,1,0,ElBlock.PS+1);
         // coefs.setZero( (ElBlock.PR+1)*(ElBlock.PS+1), controlPoints.cols()-1 );
 
@@ -1143,6 +1142,6 @@ gsMultiPatch<T> gsMultiPatch<T>::extractBezier() const
     }
 
     // result.computeTopology();
-    return result; 
+    return result;
 }
 } // namespace gismo

--- a/src/gsCore/gsRationalBasis.h
+++ b/src/gsCore/gsRationalBasis.h
@@ -215,7 +215,7 @@ public:
         typename SourceBasis::GeometryType tmp(*m_src,give(m_weights));
         tmp.degreeElevate(i,dir);
         tmp.coefs().swap(m_weights);
-        std::swap(*m_src, tmp.basis() );
+        m_src->swap(tmp.basis());
     }
 
     // todo (HV): test!!
@@ -224,7 +224,7 @@ public:
         typename SourceBasis::GeometryType tmp(*m_src, give(m_weights));
         tmp.degreeIncrease(i,dir);
         tmp.coefs().swap(m_weights);
-        std::swap(*m_src, tmp.basis() );
+        m_src->swap(tmp.basis());
     }
 
     void degreeReduce(short_t const& i = 1, short_t const dir = -1)
@@ -232,7 +232,7 @@ public:
         typename SourceBasis::GeometryType tmp(*m_src, give(m_weights));
         tmp.degreeReduce(i,dir);
         tmp.coefs().swap(m_weights);
-        std::swap(*m_src, tmp.basis() );
+        m_src->swap(tmp.basis());
     }
 
     void degreeDecrease(short_t const& i = 1, short_t const dir = -1)
@@ -240,7 +240,7 @@ public:
         typename SourceBasis::GeometryType tmp(*m_src, give(m_weights));
         tmp.degreeDecrease(i,dir);
         tmp.coefs().swap(m_weights);
-        std::swap(*m_src, tmp.basis() );
+        m_src->swap(tmp.basis());
     }
 
     /* if ever be reused, change to actual and current GISMO_UPTR_FUNCTION stuff und uPtr


### PR DESCRIPTION
Fix some small problems appearing when compiling `gsUnstructuredSplines`

NEW: 

IMPROVED: 
- Remove warnings in `gsMultiPatch`
- Remove `gsDebugVar` in `gsBiharmonicExprAssembler`
 
FIXED:
- `swap` in `gsRationalBasis`: See [this](https://cdash-ci.irisa.fr/viewBuildError.php?buildid=137728) compilation error in Windows (appeared in [gsUnstructuredSplines](https://github.com/gismo/gsUnstructuredSplines/pull/23))

API:
