### PR TITLE
Fixed bug in Python bindings

### DIFF
--- a/src/gsCore/gsMultiPatch_.cpp
+++ b/src/gsCore/gsMultiPatch_.cpp
@@ -32,7 +32,7 @@ namespace gismo
       .def("addPatch", static_cast<index_t (Class::*)(   const gsGeometry<real_t> &    )> (&Class::addPatch), "Adds a patch")
 
       .def("degreeElevate", &Class::degreeElevate, "Elevates the degree", py::arg("elevationSteps")=1, py::arg("dir")=-1)
-      .def("uniformRefine", &Class::uniformRefine, "Refines uniformly"  , py::arg("numKnots")=1 , py::arg("mul")=1)
+      .def("uniformRefine", &Class::uniformRefine, "Refines uniformly"  , py::arg("numKnots")=1 , py::arg("mul")=1, py::arg("dir")=-1)
 
       .def("basis", static_cast<gsBasis<real_t> & (Class::*)(const size_t) const> ( &Class::basis), "Access the i-th basis of the multipatch",py::return_value_policy::reference)
 


### PR DESCRIPTION
This commit fixes the bug introduced when adding the `dir` parameter to the multi-patch `uniformRefine` function