### PR TITLE
Small PR: Docs in Light Mode

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -41,6 +41,7 @@ if(DOXYGEN_FOUND)
   #set(GISMO_DOXY_INPUT                    " \"${gismo_SOURCE_DIR}/doc\" \"${gismo_SOURCE_DIR}/optional\" ")
   set(IMAGE_PATH        "\"${gismo_SOURCE_DIR}/doc/figs\"")
   set(GISMO_DOXY_EXCLUDE                    "\"${gismo_SOURCE_DIR}/external\" ${IMAGE_PATH} ")
+  set(GISMO_DOXY_HTML_COLORSTYLE      "LIGHT") #220
   set(GISMO_DOXY_HTML_COLORSTYLE_HUE      "120") #220
   set(GISMO_DOXY_HTML_COLORSTYLE_SAT      "100") #100
   set(GISMO_DOXY_HTML_COLORSTYLE_GAMMA    "100")  # 80

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1128,6 +1128,17 @@ HTML_EXTRA_STYLESHEET  =
 
 HTML_EXTRA_FILES       = "${gismo_SOURCE_DIR}/doc/gismodoxy.css"
 
+# The HTML_COLORSTYLE tag can be used to specify if the generated HTML output
+# should be rendered with a dark or light theme. Possible values are: LIGHT 
+# always generates light mode output, DARK always generates dark mode output,
+# AUTO_LIGHT automatically sets the mode according to the user preference, uses
+# light mode if no preference is set (the default), AUTO_DARK automatically sets
+# the mode according to the user preference, uses dark mode if no preference is
+# set and TOGGLE allows a user to switch between light and dark mode via a button.
+# The default value is: AUTO_LIGHT.
+
+HTML_COLORSTYLE    = ${GISMO_DOXY_HTML_COLORSTYLE}
+
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the stylesheet and background images according to
 # this color. Hue is specified as an angle on a colorwheel, see


### PR DESCRIPTION
# IMPROVED:
- Doxygen by default renders the documentation in different colors depending on the user's system setting. This PR makes sure the documentation is always rendered in light mode, which more readable.



# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
