### PR TITLE
Add __str__ methods to pybind11 classes

### DIFF
--- a/doc/Python_pybind11_interface.dox
+++ b/doc/Python_pybind11_interface.dox
@@ -21,7 +21,7 @@ pip install wheel_file.whl
 Alternative to installing pygismo from a pre-compiled wheel via pip, one can compile pygismo locally:
 ~~~~{.sh}
 cd /path/to/build
-cmake . -DGISMO_WITH_PYBIND=ON -Dpybind11_DIR=path/to/pybind11 -DPYBIND11_PYTHON_VERSION=<your python version>
+cmake . -DGISMO_WITH_PYBIND11=ON -Dpybind11_DIR=path/to/pybind11 -DPYBIND11_PYTHON_VERSION=<your python version>
 make pygismo
 ~~~~
 Then, in your Python file, you can import pygismo as follows:

--- a/src/gsCore/gsBoxTopology.cpp
+++ b/src/gsCore/gsBoxTopology.cpp
@@ -31,6 +31,14 @@ namespace gismo
       .def(py::init<>())
       .def("boundaries", static_cast<std::vector< patchSide >& (Class::*)()> (&Class::boundaries))
       .def("interfaces", static_cast<std::vector< boundaryInterface >& (Class::*)()> (&Class::interfaces))
+      .def("__str__",
+         [] (Class & self)
+        {
+            std::ostringstream os;
+            self.print(os);
+            return os.str();
+        },
+        "Returns a string with information about the object.")
 
       ;
   }

--- a/src/gsCore/gsDofMapper_.cpp
+++ b/src/gsCore/gsDofMapper_.cpp
@@ -97,7 +97,14 @@ void pybind11_init_gsDofMapper(py::module &m)
     .def("patchSize", &Class::patchSize, "Returns the total number of patch-local DoFs that live on patch \a k for component \a c")
     .def("totalSize", &Class::totalSize, "Returns the total size of the mapper")
     .def("indexOnPatch", &Class::indexOnPatch, "For \a gl being a global index, this function returns true whenever \a gl corresponds to patch \a k")
-    ;
+    .def("__str__",
+         [] (Class & self)
+        {
+            std::ostringstream os;
+            self.print(os);
+            return os.str();
+        },
+        "Returns a string with information about the object.");
 }
 #endif
 }

--- a/src/gsCore/gsFunctionSet_.cpp
+++ b/src/gsCore/gsFunctionSet_.cpp
@@ -40,6 +40,14 @@ void pybind11_init_gsFunctionSet(py::module &m)
   .def("evalAllDers", &Class::evalAllDers, "Evaluates all derivatives upto certien order into a vector of matrices")
   .def("domainDim", &Class::domainDim, "Returns the domain dimension")
   .def("targetDim", &Class::targetDim, "Returns the target dimension")
+  .def("__str__",
+         [] (Class & self)
+        {
+            std::ostringstream os;
+            self.print(os);
+            return os.str();
+        },
+        "Returns a string with information about the object.")
 
   ;
 }

--- a/src/gsNurbs/gsKnotVector_.cpp
+++ b/src/gsNurbs/gsKnotVector_.cpp
@@ -49,6 +49,13 @@ void pybind11_init_gsKnotVector(py::module &m)
     .def("inDomain", &Class::inDomain, "Checks, whether the given value is inside the domain")
     .def("greville",static_cast<gsMatrix<real_t>
          (Class::*)(void) const>(&Class::greville), "Returns the Greville points")
+     .def("__str__", [] (Class & self)
+     {
+         std::ostringstream os;
+         self.print(os);
+         return os.str();
+     },
+     "Returns a string with information about the object.")
     ;
 }
 #endif


### PR DESCRIPTION
We add a `__str__` method to the pybind11 bindings for some classes. This enables printing these objects in python just like we do in C++.

# The commit description must be structured as a list follows:


IMPROVED: Add __str__ method to python classes
FIXED: fix typo in pybind11 binding documentation