### PR TITLE
typos

### DIFF
--- a/src/gsAssembler/gsSparseSystem.h
+++ b/src/gsAssembler/gsSparseSystem.h
@@ -84,7 +84,7 @@ public:
     { }
 
     /**
-     * @brief gsSparseSystem Constuctor for the sparse System only considering one block (scalar equation),
+     * @brief gsSparseSystem Constructor for the sparse System only considering one block (scalar equation),
      * described by the one DofMapper \a mapper.
      * @param[in] mapper the one DofMapper discribing the discretization.
      */

--- a/src/gsHSplines/gsHBSpline.h
+++ b/src/gsHSplines/gsHBSpline.h
@@ -79,7 +79,7 @@ public:
 
 public:
 
-    /// Constucts an isoparametric slice of this HBSpline by fixing
+    /// Constructs an isoparametric slice of this HBSpline by fixing
     /// \a par in direction \a dir_fixed. The resulting HBSpline has
     /// one less dimension and is given back in \a result.
     void slice(index_t dir_fixed,T par,BoundaryGeometryType & result) const

--- a/src/gsHSplines/gsTHBSpline.h
+++ b/src/gsHSplines/gsTHBSpline.h
@@ -123,7 +123,7 @@ private:
 
 public:
 
-    /// Constucts an isoparametric slice of this THBSpline by fixing
+    /// Constructs an isoparametric slice of this THBSpline by fixing
     /// \a par in direction \a dir_fixed. The resulting THBSpline has
     /// one less dimension and is given back in \a result.
     void slice(index_t dir_fixed,T par,BoundaryGeometryType & result) const;

--- a/src/gsMatrix/gsMatrixBlockView.h
+++ b/src/gsMatrix/gsMatrixBlockView.h
@@ -120,7 +120,7 @@ public:
         }
     }
 
-    /// Combatibility constuctor giving the \a matrix as a block
+    /// Combatibility constructor giving the \a matrix as a block
     gsMatrixBlockView(const MatrixType & matrix)
     : m_rowSize(1),
       m_colSize(1)

--- a/src/gsNurbs/gsTensorNurbs.h
+++ b/src/gsNurbs/gsTensorNurbs.h
@@ -303,7 +303,7 @@ public:
         tbsbasis.component(k).reverse();
     }
 
-    /// Constucts an isoparametric slice of this tensor Nurbs curve by fixing
+    /// Constructs an isoparametric slice of this tensor Nurbs curve by fixing
     /// \a par in direction \a dir_fixed. The resulting tensor Nurbs has
     /// one less dimension and is given back in \a result.
     void slice(index_t dir_fixed, T par, BoundaryGeometryType & result) const


### PR DESCRIPTION
I simply noted that a few times "construct..." missed an "r" in the descriptions