### PR TITLE
Add option to enable/disable SAME_ELEMENT flag

### DIFF
--- a/examples/gsExpressions_test.cpp
+++ b/examples/gsExpressions_test.cpp
@@ -13,8 +13,6 @@
 
 #include <gismo.h>
 
-#include <gsAssembler/gsExprEvaluator.h>
-
 using namespace gismo;
 
 int main(int argc, char *argv[])

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -801,6 +801,7 @@ gsOptionList gsExprAssembler<T>::defaultOptions()
     opt.addSwitch("overInt", "Apply over-integration on boundary elements or not?", false);
     opt.addSwitch("flipSide", "Flip side of interface where integration is performed.", false);
     opt.addSwitch("movingInterface", "Used in interface assembly when interface is not stationary.", false);
+    opt.addSwitch("SameElement","Activates optimization if all quadrature points are located in the same element", true);
     return opt;
 
     /// dirichlet treatment? elimination ????
@@ -1090,7 +1091,7 @@ void gsExprAssembler<T>::assemble(const expr &... args)
 {
     auto arg_tpl = std::make_tuple(args...);
     m_exprdata->parse(arg_tpl);
-    m_exprdata->activateFlags(SAME_ELEMENT);
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
     //op_tuple(__printExpr(), arg_tpl);
 
     // check if the expression is a matrix, therefore being modified
@@ -1157,7 +1158,7 @@ void gsExprAssembler<T>::assembleBdr(const bcRefList & BCs, expr&... args)
 // #   endif
     auto arg_tpl = std::make_tuple(args...);
     m_exprdata->parse(arg_tpl);
-    m_exprdata->activateFlags(SAME_ELEMENT);
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
 
     typename gsQuadRule<T>::uPtr QuRule; // Quadrature rule
 
@@ -1272,7 +1273,7 @@ void gsExprAssembler<T>::assembleIfc(const ifContainer & iFaces, expr... args)
     auto arg_tpl = std::make_tuple(args...);
 
     m_exprdata->parse(arg_tpl);
-    m_exprdata->activateFlags(SAME_ELEMENT); //note: SAME_ELEMENT is 0 at the opposite/mirrored patch
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT); //note: SAME_ELEMENT is 0 at the opposite/mirrored patch
 
     typename gsQuadRule<T>::uPtr QuRule;
 
@@ -1351,7 +1352,7 @@ void gsExprAssembler<T>::assembleJacobian(const expr residual, solution & u)
 #pragma omp parallel
 {
     m_exprdata->parse(residual, u);
-    m_exprdata->activateFlags(SAME_ELEMENT);
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
     //op_tuple(__printExpr(), arg_tpl);
 
     m_modified = true;
@@ -1401,7 +1402,7 @@ void gsExprAssembler<T>::assembleJacobianIfc(const ifContainer & iFaces,
     // clearMatrix();
 
     m_exprdata->parse(residual, u);
-    m_exprdata->activateFlags(SAME_ELEMENT);
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
     //op_tuple(__printExpr(), arg_tpl);
 
     typename gsQuadRule<T>::uPtr QuRule; // Quadrature rule

--- a/src/gsAssembler/gsExprEvaluator.h
+++ b/src/gsAssembler/gsExprEvaluator.h
@@ -457,7 +457,7 @@ T gsExprEvaluator<T>::compute_impl(const expr::_expr<E> & expr)
 #endif
         auto _arg = expr.val();
         m_exprdata->parse(_arg);
-        m_exprdata->activateFlags(SAME_ELEMENT);
+        if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
 
         // Computed value on element
         T elVal;
@@ -519,7 +519,7 @@ T gsExprEvaluator<T>::computeBdr_impl(const expr::_expr<E> & expr,
     gsQuadRule<T> QuRule;  // Quadrature rule
     auto _arg = expr.val();
     m_exprdata->parse(_arg);
-    m_exprdata->activateFlags(SAME_ELEMENT);
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
 
     // Computed value
     T elVal;
@@ -578,7 +578,7 @@ T gsExprEvaluator<T>::computeBdrBc_impl(const bcRefList & BCs,
     typename gsQuadRule<T>::uPtr QuRule; // Quadrature rule  ---->OUT
     auto _arg = expr.val();
     m_exprdata->parse(_arg);
-    m_exprdata->activateFlags(SAME_ELEMENT);
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
 
     // Computed value
     T elVal;
@@ -633,7 +633,7 @@ T gsExprEvaluator<T>::computeInterface_impl(const expr::_expr<E> & expr, const i
 {
     auto arg_tpl = expr.val();
     m_exprdata->parse(arg_tpl);
-    // m_exprdata->activateFlags(SAME_ELEMENT);
+    if (m_options.askSwitch("SameElement",true)) m_exprdata->activateFlags(SAME_ELEMENT);
 
     typename gsQuadRule<T>::uPtr QuRule;
     // Computed value

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -1393,12 +1393,10 @@ public:
     mutable gsMatrix<T> res;
     const gsMatrix<T> & eval(index_t k) const
     {
-        bool singleActives = (1 == _u.data().actives.cols());
-
-        res.setZero(_u.dim(), 1);
+        GISMO_ASSERT(check(), "Invalid state in gsFeSolution");
+        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
-        GISMO_ASSERT(_Sv->size()==map.freeSize(), "The solution vector has wrong dimensions: "<<_Sv->size()<<" != "<<map.freeSize());
-
+        res.setZero(_u.dim(), 1);
         for (index_t c = 0; c!=_u.dim(); c++) // for all components
         {
             for (index_t i = 0; i!=_u.data().actives.rows(); ++i)
@@ -1414,6 +1412,24 @@ public:
         return res;
     }
 
+    // Performs validity checks for the solution object
+    bool check() const
+    {
+        if ( _Sv->size()!=_u.mapper().freeSize() )
+        {
+            gsWarn<< "The solution vector has wrong dimensions: "
+                  <<_Sv->size()<<" != "<<_u.mapper().freeSize() <<". ";
+            return false;
+        }
+        if((size_t)_u.source().size()*dim()!=_u.mapper().mapSize())
+        {
+            gsWarn<< "The solution space is inconsistent: "
+                  <<_u.source().size()*dim()<<" != "<<_u.mapper().mapSize()<<". ";
+            return false;
+        }
+        return true;
+    }
+    
     //template<class U>
     //linearComb(U & ie){ sum up ie[_u] times the _Sv  }
     // ie.eval(k), _u.data().actives(), fixedPart() - see lapl_expr
@@ -2805,15 +2821,15 @@ public:
     mutable gsMatrix<T> res;
     const gsMatrix<T> & eval(index_t k) const
     {
-        GISMO_ASSERT(1==_u.data().actives.cols(), "Single actives expected");
-
-        res.setZero(_u.dim(), _u.parDim());
+        GISMO_ASSERT(_u.check(), "Invalid state in gsFeSolution");
+        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
+        res.setZero(_u.dim(), _u.parDim());
         for (index_t c = 0; c!= _u.dim(); c++)
         {
-            for (index_t i = 0; i!=_u.data().actives.size(); ++i)
+            for (index_t i = 0; i!=_u.data().actives.rows(); ++i)
             {
-                const index_t ii = map.index(_u.data().actives.at(i), _u.data().patchId,c);
+                const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, c);
                 if ( map.is_free_index(ii) ) // DoF value is in the solVector
                 {
                     res.row(c) += _u.coefs().at(ii) *
@@ -3183,10 +3199,10 @@ public:
     mutable gsMatrix<T> res;
     const gsMatrix<T> & eval(const index_t k) const
     {
-        GISMO_ASSERT(1==_u.data().actives.cols(), "Single actives expected");
-
-        res.setZero(_u.dim(), 1); //  scalar, but per component
+        GISMO_ASSERT(_u.check(), "Invalid state in gsFeSolution");
+        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
+        res.setZero(_u.dim(), 1); //  scalar, but per component
 
         index_t numActs = _u.data().values[0].rows();
         index_t numDers = _u.parDim() * (_u.parDim() + 1) / 2;
@@ -3195,7 +3211,7 @@ public:
         for (index_t c = 0; c!= _u.dim(); c++)
             for (index_t i = 0; i!=numActs; ++i)
             {
-                const index_t ii = map.index(_u.data().actives.at(i), _u.data().patchId,c);
+                const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, c);
                 deriv2 = _u.data().values[2].block(i*numDers,k,_u.parDim(),1); // this only takes d11, d22, d33 part. For all the derivatives [d11, d22, d33, d12, d13, d23]: col.block(i*numDers,k,numDers,1)
                 if ( map.is_free_index(ii) ) // DoF value is in the solVector
                     res.at(c) += _u.coefs().at(ii) * deriv2.sum();
@@ -3523,17 +3539,15 @@ public:
 
     hess_expr(const gsFeSolution<T> & u) : _u(u) { }
 
-    mutable gsMatrix<T> res;
+    mutable gsMatrix<T> deriv2, res;
     const gsMatrix<T> & eval(const index_t k) const
     {
-        GISMO_ASSERT(1==_u.data().actives.cols(), "Single actives expected. Actives: \n"<<_u.data().actives);
-
+        GISMO_ASSERT(_u.check(), "Invalid state in gsFeSolution");
+        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
-
         const index_t numActs = _u.data().values[0].rows();
         const index_t pdim = _u.parDim();
         index_t numDers = pdim*(pdim+1)/2;
-        gsMatrix<T> deriv2;
 
         // In the scalar case, the hessian is returned as a pdim x pdim matrix
         if (1==_u.dim())
@@ -3541,7 +3555,7 @@ public:
             res.setZero(numDers,1);
             for (index_t i = 0; i!=numActs; ++i)
             {
-                const index_t ii = map.index(_u.data().actives.at(i), _u.data().patchId,0);
+                const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, 0);
                 deriv2 = _u.data().values[2].block(i*numDers,k,numDers,1);
                 if ( map.is_free_index(ii) ) // DoF value is in the solVector
                     res += _u.coefs().at(ii) * deriv2;
@@ -3557,8 +3571,9 @@ public:
         {
             res.setZero(rows(), numDers);
             for (index_t c = 0; c != _u.dim(); c++)
-                for (index_t i = 0; i != numActs; ++i) {
-                    const index_t ii = map.index(_u.data().actives.at(i), _u.data().patchId, c);
+                for (index_t i = 0; i != numActs; ++i)
+                {
+                    const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, c);
                     deriv2 = _u.space().data().values[2].block(i * numDers, k, numDers,
                                                                1).transpose(); // start row, start col, rows, cols
                     if (map.is_free_index(ii)) // DoF value is in the solVector

--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -1394,14 +1394,14 @@ public:
     const gsMatrix<T> & eval(index_t k) const
     {
         GISMO_ASSERT(check(), "Invalid state in gsFeSolution");
-        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
+        auto & act = _u.data().actives.col(1 == _u.data().actives.cols() ? 0:k );
         res.setZero(_u.dim(), 1);
         for (index_t c = 0; c!=_u.dim(); c++) // for all components
         {
             for (index_t i = 0; i!=_u.data().actives.rows(); ++i)
             {
-                const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, c);
+                const index_t ii = map.index( act[i], _u.data().patchId, c);
                 if ( map.is_free_index(ii) ) // DoF value is in the solVector
                     res.at(c) += _Sv->at(ii) * _u.data().values[0](i,k);
                 else
@@ -2822,14 +2822,14 @@ public:
     const gsMatrix<T> & eval(index_t k) const
     {
         GISMO_ASSERT(_u.check(), "Invalid state in gsFeSolution");
-        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
+        auto & act = _u.data().actives.col(1 == _u.data().actives.cols() ? 0:k );
         res.setZero(_u.dim(), _u.parDim());
         for (index_t c = 0; c!= _u.dim(); c++)
         {
             for (index_t i = 0; i!=_u.data().actives.rows(); ++i)
             {
-                const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, c);
+                const index_t ii = map.index(act[i], _u.data().patchId, c);
                 if ( map.is_free_index(ii) ) // DoF value is in the solVector
                 {
                     res.row(c) += _u.coefs().at(ii) *
@@ -3200,7 +3200,6 @@ public:
     const gsMatrix<T> & eval(const index_t k) const
     {
         GISMO_ASSERT(_u.check(), "Invalid state in gsFeSolution");
-        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
         res.setZero(_u.dim(), 1); //  scalar, but per component
 
@@ -3208,10 +3207,11 @@ public:
         index_t numDers = _u.parDim() * (_u.parDim() + 1) / 2;
         gsMatrix<T> deriv2;
 
+        auto & act = _u.data().actives.col(1 == _u.data().actives.cols() ? 0:k );
         for (index_t c = 0; c!= _u.dim(); c++)
             for (index_t i = 0; i!=numActs; ++i)
             {
-                const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, c);
+                const index_t ii = map.index(act[i], _u.data().patchId, c);
                 deriv2 = _u.data().values[2].block(i*numDers,k,_u.parDim(),1); // this only takes d11, d22, d33 part. For all the derivatives [d11, d22, d33, d12, d13, d23]: col.block(i*numDers,k,numDers,1)
                 if ( map.is_free_index(ii) ) // DoF value is in the solVector
                     res.at(c) += _u.coefs().at(ii) * deriv2.sum();
@@ -3543,11 +3543,11 @@ public:
     const gsMatrix<T> & eval(const index_t k) const
     {
         GISMO_ASSERT(_u.check(), "Invalid state in gsFeSolution");
-        const bool singleActives = (1 == _u.data().actives.cols());
         const gsDofMapper & map = _u.mapper();
         const index_t numActs = _u.data().values[0].rows();
         const index_t pdim = _u.parDim();
         index_t numDers = pdim*(pdim+1)/2;
+        auto & act = _u.data().actives.col(1 == _u.data().actives.cols() ? 0:k );
 
         // In the scalar case, the hessian is returned as a pdim x pdim matrix
         if (1==_u.dim())
@@ -3555,7 +3555,7 @@ public:
             res.setZero(numDers,1);
             for (index_t i = 0; i!=numActs; ++i)
             {
-                const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, 0);
+                const index_t ii = map.index(act[i], _u.data().patchId, 0);
                 deriv2 = _u.data().values[2].block(i*numDers,k,numDers,1);
                 if ( map.is_free_index(ii) ) // DoF value is in the solVector
                     res += _u.coefs().at(ii) * deriv2;
@@ -3573,7 +3573,7 @@ public:
             for (index_t c = 0; c != _u.dim(); c++)
                 for (index_t i = 0; i != numActs; ++i)
                 {
-                    const index_t ii = map.index(_u.data().actives(i, singleActives ? 0 : k), _u.data().patchId, c);
+                    const index_t ii = map.index(act[i], _u.data().patchId, c);
                     deriv2 = _u.space().data().values[2].block(i * numDers, k, numDers,
                                                                1).transpose(); // start row, start col, rows, cols
                     if (map.is_free_index(ii)) // DoF value is in the solVector

--- a/src/gsDomain/gsTensorDomainBoundaryIterator.h
+++ b/src/gsDomain/gsTensorDomainBoundaryIterator.h
@@ -43,9 +43,7 @@ public:
     explicit gsTensorDomainBoundaryIterator(const gsTensorDomain<T,D> & domain,
                                             const boxSide & s)
     : gsDomainIterator<T>(0, s),
-      d( domain.dim() ),
-      lower  ( gsVector<T, D>::Zero(d) ),
-      upper  ( gsVector<T, D>::Zero(d) )
+      d( domain.dim() )
     {
         par = s.parameter();
         dir = s.direction();
@@ -203,9 +201,6 @@ private:
 
     // Current element as pointers to it's supporting mesh-lines
     gsVector<domainIterWrapper, D> curElement;
-
-    // parameter coordinates of current grid cell
-    gsVector<T> lower, upper;
 
 public:
 #   define Eigen gsEigen

--- a/src/gsDomain/gsTensorDomainIterator.h
+++ b/src/gsDomain/gsTensorDomainIterator.h
@@ -39,14 +39,12 @@ private:
 public:
 
     explicit gsTensorDomainIterator(const gsTensorDomain<T,D> & domain)
-    : gsDomainIterator<T>(),
-      lower  ( gsVector<T, D>::Zero(D) ),
-      upper  ( gsVector<T, D>::Zero(D) )
+    : gsDomainIterator<T>()
     {
         // compute breaks and mesh size
-        meshStart.resize(D);
-        meshEnd.resize(D);
-        curElement.resize(D);
+        // meshStart.resize(D);
+        // meshEnd.resize(D);
+        // curElement.resize(D);
 
         for (int i=0; i < D; ++i)
         {
@@ -93,6 +91,8 @@ public:
     {
         result.resize( D, 1 << D);
 
+        const gsVector<T> lower = lowerCorner();
+        const gsVector<T> upper = upperCorner();
         gsVector<T,D> v, l, u;
         l.setZero();
         u.setOnes();
@@ -107,7 +107,7 @@ public:
 
     gsVector<T> lowerCorner() const override
     {
-        gsVector<T,D> lower;
+        gsVector<T> lower(D);
         for (short_t i = 0; i < D ; ++i)
             lower[i]  = curElement[i].lowerCorner().value();
         return lower;
@@ -115,7 +115,7 @@ public:
 
     gsVector<T> upperCorner() const override
     {
-        gsVector<T,D> upper;
+        gsVector<T> upper(D);
         for (short_t i = 0; i < D ; ++i)
             upper[i]  = curElement[i].upperCorner().value();
         return upper;
@@ -139,14 +139,9 @@ public:
 
 // Data members
 private:
-    // Extent of the tensor grid
-    gsVector<domainIterWrapper, D> meshStart, meshEnd;
-
-    // Current element as pointers to it's supporting mesh-lines
-    gsVector<domainIterWrapper, D> curElement;
-
-    // parameter coordinates of current grid cell
-    gsVector<T> lower, upper;
+    // Extent of the tensor grid and current element as pointers to
+    // it's supporting mesh-lines
+    gsVector<domainIterWrapper, D> meshStart, meshEnd, curElement;
 
 public:
 #   define Eigen gsEigen


### PR DESCRIPTION
In some cases evaluations are performed on a quadrature grid which is not aligned to the element mesh of a spline.
This PR adds an option to the expressions evaluator/assembler that allows to disable the SAME_ELEMENT flag (which is activated by default).