### PR TITLE
Avoids exposing 'gismo' namespace in header file.

### DIFF
--- a/src/gsModeling/gsBarrierPatch.h
+++ b/src/gsModeling/gsBarrierPatch.h
@@ -22,8 +22,6 @@
 #include <gsHLBFGS/gsHLBFGS.h>
 #endif
 
-using namespace gismo;
-
 namespace gismo
 {
 /**


### PR DESCRIPTION
There is a `.h` file exposing the `gismo` namespace:
```cpp
using namespace gismo
```

This pollutes the global namespace when using `#include <gismo/gismo.h>`.

Now, beware that this "bug" might be relied upon! So, this fix might break people's code.