### PR TITLE
Bug in interface assembly, after the changes of #779

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -1053,8 +1053,8 @@ void gsExprAssembler<T>::_computePatternIfc(const ifContainer & iFaces, expr... 
         else
             interfaceMap = gsCPPInterface<T>::make(getGeometryMap(), iFace);
 
-        typename gsBasis<T>::domainIter domIt = basis1.domain()->subdomain(iFace.first().patch)->beginBdr(iFace.first().side());
-        typename gsBasis<T>::domainIter domItEnd = basis1.domain()->subdomain(iFace.first().patch)->endBdr(iFace.first().side());
+        typename gsBasis<T>::domainIter domIt = basis1.domain()->beginBdr(iFace.first().side());
+        typename gsBasis<T>::domainIter domItEnd = basis1.domain()->endBdr(iFace.first().side());
 
         // Start iteration over elements
         //for ( domIt.next(tid); domIt.good(); domIt.next(nt) )

--- a/src/gsCore/gsMultiPatch.h
+++ b/src/gsCore/gsMultiPatch.h
@@ -162,6 +162,8 @@ public:
 
     GISMO_CLONE_FUNCTION(gsMultiPatch)
 
+    memory::shared_ptr<gsDomain<T> > domain() const;
+
 public:
 
     /// Get a const-iterator to the patches

--- a/src/gsCore/gsMultiPatch.hpp
+++ b/src/gsCore/gsMultiPatch.hpp
@@ -21,6 +21,7 @@
 #include <gsMesh2/gsSurfMesh.h>
 #include <gsTensor/gsTensorBasis.h>
 #include <gsAssembler/gsQuadrature.h>
+#include <gsDomain/gsCompositeDomain.h>
 
 #include <gsNurbs/gsNurbsBasis.h>
 
@@ -55,6 +56,12 @@ gsMultiPatch<T>::gsMultiPatch( const gsMultiPatch& other )
     // clone all geometries
     cloneAll( other.m_patches.begin(), other.m_patches.end(),
               this->m_patches.begin());
+}
+
+template<class T>
+memory::shared_ptr<gsDomain<T> > gsMultiPatch<T>::domain() const
+{
+    return memory::make_shared( new gsCompositeDomain<T>(*this) );
 }
 
 #if EIGEN_HAS_RVALUE_REFERENCES

--- a/src/gsDomain/gsCompositeDomain.h
+++ b/src/gsDomain/gsCompositeDomain.h
@@ -135,6 +135,18 @@ public:
             m_domains[i] = multiBasis.basis(i).domain();
     }
 
+    /** @brief Constructor from a \ref gsMultipatch.
+     *
+     * @param mp The multipatch from which the domains are extracted.
+     */
+    //gsCompositeDomain(const gsFunctionSet<T> & multiBasis)
+    gsCompositeDomain(const gsMultiPatch<T> & mp)
+    : Base(), m_domains(mp.nPieces()), m_topology(&mp.topology())
+    {
+        for (index_t i = 0; i != mp.nPieces(); ++i)
+            m_domains[i] = mp.patch(i).basis().domain();
+    }
+
     // void insert(Ptr other);
 
     Ptr subdomain(index_t k) const override { return m_domains[k]; }


### PR DESCRIPTION

**FIXED**: This PR fixes a bug that occurred when using `gsExprAssembler::assembleIfc()`. It was due to some unnecessary indexing happening within `gsExprAssembler::_computePatternIfc()`.

**NEW**: A new constructor of `gsCompositeDomain` is introduced, which accepts a `gsMultiPatch`. Also the corresponding function `gsMultiPatch::domain()` is added. This can be convenient when for example setting the
integration domain of a `gsExprAssembler`, one does not need to create a "dummy" `gsMultiBasis` object just for that.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [x] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
