### PR TITLE
Fix typo in gsFiberMatrix

### DIFF
--- a/src/gsMatrix/gsFiberMatrix.h
+++ b/src/gsMatrix/gsFiberMatrix.h
@@ -134,28 +134,28 @@ public:
 
     T & coef(index_t i, index_t j)
     {
-        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && i<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
+        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && j<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
         if (!IsRowMajor) std::swap(i,j);
         return m_fibers[i]->coeff(j);
     }
 
     T & coeffRef(index_t i, index_t j)
     {
-        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && i<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
+        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && j<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
         if (!IsRowMajor) std::swap(i,j);
         return m_fibers[i]->coeffRef(j);
     }
 
     void insertExplicitZero(index_t i, index_t j)
     {
-        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && i<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
+        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && j<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
         if (!IsRowMajor) std::swap(i,j);
         m_fibers[i]->data().atWithInsertion(j);
     }
 
     bool isExplicitZero(index_t i, index_t j) const
     {
-        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && i<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
+        GISMO_ASSERT( i>=0 && i<rows() && j>=0 && j<cols(), "Invalid element: "<<i<<">=0 && "<<i<<"<rows()"<<"="<<rows()<<"  &&  "<<j<<">=0 && "<<i<<"<cols()"<<"="<<cols() );
         if (!IsRowMajor) std::swap(i,j);
         auto & vdata = m_fibers[i]->data();
         const index_t jj = vdata.searchLowerIndex(j);


### PR DESCRIPTION
This PR fixes a bug in `gsFiberMatrix.h`.

FIXED:
Check if the column index `j` belongs to the range [0, `cols()`), instead of the row  index `i`

-----

Please consider the following checklist before issuing a pull
request:

- [ ] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
