### PR TITLE
Fix gsExprAssembler::computePattern

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -920,6 +920,15 @@ void gsExprAssembler<T>::_computePattern(const expr &... args)
 #pragma omp parallel
 {
     auto arg_tpl = std::make_tuple(args...);
+
+    // Checks if any of the expressions in args is a matrix
+    // If not, then there is no need to compute sparity patterns
+    // and returns
+    bool isMatrix = false;
+    _checkMatrix CM(isMatrix);
+    op_tuple(CM, arg_tpl);
+    if (!isMatrix) return;
+
     m_exprdata->parsePattern(arg_tpl);
 
     typename gsBasis<T>::domainIter domItEnd = m_exprdata->domain().endAll();
@@ -969,6 +978,15 @@ void gsExprAssembler<T>::_computePatternBdr(const bcRefList & BCs, const expr &.
 */
         auto arg_tpl = std::make_tuple(args...);
         m_exprdata->parsePattern(arg_tpl);
+
+        // Checks if any of the expressions in args is a matrix
+        // If not, then there is no need to compute sparity patterns
+        // and returns
+        bool isMatrix = false;
+        _checkMatrix CM(isMatrix);
+        op_tuple(CM, arg_tpl);
+        if (!isMatrix) return;
+
         typename gsBasis<T>::domainIter domIt;
         typename gsBasis<T>::domainIter domItEnd;
         unsigned patchInd;
@@ -1026,6 +1044,15 @@ void gsExprAssembler<T>::_computePatternIfc(const ifContainer & iFaces, expr... 
 #pragma omp parallel
 {
     auto arg_tpl = std::make_tuple(args...);
+
+    // Checks if any of the expressions in args is a matrix
+    // If not, then there is no need to compute sparity patterns
+    // and returns
+    bool isMatrix = false;
+    _checkMatrix CM(isMatrix);
+    op_tuple(CM, arg_tpl);
+    if (!isMatrix) return;
+
     m_exprdata->parsePattern(arg_tpl);
     unsigned patchInd(0);
     _pattern pp(m_fmatrix, m_exprdata->points(), patchInd


### PR DESCRIPTION
This PR provides a fix/enhancement in the computation of sparsity patterns when using some version of `gsExprAssembler::assemble / assembleBdr / assembleIfc`.




**FIXED**: When trying to assemble a vector expression on an contact interface ( i.e. using `gsCPPInterface` to handle closest point projections) `computePatternIfc` was being called before the expressions were parsed and this caused a 
bug because the geometry map was not always set, and thus the `gsCPPInterface` could not function properly.

**IMPROVED**:  Since `computePattern` was called regardless of whether a vector or a matrix was beiing assembled, unnecessary loops where performed. This now is avoided.


# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
