### PR TITLE
Exports class symbol, to be usable in dynamic libraries.

### DIFF
--- a/src/gsNurbs/gsNurbsBasis.h
+++ b/src/gsNurbs/gsNurbsBasis.h
@@ -36,7 +36,7 @@ namespace gismo
 */
 
 template<class T>
-class gsNurbsBasis : public gsRationalBasis<gsBSplineBasis<T> >
+class GISMO_EXPORT gsNurbsBasis : public gsRationalBasis<gsBSplineBasis<T> >
 {
 public:
 


### PR DESCRIPTION
FIXED: gcc "undefined reference" errors.

I was getting:
```
undefined reference to `gismo::gsNurbsBasis<double>::knots()'
```
This fixes the problem.

I do not know if there are other classes that need this same fix.