### PR TITLE
Update final keyword definition to account for related bug in llvm/clang

### DIFF
--- a/src/gsCore/gsExport.h.in
+++ b/src/gsCore/gsExport.h.in
@@ -136,7 +136,11 @@
 #  define GISMO_FINAL final
 #  define GISMO_OVERRIDE override
 #elif defined(__clang__ ) && __has_feature(cxx_override_control)
-#  define GISMO_FINAL //final // NOTE: bug with clang 16 and later
+#  if __clang_major__ < 16
+#  define GISMO_FINAL // NOTE: bug with clang 16 and later
+#  else
+#  define GISMO_FINAL final
+#  endif
 #  define GISMO_OVERRIDE override
 #elif defined(__GNUG__) && __cplusplus >= 201103 && \
     (__GNUC__ * 10000 + __GNUC_MINOR__ * 100) >= 40700


### PR DESCRIPTION
Clang 16 and above have problems with the `final` keyword. This hot fix disables the use of `final` for Clang version 16 and above.