### PR TITLE
fix `abs_expr`

### DIFF
--- a/src/gsAssembler/gsExpressions.h
+++ b/src/gsAssembler/gsExpressions.h
@@ -1429,7 +1429,7 @@ public:
         }
         return true;
     }
-    
+
     //template<class U>
     //linearComb(U & ie){ sum up ie[_u] times the _Sv  }
     // ie.eval(k), _u.data().actives(), fixedPart() - see lapl_expr
@@ -2718,7 +2718,7 @@ public:
 public:
     enum {Space= 0, ScalarValued= 1, ColBlocks= 0};
 
-    Scalar eval(const index_t k) const { return abs_expr::eval_impl     (_u,k).norm(); }
+    AutoReturn_t eval(const index_t k) const { return abs_expr::eval_impl     (_u,k); }
 
     index_t rows() const { return _u.rows(); }
     index_t cols() const { return _u.cols(); }


### PR DESCRIPTION
The change of the `abs_expr` from [this commit](https://github.com/gismo/gismo/commit/576678a9ea04947e3610a8d4677fc12ce434b756)  caused breaking tests in [`gsKLShell`](https://github.com/gismo/gsKLShell/actions/runs/14310920068/job/40105453592), [`gsStructuralAnalysis`](https://github.com/gismo/gsStructuralAnalysis/actions/runs/14310953671/job/40105560905), [`gsUnstructuredSplines`](https://github.com/gismo/gsUnstructuredSplines/actions/runs/14310980893/job/40105650529); all via the `gsThinShellAssembler`.
The problem seems to be the fact that the `abs_expr` returns a `Scalar`, hence for `ColBlocks` expressions the `norm` was added (I guess). However, for expressions that are `ScalarValued`, the `norm` does not exist, giving a compiler error.
I think the `cwiseAbs` from Eigen should already do the job, so we should not need the `norm`.

@MatuTia @filiatra could you test if the proposed fix works for you? 


---

**The commit description must be structured as a list follows:**

NEW: 

IMPROVED: 

FIXED: 
Return type in `abs_expr`

API:

-----

**Please consider the following checklist before issuing a pull**
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
