### PR TITLE
XML support for Rational THB, some refactoring in gsXmlUtils and some minor fixes.

### DIFF
--- a/src/gsCore/gsRationalBasis.h
+++ b/src/gsCore/gsRationalBasis.h
@@ -618,7 +618,7 @@ void gsRationalBasis<SrcT>::uniformRefine_withCoefs(gsMatrix<T>& coefs, int numK
 
     // Using uniformRefine_withCoefs
     auto tmp = m_src->clone();
-    coefs *= m_weights.asDiagonal();
+    coefs = m_weights.asDiagonal() * coefs;
     tmp->uniformRefine_withCoefs(coefs, numKnots);
     m_src->uniformRefine_withCoefs(m_weights, numKnots,mul,dir);
 

--- a/src/gsHSplines/gsRationalTHBSpline.hpp
+++ b/src/gsHSplines/gsRationalTHBSpline.hpp
@@ -1,0 +1,49 @@
+/** @file gsRationalTHBSpline.h
+
+    @brief Represents a rational truncated hierarchical B-Spline patch
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): A. Mantzaflaris, C. Karampatzakis
+*/
+ 
+#pragma once
+
+#include <gsIO/gsXml.h>
+#include <gsIO/gsXmlGenericUtils.hpp>
+
+namespace gismo
+{
+namespace internal
+{
+
+/// Get a RationalTHBSPline from XML data
+template<short_t d, class T>
+class gsXml< gsRationalTHBSpline<d,T> >
+{
+private:
+    gsXml() { }
+public:
+    GSXML_COMMON_FUNCTIONS(gsRationalTHBSpline<TMPLA2(d,T)>);
+    static std::string tag () { return "Geometry"; }
+    static std::string type () { return "RationalTHBSpline"+to_string(d); }
+
+    static gsRationalTHBSpline<d,T> * get (gsXmlNode * node)
+    {
+        return getGeometryFromXml< gsRationalTHBSpline<d,T> >( node );
+    }
+
+    static gsXmlNode * put (const gsRationalTHBSpline<d,T> & obj,
+                            gsXmlTree & data )
+    {
+        return putGeometryToXml(obj,data);
+    }
+};
+
+
+} // namespace internal
+} // namespace gismo

--- a/src/gsHSplines/gsRationalTHBSplineBasis.h
+++ b/src/gsHSplines/gsRationalTHBSplineBasis.h
@@ -116,6 +116,11 @@ public:
         coefs.array().colwise() /= m_weights.col(0).array();
     }
 
+    std::vector<index_t> asElements(gsMatrix<T> const & boxes, int refExt) const
+    {
+        return m_src->asElements(boxes, refExt);
+    }
+
     /// The number of basis functions in the direction of the k-th parameter component
     // void size_cwise(gsVector<index_t,d> & result) const
     // {

--- a/src/gsHSplines/gsRationalTHBSplineBasis.h
+++ b/src/gsHSplines/gsRationalTHBSplineBasis.h
@@ -16,6 +16,7 @@
 #include <gsCore/gsRationalBasis.h>
 #include <gsHSplines/gsRationalTHBSpline.h>
 #include <gsCore/gsForwardDeclarations.h>
+#include <gsHSplines/gsTHBSplineBasis.h>
 
 
 namespace gismo
@@ -241,3 +242,7 @@ protected:
 
 
 } // namespace gismo
+
+#ifndef GISMO_BUILD_LIB
+#include GISMO_HPP_HEADER(gsRationalTHBSplineBasis.hpp)
+#endif

--- a/src/gsHSplines/gsRationalTHBSplineBasis.hpp
+++ b/src/gsHSplines/gsRationalTHBSplineBasis.hpp
@@ -1,0 +1,49 @@
+/** @file gsRationalTHBSplineBasis.h
+
+    @brief Provides declaration of RationalTHBSplineBasis abstract interface.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): A. Mantzaflaris, C. Karampatzakis
+*/
+
+#pragma once
+
+#include <gsIO/gsXml.h>
+#include <gsIO/gsXmlGenericUtils.hpp>
+
+
+namespace gismo
+{
+namespace internal
+{
+    
+/// Get a RationalTHBSplineBasis from XML data
+template<short_t d, class T>
+class gsXml< gsRationalTHBSplineBasis<d,T> >
+{
+private:
+    gsXml() { }
+public:
+    GSXML_COMMON_FUNCTIONS(gsRationalTHBSplineBasis<TMPLA2(d,T)>);
+    static std::string tag () { return "Basis"; }
+    static std::string type () { return "RationalTHBSplineBasis"+to_string(d); }
+
+    static gsRationalTHBSplineBasis<d,T> * get (gsXmlNode * node)
+    {
+        return getRationalBasisFromXml< gsRationalTHBSplineBasis<d,T> >(node);
+    }
+
+    static gsXmlNode * put (const gsRationalTHBSplineBasis<d,T> & obj,
+                            gsXmlTree & data )
+    {
+        return putRationalBasisToXml< gsRationalTHBSplineBasis<d,T> >(obj,data);
+    }
+};
+
+} // namespace internal
+} // namespace gismo

--- a/src/gsHSplines/gsRationalTHBSplineBasis_.cpp
+++ b/src/gsHSplines/gsRationalTHBSplineBasis_.cpp
@@ -1,0 +1,25 @@
+/** @file gsRationalTHBSplineBasis.h
+
+    @brief Provides declaration of RationalTHBSplineBasis abstract interface.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): A. Mantzaflaris, C. Karampatzakis
+*/
+
+#include <gsCore/gsTemplateTools.h>
+
+#include <gsHSplines/gsRationalTHBSplineBasis.h>
+#include <gsHSplines/gsRationalTHBSplineBasis.hpp>
+
+namespace gismo
+{
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSplineBasis<1,real_t> >;
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSplineBasis<2,real_t> >;
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSplineBasis<3,real_t> >;
+
+} // namespace gismo

--- a/src/gsHSplines/gsRationalTHBSplineBasis_.cpp
+++ b/src/gsHSplines/gsRationalTHBSplineBasis_.cpp
@@ -21,5 +21,6 @@ namespace gismo
     CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSplineBasis<1,real_t> >;
     CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSplineBasis<2,real_t> >;
     CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSplineBasis<3,real_t> >;
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSplineBasis<4,real_t> >;
 
 } // namespace gismo

--- a/src/gsHSplines/gsRationalTHBSpline_.cpp
+++ b/src/gsHSplines/gsRationalTHBSpline_.cpp
@@ -1,0 +1,25 @@
+/** @file gsRationalTHBSpline.h
+
+    @brief Represents a rational truncated hierarchical B-Spline patch
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): A. Mantzaflaris, C. Karampatzakis
+*/
+
+#include <gsCore/gsTemplateTools.h>
+
+#include <gsHSplines/gsRationalTHBSpline.h>
+#include <gsHSplines/gsRationalTHBSpline.hpp>
+
+namespace gismo
+{
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSpline<1,real_t> >;
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSpline<2,real_t> >;
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSpline<3,real_t> >;
+
+} // namespace gismo

--- a/src/gsHSplines/gsRationalTHBSpline_.cpp
+++ b/src/gsHSplines/gsRationalTHBSpline_.cpp
@@ -21,5 +21,6 @@ namespace gismo
     CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSpline<1,real_t> >;
     CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSpline<2,real_t> >;
     CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSpline<3,real_t> >;
+    CLASS_TEMPLATE_INST internal::gsXml< gsRationalTHBSpline<4,real_t> >;
 
 } // namespace gismo

--- a/src/gsIO/gsXmlUtils.hpp
+++ b/src/gsIO/gsXmlUtils.hpp
@@ -29,6 +29,7 @@
 #include <gsNurbs/gsTensorNurbs.h>
 
 #include <gsHSplines/gsTHBSpline.h>
+#include <gsHSplines/gsRationalTHBSpline.h>
 
 #include <gsModeling/gsPlanarDomain.h>
 #include <gsModeling/gsTrimSurface.h>
@@ -47,6 +48,14 @@
 #include <gsCore/gsComposedFunction.h>
 
 #include <gsIO/gsXmlGenericUtils.hpp>
+
+#define GSXML_PUT_DYNAMIC_CAST(TYPE) \
+if (const TYPE * g = dynamic_cast<const TYPE *>(ptr)) \
+    return gsXml<TYPE>::put(*g, data);
+
+#define GSXML_GET_TYPE(TYPE) \
+if (s == gsXml<TYPE>::type().c_str()) \
+    return gsXml<TYPE>::get(node);
 
 namespace gismo {
 
@@ -532,39 +541,27 @@ public:
         }
         std::string s = gtype->value() ;
 
-        if ( s == "BSpline"    )
-            return gsXml< gsBSpline<T> >::get(node);
-        if ( s == "Nurbs"      )
-            return gsXml< gsNurbs<T> >::get(node);
-        if ( s == "HBSpline2"  )
-            return gsXml< gsHBSpline<2,T> >::get(node);
-        if ( s == "HBSpline3"  )
-            return gsXml< gsHBSpline<3,T> >::get(node);
-        if ( s == "THBSpline1" )
-            return gsXml< gsTHBSpline<1,T> >::get(node);
-        if ( s == "THBSpline2" )
-            return gsXml< gsTHBSpline<2,T> >::get(node);
-        if ( s == "THBSpline3" )
-            return gsXml< gsTHBSpline<3,T> >::get(node);
+        GSXML_GET_TYPE(gsBSpline<T>)
+        GSXML_GET_TYPE(gsNurbs<T>)
+        GSXML_GET_TYPE(gsTHBSpline<TMPLA2(1,T)>)
+        GSXML_GET_TYPE(gsTHBSpline<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsTHBSpline<TMPLA2(3,T)>)
+        GSXML_GET_TYPE(gsHBSpline<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsHBSpline<TMPLA2(3,T)>)
 
+        GSXML_GET_TYPE(gsRationalTHBSpline<TMPLA2(1,T)>)
+        GSXML_GET_TYPE(gsRationalTHBSpline<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsRationalTHBSpline<TMPLA2(3,T)>)
 
-        if ( s == "TensorBSpline1" )
-            return gsXml< gsTensorBSpline<1,T> >::get(node);
-        if ( s == "TensorBSpline2" )
-            return gsXml< gsTensorBSpline<2,T> >::get(node);
-        if ( s == "TensorBSpline3" )
-            return gsXml< gsTensorBSpline<3,T> >::get(node);
-        if ( s == "TensorBSpline4" )
-            return gsXml< gsTensorBSpline<4,T> >::get(node);
-        if ( s == "TensorNurbs2" )
-            return gsXml< gsTensorNurbs<2,T> >::get(node);
-        if ( s == "TensorNurbs3" )
-            return gsXml< gsTensorNurbs<3,T> >::get(node);
-        if ( s == "TensorNurbs4" )
-            return gsXml< gsTensorNurbs<4,T> >::get(node);
+        GSXML_GET_TYPE(gsTensorBSpline<TMPLA2(1,T)>)
+        GSXML_GET_TYPE(gsTensorBSpline<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsTensorBSpline<TMPLA2(3,T)>)
+        GSXML_GET_TYPE(gsTensorBSpline<TMPLA2(4,T)>)
+        GSXML_GET_TYPE(gsTensorNurbs<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsTensorNurbs<TMPLA2(3,T)>)
+        GSXML_GET_TYPE(gsTensorNurbs<TMPLA2(4,T)>)
 
-        if ( s == "ComposedGeometry")
-            return gsXml< gsComposedGeometry<T> >::get(node);
+        GSXML_GET_TYPE(gsComposedGeometry<T>)
 
         //if ( s == "TrimSurface" )
         //    return gsXml< gsTrimSurface<T> >::get(node);
@@ -582,73 +579,29 @@ public:
 	{
 	    const gsGeometry<T> * ptr = & obj;
 
-	    if ( const gsBSpline<T> * g =
-             dynamic_cast<const gsBSpline<T> *>( ptr ) )
-		    return gsXml< gsBSpline<T> >::put(*g,data);
-
-	    if ( const gsNurbs<T> * g =
-             dynamic_cast<const gsNurbs<T> *>( ptr ) )
-		    return gsXml< gsNurbs<T> >::put(*g,data);
-
-	    if ( const gsTensorBSpline<2,T> * g =
-             dynamic_cast<const gsTensorBSpline<2,T> *>( ptr ) )
-            return gsXml< gsTensorBSpline<2,T> >::put(*g,data);
-
-	    if ( const gsTensorBSpline<3,T> * g =
-             dynamic_cast<const gsTensorBSpline<3,T> *>( ptr ) )
-            return gsXml< gsTensorBSpline<3,T> >::put(*g,data);
-
-	    if ( const gsTensorBSpline<4,T> * g =
-             dynamic_cast<const gsTensorBSpline<4,T> *>( ptr ) )
-            return gsXml< gsTensorBSpline<4,T> >::put(*g,data);
-
-	    if ( const gsTensorNurbs<2,T> * g =
-             dynamic_cast<const gsTensorNurbs<2,T> *>( ptr ) )
-            return gsXml< gsTensorNurbs<2,T> >::put(*g,data);
-
-	    if ( const gsTensorNurbs<3,T> * g =
-             dynamic_cast<const gsTensorNurbs<3,T> *>( ptr ) )
-            return gsXml< gsTensorNurbs<3,T> >::put(*g,data);
-
-	    if ( const gsTensorNurbs<4,T> * g =
-             dynamic_cast<const gsTensorNurbs<4,T> *>( ptr ) )
-            return gsXml< gsTensorNurbs<4,T> >::put(*g,data);
-
-	    if ( const gsTHBSpline<1,T> * g =
-             dynamic_cast<const gsTHBSpline<1,T> *>( ptr ) )
-	        return gsXml< gsTHBSpline<1,T> >::put(*g,data);
-
-	    if ( const gsTHBSpline<2,T> * g =
-             dynamic_cast<const gsTHBSpline<2,T> *>( ptr ) )
-	        return gsXml< gsTHBSpline<2,T> >::put(*g,data);
-
-	    if ( const gsTHBSpline<3,T> * g =
-             dynamic_cast<const gsTHBSpline<3,T> *>( ptr ) )
-	        return gsXml< gsTHBSpline<3,T> >::put(*g,data);
-
-	    if ( const gsTrimSurface<T> * g =
-             dynamic_cast<const gsTrimSurface<T> *>( ptr ) )
-		    return gsXml< gsTrimSurface<T> >::put(*g,data);
-
-	    if ( const gsHBSpline<1,T> * g =
-	    	 dynamic_cast<const gsHBSpline<1,T> *>( ptr ) )
-            return gsXml< gsHBSpline<1,T> >::put(*g,data);
-
-	    if ( const gsHBSpline<2,T> * g =
-	    	 dynamic_cast<const gsHBSpline<2,T> *>( ptr ) )
-            return gsXml< gsHBSpline<2,T> >::put(*g,data);
-
-	    if ( const gsHBSpline<3,T> * g =
-	    	 dynamic_cast<const gsHBSpline<3,T> *>( ptr ) )
-            return gsXml< gsHBSpline<3,T> >::put(*g,data);
-
+        GSXML_PUT_DYNAMIC_CAST(gsBSpline<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsNurbs<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorBSpline<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorBSpline<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorBSpline<TMPLA2(4, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorNurbs<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorNurbs<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorNurbs<TMPLA2(4, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTHBSpline<TMPLA2(1, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTHBSpline<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTHBSpline<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTrimSurface<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsHBSpline<TMPLA2(1, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsHBSpline<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsHBSpline<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsRationalTHBSpline<TMPLA2(1, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsRationalTHBSpline<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsRationalTHBSpline<TMPLA2(3, T)>)
         //if ( const gsTriangularBezier<2,T> * g =
         //     dynamic_cast<const gsTriangularBezier<2,T> *>( ptr ) )
         //    return gsXml< gsTriangularBezier<2,T> >::put(*g,data);
 
-        if ( const gsComposedGeometry<T> * g =
-             dynamic_cast<const gsComposedGeometry<T> *>( ptr ) )
-            return gsXml< gsComposedGeometry<T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsComposedGeometry<T>)
 
 		gsWarn<<"gsXmlUtils: put Geometry: No known object \""<< obj <<"\". Error.\n";
         return NULL;
@@ -679,12 +632,9 @@ public:
             return NULL;
         }
         std::string s = ftype->value() ;
-        if ( s == "ConstantFunction"   )
-            return gsXml< gsConstantFunction<T> >::get(node);
-        if ( s == "FunctionExpr"        )
-            return gsXml< gsFunctionExpr<T> >::get(node);
-        if ( s == "ComposedFunction"    )
-            return gsXml< gsComposedFunction<T> >::get(node);
+        GSXML_GET_TYPE(gsConstantFunction<T>)
+        GSXML_GET_TYPE(gsFunctionExpr<T>)
+        GSXML_GET_TYPE(gsComposedFunction<T>)
 
         gsWarn<<"gsXmlUtils: getFunction: No known function \""<<s<<"\". Error.\n";
         return NULL;
@@ -695,17 +645,9 @@ public:
 	{
 	    const gsFunction<T> * ptr = & obj;
 
-	    if ( const gsConstantFunction<T> * g =
-             dynamic_cast<const gsConstantFunction<T> *>( ptr ) )
-		    return gsXml< gsConstantFunction<T> >::put(*g,data);
-
-	    if ( const gsFunctionExpr<T> * g =
-             dynamic_cast<const gsFunctionExpr<T> *>( ptr ) )
-		    return gsXml< gsFunctionExpr<T> >::put(*g,data);
-
-	    if ( const gsComposedFunction<T> * g =
-             dynamic_cast<const gsComposedFunction<T> *>( ptr ) )
-            return gsXml< gsComposedFunction<T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsConstantFunction<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsFunctionExpr<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsComposedFunction<T>)
 
         gsWarn<<"gsXmlUtils: put Function: No known object \""<< obj <<"\". Error.\n";
         return NULL;
@@ -737,10 +679,8 @@ public:
         }
         std::string s = gtype->value() ;
 
-        if ( s == "BSpline"    )
-            return gsXml< gsBSpline<T> >::get(node);
-        if ( s == "Nurbs"      )
-            return gsXml< gsNurbs<T> >::get(node);
+        GSXML_GET_TYPE(gsBSpline<T>)
+        GSXML_GET_TYPE(gsNurbs<T>)
 
         gsWarn<<"gsXmlUtils: getCurve: No known curve \""<<s<<"\". Error.\n";
         return NULL;
@@ -752,17 +692,9 @@ public:
 	{
 	    const gsGeometry<T> * ptr = & obj;
 
-	    if ( const gsBSpline<T> * g =
-             dynamic_cast<const gsBSpline<T> *>( ptr ) )
-		    return gsXml< gsBSpline<T> >::put(*g,data);
-
-	    if ( const gsNurbs<T> * g =
-             dynamic_cast<const gsNurbs<T> *>( ptr ) )
-		    return gsXml< gsNurbs<T> >::put(*g,data);
-
-	    if ( const gsHBSpline<1,T> * g =
-	    	 dynamic_cast<const gsHBSpline<1,T> *>( ptr ) )
-            return gsXml< gsHBSpline<1,T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsBSpline<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsNurbs<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsHBSpline<TMPLA2(1, T)>)
 
 		gsWarn<<"gsXmlUtils: put Curve: No known object "<< obj <<"Error.\n";
         return NULL;
@@ -794,15 +726,10 @@ public:
         }
         std::string s = gtype->value() ;
 
-        if ( s == "HBSpline2"  )
-            return gsXml< gsHBSpline<2,T> >::get(node);
-        if ( s == "THBSpline2" )
-            return gsXml< gsTHBSpline<2,T> >::get(node);
-
-        if ( s == "TensorBSpline2" )
-            return gsXml< gsTensorBSpline<2,T> >::get(node);
-        if ( s == "TensorNurbs2" )
-            return gsXml< gsTensorNurbs<2,T> >::get(node);
+        GSXML_GET_TYPE(gsTHBSpline<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsHBSpline<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsTensorBSpline<TMPLA2(2,T)>)
+        GSXML_GET_TYPE(gsTensorNurbs<TMPLA2(2,T)>)
 
         gsWarn<<"gsXmlUtils: getSurface: No known surface \""<<s<<"\". Error.\n";
         return NULL;
@@ -813,21 +740,10 @@ public:
 	{
 	    const gsGeometry<T> * ptr = & obj;
 
-	    if ( const gsTensorBSpline<2,T> * g =
-             dynamic_cast<const gsTensorBSpline<2,T> *>( ptr ) )
-            return gsXml< gsTensorBSpline<2,T> >::put(*g,data);
-
-	    if ( const gsTensorNurbs<2,T> * g =
-             dynamic_cast<const gsTensorNurbs<2,T> *>( ptr ) )
-            return gsXml< gsTensorNurbs<2,T> >::put(*g,data);
-
-	    if ( const gsTHBSpline<2,T> * g =
-             dynamic_cast<const gsTHBSpline<2,T> *>( ptr ) )
-	        return gsXml< gsTHBSpline<2,T> >::put(*g,data);
-
-	    if ( const gsHBSpline<2,T> * g =
-	    	 dynamic_cast<const gsHBSpline<2,T> *>( ptr ) )
-            return gsXml< gsHBSpline<2,T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsTensorBSpline<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorNurbs<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTHBSpline<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsHBSpline<TMPLA2(2, T)>)
 
 		gsWarn<<"gsXmlUtils: put Geometry: No known object "<< obj <<"Error.\n";
         return NULL;
@@ -857,48 +773,32 @@ public:
         }
         std::string s = btype->value() ;
 
-        if ( s == "BSplineBasis" )
-            return gsXml< gsBSplineBasis<T> >::get(node);
-        if ( s == "NurbsBasis"   )
-            return gsXml< gsNurbsBasis<T>   >::get(node);
+        GSXML_GET_TYPE(gsBSplineBasis<T>)
+        GSXML_GET_TYPE(gsNurbsBasis<T>)
 
-        if ( s == "HBSplineBasis" )
-            return gsXml< gsHBSplineBasis<1,T> >::get(node);
-        if ( s == "HBSplineBasis2" )
-            return gsXml< gsHBSplineBasis<2,T> >::get(node);
-        if ( s == "HBSplineBasis3" )
-            return gsXml< gsHBSplineBasis<3,T> >::get(node);
-        if ( s == "HBSplineBasis4" )
-            return gsXml< gsHBSplineBasis<4,T> >::get(node);
+        GSXML_GET_TYPE(gsTHBSplineBasis<TMPLA2(1, T)>)
+        GSXML_GET_TYPE(gsTHBSplineBasis<TMPLA2(2, T)>)
+        GSXML_GET_TYPE(gsTHBSplineBasis<TMPLA2(3, T)>)
+        GSXML_GET_TYPE(gsTHBSplineBasis<TMPLA2(4, T)>)
 
-        if ( s == "THBSplineBasis" )
-            return gsXml< gsTHBSplineBasis<1,T> >::get(node);
-        if ( s == "THBSplineBasis2" )
-            return gsXml< gsTHBSplineBasis<2,T> >::get(node);
-        if ( s == "THBSplineBasis3" )
-            return gsXml< gsTHBSplineBasis<3,T> >::get(node);
-        if ( s == "THBSplineBasis4" )
-            return gsXml< gsTHBSplineBasis<4,T> >::get(node);
+        GSXML_GET_TYPE(gsHBSplineBasis<TMPLA2(1, T)>)
+        GSXML_GET_TYPE(gsHBSplineBasis<TMPLA2(2, T)>)
+        GSXML_GET_TYPE(gsHBSplineBasis<TMPLA2(3, T)>)
+        GSXML_GET_TYPE(gsHBSplineBasis<TMPLA2(4, T)>)
 
-        //if ( s == "gsTriangularBezierBasis2" )
-        //    return gsXml< gsTriangularBezierBasis<2,T> >::get(node);
+        GSXML_GET_TYPE(gsRationalTHBSplineBasis<TMPLA2(1, T)>)
+        GSXML_GET_TYPE(gsRationalTHBSplineBasis<TMPLA2(2, T)>)
+        GSXML_GET_TYPE(gsRationalTHBSplineBasis<TMPLA2(3, T)>)
 
-        if ( s == "TensorBSplineBasis2" )
-            return gsXml< gsTensorBSplineBasis<2, T> >::get(node);
-        if ( s == "TensorBSplineBasis3" )
-            return gsXml< gsTensorBSplineBasis<3, T> >::get(node);
-        if ( s == "TensorBSplineBasis4" )
-            return gsXml< gsTensorBSplineBasis<4, T> >::get(node);
+        GSXML_GET_TYPE(gsTensorBSplineBasis<TMPLA2(2, T)>)
+        GSXML_GET_TYPE(gsTensorBSplineBasis<TMPLA2(3, T)>)
+        GSXML_GET_TYPE(gsTensorBSplineBasis<TMPLA2(4, T)>)
 
-        if ( s == "TensorNurbsBasis2" )
-            return gsXml< gsTensorNurbsBasis<2, T> >::get(node);
-        if ( s == "TensorNurbsBasis3" )
-            return gsXml< gsTensorNurbsBasis<3, T> >::get(node);
-        if ( s == "TensorNurbsBasis4" )
-            return gsXml< gsTensorNurbsBasis<4, T> >::get(node);
+        GSXML_GET_TYPE(gsTensorNurbsBasis<TMPLA2(2, T)>)
+        GSXML_GET_TYPE(gsTensorNurbsBasis<TMPLA2(3, T)>)
+        GSXML_GET_TYPE(gsTensorNurbsBasis<TMPLA2(4, T)>)
 
-        if ( s == "ComposedBasis" )
-            return gsXml< gsComposedBasis<T> >::get(node);
+        GSXML_GET_TYPE(gsComposedBasis<T>)
 
         gsWarn<<"gsXmlUtils: getBasis: No known basis \""<<s<<"\". Error.\n";
         return NULL;
@@ -909,64 +809,33 @@ public:
     {
         const gsBasis<T> * ptr = & obj;
 
-        if ( const gsBSplineBasis<T> * g =
-             dynamic_cast<const gsBSplineBasis<T> *>( ptr ) )
-            return gsXml< gsBSplineBasis<T> >::put(*g,data);
-
-        if ( const gsNurbsBasis<T> * g =
-             dynamic_cast<const gsNurbsBasis<T> *>( ptr ) )
-            return gsXml< gsNurbsBasis<T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsBSplineBasis<T>)
+        GSXML_PUT_DYNAMIC_CAST(gsNurbsBasis<T>)
 
         // Tensor B-spline
-        if ( const gsTensorBSplineBasis<2, T> * g =
-             dynamic_cast<const gsTensorBSplineBasis<2, T> *>( ptr ) )
-            return gsXml< gsTensorBSplineBasis<2, T> >::put(*g,data);
-
-        if ( const gsTensorBSplineBasis<3, T> * g =
-             dynamic_cast<const gsTensorBSplineBasis<3, T> *>( ptr ) )
-            return gsXml< gsTensorBSplineBasis<3, T> >::put(*g,data);
-
-        if ( const gsTensorBSplineBasis<4, T> * g =
-             dynamic_cast<const gsTensorBSplineBasis<4, T> *>( ptr ) )
-            return gsXml< gsTensorBSplineBasis<4, T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsTensorBSplineBasis<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorBSplineBasis<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorBSplineBasis<TMPLA2(4, T)>)
 
         // Tensor Nurbs
-        if ( const gsTensorNurbsBasis<2, T> * g =
-             dynamic_cast<const gsTensorNurbsBasis<2, T> *>( ptr ) )
-            return gsXml< gsTensorNurbsBasis<2, T> >::put(*g,data);
-
-        if ( const gsTensorNurbsBasis<3, T> * g =
-             dynamic_cast<const gsTensorNurbsBasis<3, T> *>( ptr ) )
-            return gsXml< gsTensorNurbsBasis<3, T> >::put(*g,data);
-
-        if ( const gsTensorNurbsBasis<4, T> * g =
-             dynamic_cast<const gsTensorNurbsBasis<4, T> *>( ptr ) )
-            return gsXml< gsTensorNurbsBasis<4, T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsTensorNurbsBasis<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorNurbsBasis<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsTensorNurbsBasis<TMPLA2(4, T)>)
 
         // Tensor-Hier. B-splines
-        if ( const gsHTensorBasis<1,T>  * g =
-             dynamic_cast<const gsHTensorBasis<1,T> *>( ptr ) )
-            return gsXml< gsHTensorBasis<1,T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsHTensorBasis<TMPLA2(1, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsHTensorBasis<TMPLA2(2, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsHTensorBasis<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsHTensorBasis<TMPLA2(4, T)>)
 
-        if ( const gsHTensorBasis<2,T>  * g =
-             dynamic_cast<const gsHTensorBasis<2,T> *>( ptr ) )
-            return gsXml< gsHTensorBasis<2,T> >::put(*g,data);
-
-        if ( const gsHTensorBasis<3,T>  * g =
-             dynamic_cast<const gsHTensorBasis<3,T> *>( ptr ) )
-            return gsXml< gsHTensorBasis<3,T> >::put(*g,data);
-
-        if ( const gsHTensorBasis<4,T>  * g =
-             dynamic_cast<const gsHTensorBasis<4,T> *>( ptr ) )
-            return gsXml< gsHTensorBasis<4,T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsTHBSplineBasis<TMPLA2(3, T)>)
+        GSXML_PUT_DYNAMIC_CAST(gsRationalTHBSplineBasis<TMPLA2(3, T)>)
 
         //if ( const gsTriangularBezierBasis<2,T>  * g =
         //     dynamic_cast<const gsTriangularBezierBasis<2,T> *>( ptr ) )
         //    return gsXml< gsTriangularBezierBasis<2,T> >::put(*g,data);
 
-        if ( const gsComposedBasis<T> * g =
-             dynamic_cast<const gsComposedBasis<T> *>( ptr ) )
-            return gsXml< gsComposedBasis<T> >::put(*g,data);
+        GSXML_PUT_DYNAMIC_CAST(gsComposedBasis<T>)
 
         gsWarn<<"gsXmlUtils put: getBasis: No known basis \""<<obj<<"\". Error.\n";
         return NULL;
@@ -990,10 +859,8 @@ public:
                       "Something went wrong. Expected Pde tag." );
 
         std::string s = node->first_attribute("type")->value() ;
-        if ( s == "PoissonPde" )
-            return gsXml< gsPoissonPde<T> >::get(node);
-        if ( s == "SurfacePoissonPde" )
-            return gsXml< gsSurfacePoissonPde<T> >::get(node);
+        GSXML_GET_TYPE(gsPoissonPde<T>)
+        GSXML_GET_TYPE(gsSurfacePoissonPde<T>)
 
         gsWarn<<"gsXmlUtils: getPde: No known Pde \""<<s<<"\". Error.\n";
         return NULL;
@@ -1599,3 +1466,5 @@ public:
 //#undef GSXML_COMMON_FUNCTIONS
 //#undef TMPLA2
 //#undef TMPLA3
+#undef GSXML_GET_TYPE
+#undef GSXML_PUT_DYNAMIC_CAST

--- a/src/gsNurbs/gsTensorNurbsBasis.h
+++ b/src/gsNurbs/gsTensorNurbsBasis.h
@@ -167,7 +167,7 @@ public:
         else
         {
             GISMO_ASSERT( dir >= 0 && static_cast<unsigned>(dir) < d,
-                          "Invalid basis component "<< dir <<" requested for degree elevation" );
+                          "Invalid basis component "<< dir <<" requested for uniform refinement." );
 
             gsVector<index_t,d> sz;
             m_src->size_cwise(sz);

--- a/src/gsSolver/gsSolverUtils.h
+++ b/src/gsSolver/gsSolverUtils.h
@@ -58,13 +58,19 @@ public:
         return rate(0);
     }
 
-    /// \brief Finds the spectral condition number of a small matrix.
+    /// \brief Finds the spectral condition number of a small symmetric matrix.
     ///
-    /// Find the condition number of a matrix by fist finding the eigenvalues
+    /// Find the condition number of a symmetric matrix by fist finding the eigenvalues
     /// of the matrix and then dividing the highest (absolute) eigenvalue by the
     /// lowest (absolute) eigenvalue. This method is computationally expensive
     /// and will only work on small matrices. The method assumes that the
-    /// eigenvalues are reel.
+    /// eigenvalues are real and the matrix is symmetric.
+    /// 
+    /// For a non-symmetric matrix the condition number is given by 
+    /// \code{.cpp}
+    /// math::sqrt( conditionNumber(matrix.transpose() * matrix) );
+    /// \endcode
+    ///
     /// \param[in] matrix is a square matrix hows eigenvalues are found.
     /// \param[in] removeSingularity is true: ONE eigenvalue is removed to avoid inf condition number.
     static T conditionNumber(const gsMatrix<T> & matrix, bool removeSingularity = false)

--- a/src/gsSolver/gsSolverUtils.h
+++ b/src/gsSolver/gsSolverUtils.h
@@ -60,7 +60,7 @@ public:
 
     /// \brief Finds the spectral condition number of a small symmetric matrix.
     ///
-    /// Find the condition number of a symmetric matrix by fist finding the eigenvalues
+    /// Find the condition number of a dense symmetric matrix by fist finding the eigenvalues
     /// of the matrix and then dividing the highest (absolute) eigenvalue by the
     /// lowest (absolute) eigenvalue. This method is computationally expensive
     /// and will only work on small matrices. The method assumes that the

--- a/src/gsUtils/gsQuasiInterpolate.h
+++ b/src/gsUtils/gsQuasiInterpolate.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <gsCore/gsForwardDeclarations.h>
+#include <gsHSplines/gsRationalTHBSplineBasis.h>
 
 namespace gismo {
 

--- a/src/gsUtils/gsQuasiInterpolate.hpp
+++ b/src/gsUtils/gsQuasiInterpolate.hpp
@@ -93,6 +93,9 @@ gsMatrix<T> gsQuasiInterpolate<T>::localIntpl(const gsBasis<T> &bb,
     if (const gsHTensorBasis<3,T>* b = dynamic_cast<const gsHTensorBasis<3,T>* >(&bb))
         return localIntpl(*b,fun,i);
     if (const gsHTensorBasis<4,T>* b = dynamic_cast<const gsHTensorBasis<4,T>* >(&bb))
+        return localIntpl(*b,fun,i);        
+    // If it is a gsRationalTHBSplineBasis, we check the source
+    if (const gsHTensorBasis<2, T>* b = dynamic_cast<const gsHTensorBasis<2,T>* >(&bb.source())) 
         return localIntpl(*b,fun,i);
     else
         return localIntpl(bb,fun,i,bb.elementInSupportOf(i));

--- a/src/gsUtils/gsQuasiInterpolate.hpp
+++ b/src/gsUtils/gsQuasiInterpolate.hpp
@@ -95,7 +95,11 @@ gsMatrix<T> gsQuasiInterpolate<T>::localIntpl(const gsBasis<T> &bb,
     if (const gsHTensorBasis<4,T>* b = dynamic_cast<const gsHTensorBasis<4,T>* >(&bb))
         return localIntpl(*b,fun,i);        
     // If it is a gsRationalTHBSplineBasis, we check the source
+    if (const gsHTensorBasis<1, T>* b = dynamic_cast<const gsHTensorBasis<1,T>* >(&bb.source())) 
+        return localIntpl(*b,fun,i);
     if (const gsHTensorBasis<2, T>* b = dynamic_cast<const gsHTensorBasis<2,T>* >(&bb.source())) 
+        return localIntpl(*b,fun,i);
+    if (const gsHTensorBasis<3, T>* b = dynamic_cast<const gsHTensorBasis<3,T>* >(&bb.source()))
         return localIntpl(*b,fun,i);
     else
         return localIntpl(bb,fun,i,bb.elementInSupportOf(i));


### PR DESCRIPTION
### NEW
- Added support for the input / output of `gsRationalTHBSpline` / `gsRationalTHBSplineBasis`
- `gsRationalTHBSplineBasis::asElements`

### IMPROVED
- Reduced the boiler plate code in `gsXmlUtils` by defining two macros.
- Also when reading an xml file the `type` tag of an entry is not compared to a string literal, but rather to the class' `::type()` in order to avoid having mismatches when defining new classes in the future.

### FIXED
- `gsRationalBasis::uniformRefine_withCoefs` had a matrix-vector multiplication done on the wrong side
- `gsQuasiInterpolate::localIntpl` would not work for rational THB, this has now been addressed

For each new/improved/fixed/api change use a new line with the
respective word prefix in capital.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [x] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
