### PR TITLE
Small fix, gsTensorBasis::degreeReduce assumed dir=-1 always

### DIFF
--- a/src/gsTensor/gsTensorBasis.h
+++ b/src/gsTensor/gsTensorBasis.h
@@ -409,11 +409,17 @@ public:
     // Look at gsBasis class for documentation
     virtual void degreeReduce(short_t const & i = 1, short_t const dir = -1) override
     {
-        GISMO_UNUSED(dir);
-        GISMO_ASSERT( dir < this->dim(),
-                      "Invalid basis component requested" );
-        for (short_t j = 0; j < d; ++j)
+        if (dir == -1)
+        {
+            for (short_t j = 0; j < d; ++j)
             m_bases[j]->degreeReduce(i);
+        }
+        else
+        {
+            GISMO_ASSERT( dir < this->dim(),
+                          "Invalid basis component requested" );
+            m_bases[dir]->degreeReduce(i);
+        }
     }
 
     /// Get a const-iterator to the beginning of the bases vector


### PR DESCRIPTION

### FIXED: 
- Minor fix in `gsTensorBasis::degreeReduce`, it disregarded `dir` and thus always reduced all parametric directions.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
