### PR TITLE
Fix bug in _expr.npart()

### DIFF
--- a/src/gsExpressions/_expr.h
+++ b/src/gsExpressions/_expr.h
@@ -108,8 +108,8 @@ public:
     { return ppartval_expr<E>(static_cast<E const&>(*this)); }
 
     /// Returns the expression's negative part
-    mult_expr<real_t, ppart_expr<mult_expr<double,E,false>> , false>
-    npart() const { return -1* ( -(*this) ).ppart() ; }
+    mult_expr< _expr<Scalar,true> , ppart_expr<mult_expr< _expr<Scalar,true>,E,false>> , false>
+    npart() const { return (-1)* ( -(*this) ).ppart() ; }
 
     /// Returns an evaluation of the (sub-)expression in temporary memory
     temp_expr<E> temp() const
@@ -143,7 +143,7 @@ public:
     sqNorm_expr<E> sqNorm() const
     { return sqNorm_expr<E>(static_cast<E const&>(*this)); }
 
-    /// Returns the square root of the expression (component-wise)
+    /// Returns the square of the expression (component-wise)
     mult_expr<E,E,0> (sqr)() const { return (*this)*(*this); }
 
     symm_expr<E> symm() const

--- a/unittests/gsExpressions_test.cpp
+++ b/unittests/gsExpressions_test.cpp
@@ -204,4 +204,36 @@ SUITE(gsExpressions_test)
 
     }
 
+    // Test for the positive part of an expression ( Macaulay bracket )
+    TEST(ppart_expr)
+    {
+
+        gsMatrix<real_t> zero1D = gsMatrix<real_t>::Zero(1,1);
+        CHECK_EQUAL( ev.eval(f2D.ppart(), zero) , zero);
+        CHECK_EQUAL( ev.eval(f1D.ppart(), zero) , zero1D);
+
+        CHECK_EQUAL( ev.eval((-f2D).ppart(), zero) , zero);
+        CHECK_EQUAL( ev.eval((-f1D).ppart(), zero) , zero1D);
+
+        // Test positive part with positive values
+        gsMatrix<real_t> pos_result2D = ev_func2D.cwiseMax(0.0);
+        gsMatrix<real_t> pos_result1D = gsMatrix<real_t>::Constant(1,1,std::max(ev_func1D.value(),0.0));
+        CHECK_EQUAL((ev.eval(f2D.ppart(), pt) - pos_result2D).norm(), 0.0);
+        CHECK_EQUAL((ev.eval(f1D.ppart(), pt) - pos_result1D).norm(), 0.0);
+
+        // Test for the negative part of an expression
+        CHECK_EQUAL( ev.eval(f2D.npart(), zero) , zero);
+        CHECK_EQUAL( ev.eval(f1D.npart(), zero) , zero1D);
+
+        CHECK_EQUAL( ev.eval((-f2D).npart(), pt) , -ev_func2D);
+        CHECK_EQUAL( ev.eval((-f1D).npart(), pt) , -ev_func1D);
+
+        // Test negative part with positive values (should be zero)
+        gsMatrix<real_t> neg_result2D = (-ev_func2D).cwiseMax(0.0);
+        gsMatrix<real_t> neg_result1D = gsMatrix<real_t>::Constant(1,1,std::max(-ev_func1D.value(),0.0));
+        CHECK_EQUAL((ev.eval(f2D.npart(), pt) - neg_result2D).norm(), 0.0);
+        CHECK_EQUAL((ev.eval(f1D.npart(), pt) - neg_result1D).norm(), 0.0);
+
+    }
+
 }


### PR DESCRIPTION
Fixes a minor bug in the negative part expression's return type. 

### FIX:
* Updated the return type of the `npart` method to use `_expr<Scalar, true>` instead of double, for type consistency.

### IMPROVED:
* Corrected the documentation for the `sqr` method "square" (component-wise) of the expression instead of "square root".

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
