### PR TITLE
Add #include<cstdint> explicitly

### DIFF
--- a/src/gsCore/gsForwardDeclarations.h
+++ b/src/gsCore/gsForwardDeclarations.h
@@ -14,6 +14,7 @@
 #pragma once
 
 // STD includes
+#include <cstdint>
 #include <vector>
 #include <iterator>
 #include <set>


### PR DESCRIPTION
This PR explicitly adds `#include <cstdint>` for GCC 15 compatibility.
 
NEW: Explicit `#include <cstdint>` in `gsForwardDeclarations`; no longer included transitively by standard C++ headers.