### PR TITLE
Fix bug in gsTensorNurbsBasis::uniformRefine_withCoefs

### DIFF
--- a/src/gsNurbs/gsTensorNurbsBasis.h
+++ b/src/gsNurbs/gsTensorNurbsBasis.h
@@ -169,28 +169,31 @@ public:
             GISMO_ASSERT( dir >= 0 && static_cast<unsigned>(dir) < d,
                           "Invalid basis component "<< dir <<" requested for uniform refinement." );
 
-            gsVector<index_t,d> sz;
-            m_src->size_cwise(sz);
+            gsVector<index_t,d> sz_weights, sz_coefs;
+            m_src->size_cwise(sz_coefs);
+            sz_weights = sz_coefs;
             m_src->component(dir).uniformRefine_withTransfer( transfer, numKnots, mul );
 
-            const index_t coefs_cols = coefs.cols();
-            const index_t weights_cols = m_weights.cols();
+            const index_t coefs_cols = coefs.cols();           // Original number of columns
+            const index_t weights_cols = m_weights.cols();     // Original number of columns
 
             coefs = m_weights.asDiagonal() * coefs; //<<<<-----this goes wrong!!
-            swapTensorDirection(0, dir, sz, coefs);
-            coefs.resize( sz[0], coefs_cols * sz.template tail<static_cast<short_t>(d-1)>().prod() );
+            swapTensorDirection(0, dir, sz_coefs, coefs);
+            coefs.resize( sz_coefs[0], coefs_cols * sz_coefs.template tail<static_cast<short_t>(d-1)>().prod() );
             coefs     = transfer * coefs;
 
-            swapTensorDirection(0, dir, sz, m_weights);
-            m_weights.resize( sz[0], weights_cols * sz.template tail<static_cast<short_t>(d-1)>().prod() );
+
+            swapTensorDirection(0, dir, sz_weights, m_weights);
+            m_weights.resize( sz_weights[0], weights_cols * sz_weights.template tail<static_cast<short_t>(d-1)>().prod() );
             m_weights = transfer * m_weights;
 
-            sz[0] = coefs.rows();
+            sz_coefs[0] = coefs.rows();
+            sz_weights[0] = m_weights.rows();
 
-            coefs.resize( sz.prod(), coefs_cols );
-            m_weights.resize( sz.prod(), weights_cols );
-            swapTensorDirection(0, dir, sz, coefs);
-            swapTensorDirection(0, dir, sz, m_weights);
+            coefs.resize( sz_coefs.prod(), coefs_cols );
+            m_weights.resize( sz_weights.prod(), weights_cols );
+            swapTensorDirection(0, dir, sz_coefs, coefs);
+            swapTensorDirection(0, dir, sz_weights, m_weights);
 
             coefs.array().colwise() /= m_weights.col(0).array();
         }


### PR DESCRIPTION

### FIXED: A bug in gsTensorNurbsBasis::uniformRefine_withCoefs

This pull request refactors the handling of tensor dimensions during uniform refinement in the `gsTensorNurbsBasis` class. The main improvement is the separation of size vectors for coefficients and weights, which clarifies the operations and helps prevent errors when manipulating tensor directions and resizing matrices.

**Tensor dimension handling improvements:**

* Introduced separate size vectors (`sz_coefs` and `sz_weights`) for coefficients and weights instead of a single shared vector, making the code clearer and reducing the risk of dimension mismatches.
* Updated all tensor direction swapping and resizing operations to use the appropriate size vector for coefficients and weights, ensuring correct matrix transformations during refinement.

# Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
-----
