### PR TITLE
Add option to skip element extensions

### DIFF
--- a/src/gsHSplines/gsHElementHelper.h
+++ b/src/gsHSplines/gsHElementHelper.h
@@ -186,13 +186,13 @@ public:
     /// @param element The element to convert.
     /// @param targetLevel The target level for the refinement box.
     /// @return A vector of indices representing the refinement box at the target level.
-    std::vector<index_t> toRefBox(const element_t & element, level_t targetLevel) const;
-    std::vector<index_t> toRefBox(const element_t & element) const;
+    std::vector<index_t> toRefBox(const element_t & element, level_t targetLevel, bool extesnion = true) const;
+    std::vector<index_t> toRefBox(const element_t & element, bool extension = true) const;
 
     /// Convert a set of elements to refinement box indices
     /// @param elements The set of elements to convert.
     /// @return A vector of indices representing the refinement boxes of the elements.
-    std::vector<index_t> toRefBoxes(const HElementContainer & elements) const;
+    std::vector<index_t> toRefBoxes(const HElementContainer & elements, bool extension = true) const;
 
     /// Convert an element to coarsen box indices
     /// @param element The element to convert.

--- a/src/gsHSplines/gsHElementHelper.h
+++ b/src/gsHSplines/gsHElementHelper.h
@@ -185,12 +185,14 @@ public:
     /// Convert an element to refinement box indices
     /// @param element The element to convert.
     /// @param targetLevel The target level for the refinement box.
+    /// @param extension If true, element is extended.
     /// @return A vector of indices representing the refinement box at the target level.
-    std::vector<index_t> toRefBox(const element_t & element, level_t targetLevel, bool extesnion = true) const;
+    std::vector<index_t> toRefBox(const element_t & element, level_t targetLevel, bool extension = true) const;
     std::vector<index_t> toRefBox(const element_t & element, bool extension = true) const;
 
     /// Convert a set of elements to refinement box indices
     /// @param elements The set of elements to convert.
+    /// @param extension If true, elements are extended.
     /// @return A vector of indices representing the refinement boxes of the elements.
     std::vector<index_t> toRefBoxes(const HElementContainer & elements, bool extension = true) const;
 

--- a/src/gsHSplines/gsHElementHelper.hpp
+++ b/src/gsHSplines/gsHElementHelper.hpp
@@ -466,7 +466,7 @@ namespace gismo
     }
 
     template <short_t d, class T>
-    std::vector<index_t> gsHElementHelper<d,T>::toRefBox(const element_t & element, level_t targetLevel) const
+    std::vector<index_t> gsHElementHelper<d,T>::toRefBox(const element_t & element, level_t targetLevel, bool extension) const
     {
         GISMO_ASSERT(targetLevel > element.level(),
                      "Target level must be larger than the element level. "
@@ -484,11 +484,13 @@ namespace gismo
             degree = m_basis.degree(i);
             lowerIndex = element.lowerCorner()(i)*math::pow(2, diff);
             upperIndex = element.upperCorner()(i)*math::pow(2, diff);
-            if (degree % 2 == 1 && degree > 1)
-                ( (lowerIndex < (degree-1)/2-1) ? lowerIndex = 0 : lowerIndex -= (degree-1)/2-1);
-            else
-                ( (lowerIndex < (degree-1)/2)   ? lowerIndex = 0 : lowerIndex -= (degree-1)/2  );
-
+            if (extension)
+            {
+                if (degree % 2 == 1 && degree > 1)
+                    ( (lowerIndex < (degree-1)/2-1) ? lowerIndex = 0 : lowerIndex -= (degree-1)/2-1);
+                else
+                    ( (lowerIndex < (degree-1)/2)   ? lowerIndex = 0 : lowerIndex -= (degree-1)/2  );
+            }
             result[i+1] = lowerIndex;
             result[d+i+1] = upperIndex;
         }
@@ -497,19 +499,19 @@ namespace gismo
     }
 
     template <short_t d, class T>
-    std::vector<index_t> gsHElementHelper<d,T>::toRefBox(const element_t & element) const
+    std::vector<index_t> gsHElementHelper<d,T>::toRefBox(const element_t & element, bool extension) const
     {
-        return this->toRefBox(element, element.level() + 1);
+        return this->toRefBox(element, element.level() + 1, extension);
     }
 
     template <short_t d, class T>
-    std::vector<index_t> gsHElementHelper<d,T>::toRefBoxes(const HElementContainer & elements) const
+    std::vector<index_t> gsHElementHelper<d,T>::toRefBoxes(const HElementContainer & elements, bool extension) const
     {
         std::vector<index_t> refBoxes;
         refBoxes.reserve(elements.size() * (2 * d + 1));
         for (const auto & elem : elements)
         {
-            std::vector<index_t> refBox = this->toRefBox(elem);
+            std::vector<index_t> refBox = this->toRefBox(elem, extension);
             refBoxes.insert(refBoxes.end(), refBox.begin(), refBox.end());
         }
         return refBoxes;

--- a/src/gsHSplines/gsHElementMarker.hpp
+++ b/src/gsHSplines/gsHElementMarker.hpp
@@ -59,6 +59,7 @@ namespace gismo
         options.addInt("Admissibility","Admissibility region, 0=T-admissibility (default), 1=H-admissibility",0);
         options.addSwitch("Admissible","Mark the admissible region",true);
         options.addInt("Jump","Jump parameter m",2);
+        options.addSwitch("Extension", "Extend marked elements regions", true);
         // options.addInt("Verbose","Verbosity level",0);
         return options;
     }
@@ -126,7 +127,7 @@ namespace gismo
     template <short_t d, class T>
     std::vector<index_t> gsHElementMarker<d,T>::toRefBoxes(const HElementContainer & elements) const
     {
-        return m_helper.toRefBoxes(elements);
+        return m_helper.toRefBoxes(elements, m_options.askSwitch("Extension", true));
     }
 
     template <short_t d, class T>


### PR DESCRIPTION
Add `Extension` switch to skip extension  in `gsHElementMarker`:
```
gsHElementMarker<D, T> marker{basis};
marker.options().setSwitch("Extension", true);
```
This allows skipping the extension step of `gsHElementHelper::toRefBox`, which is useful for benchmarking when the refinement strategy is fixed.

------

NEW: 
`Extension` switch option in `gsHElementMarker`
`extension` function parameter (default: `true`) in `gsHElementHelper::toRefBox` and `gsHElementHelper::toRefBoxex` 

 ------

 Please consider the following checklist before issuing a pull
request:
- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?

-----
