### PR TITLE
fix output in basis example

### DIFF
--- a/examples/basis_example.cpp
+++ b/examples/basis_example.cpp
@@ -103,8 +103,7 @@ int main(int argc, char* argv[])
     gsInfo << "#Active basis functions at u: " << size(active) << ": \n"
            << active << "\n\n";
 
-    gsInfo << "Is number 2 active at the point ? " <<pBasis->isActive(0,u.col(0)) << ": \n"
-           << active << "\n\n";
+    gsInfo << "Is number 2 active at the point ? " <<pBasis->isActive(2,u.col(0)) << "\n";
 
 
     // values of all active functions at u


### PR DESCRIPTION
To know if the basis function 2 is active, one has the query that. There is no need to dump the variable "active" a second time.