### PR TITLE
Fix gsParasolid examples

### DIFF
--- a/optional/gsParasolid/CMakeLists.txt
+++ b/optional/gsParasolid/CMakeLists.txt
@@ -50,14 +50,17 @@ install(FILES   ${CMAKE_CURRENT_SOURCE_DIR}/gsReadParasolid.h
 endif()
 
 # add example files
-aux_cpp_directory(${CMAKE_CURRENT_SOURCE_DIR}/examples FILES)
-foreach(file ${FILES})
-    add_gismo_executable(${file})
-    get_filename_component(tarname ${file} NAME_WE) # name without extension
-    set_property(TEST ${tarname} PROPERTY LABELS "${PROJECT_NAME}")
-    set_target_properties(${tarname} PROPERTIES FOLDER "${PROJECT_NAME}")
-    # install the example executables (optionally)
-    install(TARGETS ${tarname} DESTINATION "${BIN_INSTALL_DIR}" COMPONENT exe OPTIONAL)
-endforeach(file ${FILES})
+if(GISMO_BUILD_EXAMPLES)
+    aux_cpp_directory(${CMAKE_CURRENT_SOURCE_DIR}/examples FILES)
+    foreach(file ${FILES})
+        add_gismo_executable(${file})
+        get_filename_component(tarname ${file} NAME_WE) # name without extension
+        set_property(TEST ${tarname} PROPERTY LABELS "${PROJECT_NAME}")
+        set_target_properties(${tarname} PROPERTIES FOLDER "${PROJECT_NAME}")
+        # install the example executables (optionally)
+        install(TARGETS ${tarname} DESTINATION "${BIN_INSTALL_DIR}" COMPONENT exe OPTIONAL)
+    endforeach(file ${FILES})
+endif(GISMO_BUILD_EXAMPLES)
+
 
 #set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})

--- a/optional/gsParasolid/examples/gsParasolidExportMesh.cpp
+++ b/optional/gsParasolid/examples/gsParasolidExportMesh.cpp
@@ -38,10 +38,8 @@ int main(int argc, char *argv[])
 	      << "--------------------------------------------------\n" << std::endl;
     
     gsGeometry<>::uPtr geom = gsReadFile<>(input);
-    
-    gsMesh<> mesh;
-    
-    makeMesh<>( geom->basis(), mesh, 5);
+
+    gsMesh<> mesh (geom->basis(), 5);
     
     geom->evaluateMesh(mesh);
     


### PR DESCRIPTION
FIXED: Fix `gsParasolidExportMesh`
FIXED: Obey GISMO_BUILD_EXAMPLES in gsParasolid

`gsParasolidExportMesh` still used `makeMesh<>`, which does not exist anymore. The functionality is now a constructor of ` gsMesh`.
Moreover, the CMakeLists of gsParasolid did not apply the flag GISMO_BUILD_EXAMPLES, so examples were built regardless.