### PR TITLE
Parasolid closest point computation for parameter correction

### DIFF
--- a/optional/gsParasolid/CMakeLists.txt
+++ b/optional/gsParasolid/CMakeLists.txt
@@ -46,6 +46,7 @@ if(GISMO_BUILD_LIB)
 install(FILES   ${CMAKE_CURRENT_SOURCE_DIR}/gsReadParasolid.h
 		${CMAKE_CURRENT_SOURCE_DIR}/gsWriteParasolid.h
 		${CMAKE_CURRENT_SOURCE_DIR}/gsPKSession.h
+		${CMAKE_CURRENT_SOURCE_DIR}/gsClosestPoint.h
         DESTINATION include/gismo/gsParasolid/)
 endif()
 

--- a/optional/gsParasolid/gsClosestPoint.cpp
+++ b/optional/gsParasolid/gsClosestPoint.cpp
@@ -1,0 +1,37 @@
+/** @file gsClosestPoint.cpp
+
+    @brief Provides instantization of gsClosestPoint functions.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): D. Mokris
+*/
+
+#include <gsCore/gsTemplateTools.h>
+
+#include <gsParasolid/gsClosestPoint.h>
+#include <gsParasolid/gsClosestPoint.hpp>
+
+namespace gismo
+{
+namespace extensions
+{
+TEMPLATE_INST PK_VECTOR_t
+gsPK_VECTOR(const gsVector<real_t, 3>& gsVector);
+
+TEMPLATE_INST bool
+gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
+               const gsVector<real_t, 3>& gsPoint,
+               gsVector<real_t, 2>& gsResult);
+
+TEMPLATE_INST bool
+gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
+               const gsMatrix<real_t>& gsPoints,
+               gsMatrix<real_t>& gsResults);
+
+} // namespace extensions
+} // namespace gismo

--- a/optional/gsParasolid/gsClosestPoint.cpp
+++ b/optional/gsParasolid/gsClosestPoint.cpp
@@ -11,8 +11,6 @@
     Author(s): D. Mokris
 */
 
-#include <gsCore/gsTemplateTools.h>
-
 #include <gsParasolid/gsClosestPoint.h>
 #include <gsParasolid/gsClosestPoint.hpp>
 

--- a/optional/gsParasolid/gsClosestPoint.cpp
+++ b/optional/gsParasolid/gsClosestPoint.cpp
@@ -26,12 +26,14 @@ gsPK_VECTOR(const gsVector<real_t, 3>& gsVector);
 TEMPLATE_INST bool
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsVector<real_t, 3>& gsPoint,
-               gsVector<real_t, 2>& gsResult);
+               gsVector<real_t, 2>& gsResult,
+               bool performance = true);
 
 TEMPLATE_INST bool
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsMatrix<real_t>& gsPoints,
-               gsMatrix<real_t>& gsResults);
+               gsMatrix<real_t>& gsResults,
+               bool performance = true);
 
 } // namespace extensions
 } // namespace gismo

--- a/optional/gsParasolid/gsClosestPoint.cpp
+++ b/optional/gsParasolid/gsClosestPoint.cpp
@@ -21,13 +21,13 @@ namespace extensions
 TEMPLATE_INST PK_VECTOR_t
 gsPK_VECTOR(const gsVector<real_t, 3>& gsVector);
 
-TEMPLATE_INST bool
+TEMPLATE_INST PK_ERROR_code_t
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsVector<real_t, 3>& gsPoint,
                gsVector<real_t, 2>& gsResult,
                bool performance);
 
-TEMPLATE_INST bool
+TEMPLATE_INST PK_ERROR_code_t
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsMatrix<real_t>& gsPoints,
                gsMatrix<real_t>& gsResults,

--- a/optional/gsParasolid/gsClosestPoint.cpp
+++ b/optional/gsParasolid/gsClosestPoint.cpp
@@ -25,13 +25,13 @@ TEMPLATE_INST PK_ERROR_code_t
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsVector<real_t, 3>& gsPoint,
                gsVector<real_t, 2>& gsResult,
-               range::opt optimise);
+               range_opt optimise);
 
 TEMPLATE_INST PK_ERROR_code_t
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsMatrix<real_t>& gsPoints,
                gsMatrix<real_t>& gsResults,
-               range::opt optimise);
+               range_opt optimise);
 
 } // namespace extensions
 } // namespace gismo

--- a/optional/gsParasolid/gsClosestPoint.cpp
+++ b/optional/gsParasolid/gsClosestPoint.cpp
@@ -27,13 +27,13 @@ TEMPLATE_INST bool
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsVector<real_t, 3>& gsPoint,
                gsVector<real_t, 2>& gsResult,
-               bool performance = true);
+               bool performance);
 
 TEMPLATE_INST bool
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsMatrix<real_t>& gsPoints,
                gsMatrix<real_t>& gsResults,
-               bool performance = true);
+               bool performance);
 
 } // namespace extensions
 } // namespace gismo

--- a/optional/gsParasolid/gsClosestPoint.cpp
+++ b/optional/gsParasolid/gsClosestPoint.cpp
@@ -25,13 +25,13 @@ TEMPLATE_INST PK_ERROR_code_t
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsVector<real_t, 3>& gsPoint,
                gsVector<real_t, 2>& gsResult,
-               bool performance);
+               range::opt optimise);
 
 TEMPLATE_INST PK_ERROR_code_t
 gsClosestParam(const gsTensorBSpline<2, real_t>& gsBSurf,
                const gsMatrix<real_t>& gsPoints,
                gsMatrix<real_t>& gsResults,
-               bool performance);
+               range::opt optimise);
 
 } // namespace extensions
 } // namespace gismo

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -1,0 +1,75 @@
+/** @file gsClosestPoint.h
+
+    @brief Provides declarations of functions for determining the
+    closest point and parameter on a geometry to a given point using
+    Parasolid functionality.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): D. Mokris
+*/
+
+#pragma once
+
+#include <gsCore/gsForwardDeclarations.h>
+#include <gsParasolid/gsPKSession.h>
+
+// TODO: Why can't I include gsFrustrum.h already here?
+
+struct PK_VECTOR_s;
+typedef struct PK_VECTOR_s PK_VECTOR_t;
+
+namespace gismo
+{
+    namespace extensions
+    {
+        /// Converts a G+Smo vector to a Parasolid vector.
+        template <class T>
+        PK_VECTOR_t gsPK_VECTOR(const gsVector<T, 3>& gsVector);
+
+        /**
+           Finds the point on \a gsBSurf that is closest to \a point
+           and writes its parameter values into \a result.
+           Returns Parasolid error status.
+        */
+        template <class T>
+        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                            const gsVector<T, 3>& gsPoint,
+                            gsVector<T, 2>& gsResult);
+
+        /**
+           For each three-dimensional point represented as a row of \a
+           gsPoints finds the closest point on \a gsBSurf and writes
+           its parameters as a column of \a gsResults. (This might
+           sound strange but it corresponds to the ordering in
+           gsFitting.  Returns Parasolid error status.
+        */
+        template <class T>
+        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                            const gsMatrix<T>& gsPoints,
+                            gsMatrix<T>& gsResults);
+
+        /**
+           Finds the point on \a gsBSurf that is closest to \a point
+           and writes it into \a result.
+           Returns Parasolid error status.
+
+           TODO: Not implemented, yet.
+        */
+        template <class T>
+        bool gsClosestPoint(const gsTensorBSpline<2, T>& gsBSurf,
+                            const gsVector<T, 3>& gsPoint,
+                            gsVector<T, 3>& gsResult)
+        {
+            gsWarn << "This function is not implemented, yet." << std::endl;
+            return false;
+        }
+
+    } // namespace extensions
+
+} // namespace gismo
+    

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -45,7 +45,7 @@ namespace gismo
            Finds the point on \a gsBSurf that is closest to \a gsPoint
            and writes its parameter values into \a gsResult. The
            optional parameter \a performance decides between
-           performance (true) and precision (false). Returns Parasolid
+           performance and accuracy. Returns Parasolid
            error status.
         */
         template <class T>
@@ -60,7 +60,7 @@ namespace gismo
            its parameters as a column of \a gsResults. (This might
            sound strange but it corresponds to the ordering in
            gsFitting.) The optional parameter \a performance decides
-           between performance (true) and precision (false). Returns
+           between performance and accuracy. Returns
            Parasolid error status.
         */
         template <class T>

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -32,6 +32,15 @@ namespace gismo
         template <class T>
         PK_VECTOR_t gsPK_VECTOR(const gsVector<T, 3>& gsVector);
 
+        struct range
+        {
+            enum opt
+            {
+                performance = 23760,
+                accuracy    = 23761
+            };
+        };
+
         /**
            Finds the point on \a gsBSurf that is closest to \a gsPoint
            and writes its parameter values into \a gsResult. The
@@ -43,7 +52,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsVector<T, 3>& gsPoint,
                                        gsVector<T, 2>& gsResult,
-                                       bool performance = true);
+                                       range::opt optimise = range::opt::performance);
 
         /**
            For each three-dimensional point represented as a row of \a
@@ -58,7 +67,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsMatrix<T>& gsPoints,
                                        gsMatrix<T>& gsResults,
-                                       bool performance = true);
+                                       range::opt optimise = range::opt::performance);
 
     } // namespace extensions
 

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -33,25 +33,31 @@ namespace gismo
 
         /**
            Finds the point on \a gsBSurf that is closest to \a point
-           and writes its parameter values into \a result.
-           Returns Parasolid error status.
+           and writes its parameter values into \a result. The
+           optional parameter \a performance decides between
+           performance (true) and precision (false). Returns Parasolid
+           error status.
         */
         template <class T>
         bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                             const gsVector<T, 3>& gsPoint,
-                            gsVector<T, 2>& gsResult);
+                            gsVector<T, 2>& gsResult,
+                            bool performance = true);
 
         /**
            For each three-dimensional point represented as a row of \a
            gsPoints finds the closest point on \a gsBSurf and writes
            its parameters as a column of \a gsResults. (This might
            sound strange but it corresponds to the ordering in
-           gsFitting.  Returns Parasolid error status.
+           gsFitting.  The optional parameter \a performance decides
+           between performance (true) and precision (false).  Returns
+           Parasolid error status.
         */
         template <class T>
         bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                             const gsMatrix<T>& gsPoints,
-                            gsMatrix<T>& gsResults);
+                            gsMatrix<T>& gsResults,
+                            bool performance = true);
 
         /**
            Finds the point on \a gsBSurf that is closest to \a point

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <gsCore/gsForwardDeclarations.h>
+#include <gsCore/gsLinearAlgebra.h>
+
 #include <gsParasolid/gsPKSession.h>
 
 // TODO: Why can't I include gsFrustrum.h already here?

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -34,13 +34,10 @@ namespace gismo
         template <class T>
         PK_VECTOR_t gsPK_VECTOR(const gsVector<T, 3>& gsVector);
 
-        struct range
+        enum range_opt
         {
-            enum opt
-            {
-                performance = 23760,
-                accuracy    = 23761
-            };
+            performance = 23760,
+            accuracy    = 23761
         };
 
         /**
@@ -54,7 +51,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsVector<T, 3>& gsPoint,
                                        gsVector<T, 2>& gsResult,
-                                       range::opt optimise = range::opt::performance);
+                                       range_opt optimise = range_opt::performance);
 
         /**
            For each three-dimensional point represented as a row of \a
@@ -69,7 +66,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsMatrix<T>& gsPoints,
                                        gsMatrix<T>& gsResults,
-                                       range::opt optimise = range::opt::performance);
+                                       range_opt optimise = range_opt::performance);
 
     } // namespace extensions
 

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -32,8 +32,8 @@ namespace gismo
         PK_VECTOR_t gsPK_VECTOR(const gsVector<T, 3>& gsVector);
 
         /**
-           Finds the point on \a gsBSurf that is closest to \a point
-           and writes its parameter values into \a result. The
+           Finds the point on \a gsBSurf that is closest to \a gsPoint
+           and writes its parameter values into \a gsResult. The
            optional parameter \a performance decides between
            performance (true) and precision (false). Returns Parasolid
            error status.
@@ -49,8 +49,8 @@ namespace gismo
            gsPoints finds the closest point on \a gsBSurf and writes
            its parameters as a column of \a gsResults. (This might
            sound strange but it corresponds to the ordering in
-           gsFitting.  The optional parameter \a performance decides
-           between performance (true) and precision (false).  Returns
+           gsFitting.) The optional parameter \a performance decides
+           between performance (true) and precision (false). Returns
            Parasolid error status.
         */
         template <class T>

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -22,6 +22,7 @@
 
 struct PK_VECTOR_s;
 typedef struct PK_VECTOR_s PK_VECTOR_t;
+typedef int PK_ERROR_code_t;
 
 namespace gismo
 {
@@ -39,10 +40,10 @@ namespace gismo
            error status.
         */
         template <class T>
-        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
-                            const gsVector<T, 3>& gsPoint,
-                            gsVector<T, 2>& gsResult,
-                            bool performance = true);
+        PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                                       const gsVector<T, 3>& gsPoint,
+                                       gsVector<T, 2>& gsResult,
+                                       bool performance = true);
 
         /**
            For each three-dimensional point represented as a row of \a
@@ -54,10 +55,10 @@ namespace gismo
            Parasolid error status.
         */
         template <class T>
-        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
-                            const gsMatrix<T>& gsPoints,
-                            gsMatrix<T>& gsResults,
-                            bool performance = true);
+        PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                                       const gsMatrix<T>& gsPoints,
+                                       gsMatrix<T>& gsResults,
+                                       bool performance = true);
 
     } // namespace extensions
 

--- a/optional/gsParasolid/gsClosestPoint.h
+++ b/optional/gsParasolid/gsClosestPoint.h
@@ -59,22 +59,6 @@ namespace gismo
                             gsMatrix<T>& gsResults,
                             bool performance = true);
 
-        /**
-           Finds the point on \a gsBSurf that is closest to \a point
-           and writes it into \a result.
-           Returns Parasolid error status.
-
-           TODO: Not implemented, yet.
-        */
-        template <class T>
-        bool gsClosestPoint(const gsTensorBSpline<2, T>& gsBSurf,
-                            const gsVector<T, 3>& gsPoint,
-                            gsVector<T, 3>& gsResult)
-        {
-            gsWarn << "This function is not implemented, yet." << std::endl;
-            return false;
-        }
-
     } // namespace extensions
 
 } // namespace gismo

--- a/optional/gsParasolid/gsClosestPoint.hpp
+++ b/optional/gsParasolid/gsClosestPoint.hpp
@@ -15,7 +15,9 @@
 
 #include <gsParasolid/gsFrustrum.h>
 #include <gsParasolid/gsClosestPoint.h>
-#include <gsParasolid/gsWriteParasolid.h>
+#include <gsParasolid/gsPKUtils.h>
+
+#include <gsMatrix/gsVector.h>
 
 namespace gismo
 {

--- a/optional/gsParasolid/gsClosestPoint.hpp
+++ b/optional/gsParasolid/gsClosestPoint.hpp
@@ -36,7 +36,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsVector<T, 3>& gsPoint,
                                        gsVector<T, 2>& gsResult,
-                                       bool performance)
+                                       range::opt optimise)
         {
 			gsPKSession::start();
             PK_BSURF_t               bsurf;
@@ -48,7 +48,7 @@ namespace gismo
             PK_GEOM_range_vector_o_t options;
             PK_GEOM_range_vector_o_m(options);
 
-            if(performance)
+            if(optimise == range::opt::performance)
                 options.opt_level =  PK_range_opt_performance_c;
             else
                 options.opt_level =  PK_range_opt_accuracy_c;
@@ -72,7 +72,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsMatrix<T>& gsPoints,
                                        gsMatrix<T>& gsResults,
-                                       bool performance)
+                                       range::opt optimise)
         {
             GISMO_ASSERT(gsPoints.cols() == 3, "gsClosestParam is implemented for three-dimensional points only.");
             PK_BSURF_t               bsurf;
@@ -89,7 +89,7 @@ namespace gismo
             PK_GEOM_range_vector_many_o_t options;
             PK_GEOM_range_vector_many_o_m(options);
 
-            if(performance)
+            if(optimise == range::opt::performance)
                 options.opt_level =  PK_range_opt_performance_c;
             else
                 options.opt_level =  PK_range_opt_accuracy_c;

--- a/optional/gsParasolid/gsClosestPoint.hpp
+++ b/optional/gsParasolid/gsClosestPoint.hpp
@@ -35,7 +35,8 @@ namespace gismo
         template <class T>
         bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                             const gsVector<T, 3>& gsPoint,
-                            gsVector<T, 2>& gsResult)
+                            gsVector<T, 2>& gsResult,
+                            bool performance)
         {
 			gsPKSession::start();
             PK_BSURF_t               bsurf;
@@ -46,8 +47,11 @@ namespace gismo
 
             PK_GEOM_range_vector_o_t options;
             PK_GEOM_range_vector_o_m(options);
-            options.opt_level =      PK_range_opt_performance_c;
-            //options.opt_level =      PK_range_opt_accuracy_c;
+
+            if(performance)
+                options.opt_level =  PK_range_opt_performance_c;
+            else
+                options.opt_level =  PK_range_opt_accuracy_c;
 
             PK_range_result_t        range_result;
             PK_range_1_r_t           range;
@@ -67,7 +71,8 @@ namespace gismo
         template <class T>
         bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                             const gsMatrix<T>& gsPoints,
-                            gsMatrix<T>& gsResults)
+                            gsMatrix<T>& gsResults,
+                            bool performance)
         {
             GISMO_ASSERT(gsPoints.cols() == 3, "gsClosestParam is implemented for three-dimensional points only.");
             PK_BSURF_t               bsurf;
@@ -84,12 +89,10 @@ namespace gismo
             PK_GEOM_range_vector_many_o_t options;
             PK_GEOM_range_vector_many_o_m(options);
 
-            // Keeping the opt_level at PK_range_opt_performace_c
-            // (default) lead to slightly different results between
-            // the two versions of this function.
-			//gsInfo << "accuracy!" << std::endl;
-            //options.opt_level =      PK_range_opt_performance_c;
-            options.opt_level =      PK_range_opt_accuracy_c;
+            if(performance)
+                options.opt_level =  PK_range_opt_performance_c;
+            else
+                options.opt_level =  PK_range_opt_accuracy_c;
 
             PK_range_result_t        range_result[n_vectors];
             PK_range_1_r_t           ranges[n_vectors];
@@ -99,7 +102,6 @@ namespace gismo
             if(err)
                 gsWarn << "err: " << err << std::endl;
 
-            // gsResults.col(i) = (u[i], v[i])
             gsResults.resize(2, n_vectors);
             for(int j=0; j<n_vectors; j++)
                 for(int i=0; i<2; i++)

--- a/optional/gsParasolid/gsClosestPoint.hpp
+++ b/optional/gsParasolid/gsClosestPoint.hpp
@@ -1,0 +1,113 @@
+/** @file gsClosestPoint.h
+
+    @brief Provides definitions of functions for determining the
+    closest point and parameter on a geometry to a given point using
+    Parasolid functionality.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): D. Mokris
+*/
+
+#include <gsParasolid/gsFrustrum.h>
+#include <gsParasolid/gsClosestPoint.h>
+#include <gsParasolid/gsWriteParasolid.h>
+
+namespace gismo
+{
+    namespace extensions
+    {
+        template <class T>
+        PK_VECTOR_t gsPK_VECTOR(const gsVector<T, 3>& gsVector)
+        {
+            PK_VECTOR_t result;
+
+            for(index_t i=0; i<3; i++)
+                result.coord[i] = double(gsVector(i));
+
+            return result;
+        }
+
+        template <class T>
+        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                            const gsVector<T, 3>& gsPoint,
+                            gsVector<T, 2>& gsResult)
+        {
+			gsPKSession::start();
+            PK_BSURF_t               bsurf;
+            createPK_BSURF<T>(gsBSurf, bsurf, false, false);
+            // TODO: What shall we do about periodic surfaces?
+
+            PK_VECTOR_t              point = gsPK_VECTOR(gsPoint);
+
+            PK_GEOM_range_vector_o_t options;
+            PK_GEOM_range_vector_o_m(options);
+            options.opt_level =      PK_range_opt_performance_c;
+            //options.opt_level =      PK_range_opt_accuracy_c;
+
+            PK_range_result_t        range_result;
+            PK_range_1_r_t           range;
+
+            PK_ERROR_code_t err =    PK_GEOM_range_vector(bsurf, point, &options,
+                                                          &range_result, &range);
+            if(err)
+                gsWarn << "err: " << err << std::endl;
+
+            for(index_t i=0; i<2; i++)
+                gsResult(i) = range.end.parameters[i];
+
+			gsPKSession::stop();
+            return err;
+        }
+
+        template <class T>
+        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                            const gsMatrix<T>& gsPoints,
+                            gsMatrix<T>& gsResults)
+        {
+            GISMO_ASSERT(gsPoints.cols() == 3, "gsClosestParam is implemented for three-dimensional points only.");
+            PK_BSURF_t               bsurf;
+            createPK_BSURF<T>(gsBSurf, bsurf, false, false);
+
+            int                      n_vectors = gsPoints.rows();
+            PK_VECTOR_t              vectors[n_vectors];
+            for(int i=0; i<n_vectors; i++)
+            {
+                gsVector<T, 3> point = gsPoints.row(i);
+                vectors[i] = gsPK_VECTOR(point);
+            }
+
+            PK_GEOM_range_vector_many_o_t options;
+            PK_GEOM_range_vector_many_o_m(options);
+
+            // Keeping the opt_level at PK_range_opt_performace_c
+            // (default) lead to slightly different results between
+            // the two versions of this function.
+			//gsInfo << "accuracy!" << std::endl;
+            //options.opt_level =      PK_range_opt_performance_c;
+            options.opt_level =      PK_range_opt_accuracy_c;
+
+            PK_range_result_t        range_result[n_vectors];
+            PK_range_1_r_t           ranges[n_vectors];
+
+            PK_ERROR_code_t err =    PK_GEOM_range_vector_many(bsurf, n_vectors, vectors, &options,
+                                                               range_result, ranges);
+            if(err)
+                gsWarn << "err: " << err << std::endl;
+
+            // gsResults.col(i) = (u[i], v[i])
+            gsResults.resize(2, n_vectors);
+            for(int j=0; j<n_vectors; j++)
+                for(int i=0; i<2; i++)
+                    gsResults(i, j) = ranges[j].end.parameters[i];
+
+            return err;
+        }
+
+    } // namespace extensions
+
+} // namespace gismo

--- a/optional/gsParasolid/gsClosestPoint.hpp
+++ b/optional/gsParasolid/gsClosestPoint.hpp
@@ -38,7 +38,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsVector<T, 3>& gsPoint,
                                        gsVector<T, 2>& gsResult,
-                                       range::opt optimise)
+                                       range_opt optimise)
         {
 			gsPKSession::start();
             PK_BSURF_t               bsurf;
@@ -50,10 +50,7 @@ namespace gismo
             PK_GEOM_range_vector_o_t options;
             PK_GEOM_range_vector_o_m(options);
 
-            if(optimise == range::opt::performance)
-                options.opt_level =  PK_range_opt_performance_c;
-            else
-                options.opt_level =  PK_range_opt_accuracy_c;
+			options.opt_level =      optimise;
 
             PK_range_result_t        range_result;
             PK_range_1_r_t           range;
@@ -74,7 +71,7 @@ namespace gismo
         PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
                                        const gsMatrix<T>& gsPoints,
                                        gsMatrix<T>& gsResults,
-                                       range::opt optimise)
+                                       range_opt optimise)
         {
             GISMO_ASSERT(gsPoints.cols() == 3, "gsClosestParam is implemented for three-dimensional points only.");
             PK_BSURF_t               bsurf;
@@ -91,10 +88,7 @@ namespace gismo
             PK_GEOM_range_vector_many_o_t options;
             PK_GEOM_range_vector_many_o_m(options);
 
-            if(optimise == range::opt::performance)
-                options.opt_level =  PK_range_opt_performance_c;
-            else
-                options.opt_level =  PK_range_opt_accuracy_c;
+			options.opt_level =      optimise;
 
             PK_range_result_t        range_result[n_vectors];
             PK_range_1_r_t           ranges[n_vectors];

--- a/optional/gsParasolid/gsClosestPoint.hpp
+++ b/optional/gsParasolid/gsClosestPoint.hpp
@@ -33,10 +33,10 @@ namespace gismo
         }
 
         template <class T>
-        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
-                            const gsVector<T, 3>& gsPoint,
-                            gsVector<T, 2>& gsResult,
-                            bool performance)
+        PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                                       const gsVector<T, 3>& gsPoint,
+                                       gsVector<T, 2>& gsResult,
+                                       bool performance)
         {
 			gsPKSession::start();
             PK_BSURF_t               bsurf;
@@ -69,10 +69,10 @@ namespace gismo
         }
 
         template <class T>
-        bool gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
-                            const gsMatrix<T>& gsPoints,
-                            gsMatrix<T>& gsResults,
-                            bool performance)
+        PK_ERROR_code_t gsClosestParam(const gsTensorBSpline<2, T>& gsBSurf,
+                                       const gsMatrix<T>& gsPoints,
+                                       gsMatrix<T>& gsResults,
+                                       bool performance)
         {
             GISMO_ASSERT(gsPoints.cols() == 3, "gsClosestParam is implemented for three-dimensional points only.");
             PK_BSURF_t               bsurf;

--- a/optional/gsParasolid/gsPKUtils.cpp
+++ b/optional/gsParasolid/gsPKUtils.cpp
@@ -1,0 +1,34 @@
+/** @file gsPKUtils.cpp
+
+    @brief Provides instantization of gsPKUtils functions.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): A. Mantzaflaris, D. Mokris
+*/
+
+#include <gsParasolid/gsPKUtils.h>
+#include <gsParasolid/gsPKUtils.hpp>
+
+namespace gismo {
+namespace extensions {
+
+TEMPLATE_INST bool
+createPK_BSURF(const gsTensorBSpline< 2, real_t> & bsp, 
+			   PK_BSURF_t & bsurf,
+			   bool closed_u, 
+			   bool closed_v);
+
+TEMPLATE_INST bool
+createPK_BCURVE(const gsBSpline<real_t>& curve, PK_BCURVE_t& bcurve);
+
+TEMPLATE_INST bool
+createPK_GEOM(const gsGeometry<real_t> & ggeo, PK_GEOM_t & pgeo);
+
+} // namespace extensions
+
+} // namespace gismo

--- a/optional/gsParasolid/gsPKUtils.h
+++ b/optional/gsParasolid/gsPKUtils.h
@@ -1,0 +1,54 @@
+/** @file gsPKUtils.h
+
+    @brief Provides headers of utilities functions used by other parts of gsParasolid.
+
+    This file is part of the G+Smo library. 
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    
+    Author(s): A. Mantzaflaris, D. Mokris
+*/
+
+#pragma once
+
+#include <gsCore/gsForwardDeclarations.h>
+
+#include <gsParasolid/gsPKSession.h>
+
+typedef int PK_BSURF_t;
+typedef int PK_BCURVE_t;
+typedef int PK_GEOM_t;
+
+namespace gismo {
+
+	namespace extensions {
+
+		// returns true la all multiplicities in muls are less (<) than deg + 1
+        // parasolid restriction
+		bool validMultiplicities(const std::vector<index_t>& mult,
+								 const int deg);
+
+		/// Translates a gsTensorBSpline to a PK_BSURF_t
+		/// \param[in] bsp B-spline surface
+		/// \param[out] bsurf Parasolid spline surface
+		template<class T>
+			bool createPK_BSURF( const gsTensorBSpline< 2,T> & bsp, PK_BSURF_t & bsurf,
+								 bool closed_u = false, bool closed_v = false );
+
+		/// Translates a gsBSpline to a PK_BCURVE_t
+		/// \param[in] curve B-Spline surve
+		/// \param[out] bcurve Parasolid spline curve
+		template<class T> 
+			bool createPK_BCURVE( const gsBSpline<T>& curve, PK_BCURVE_t& bcurve );
+
+		/// Translates a gsGeometry to a PK_GEOM_t
+		/// \param[in] ggeo inpute G+SMO geometry
+		/// \param[out] pgeo Parasolid geometric entity
+		template<class T> 
+			bool createPK_GEOM( const gsGeometry<T> & ggeo, PK_GEOM_t & pgeo );
+
+	} // namespace extensions
+
+} // namespace gismo

--- a/optional/gsParasolid/gsPKUtils.hpp
+++ b/optional/gsParasolid/gsPKUtils.hpp
@@ -1,0 +1,217 @@
+/** @file gsWriteParasolid.hpp
+
+    @brief Provides implementation of gsWriteParasolid function.
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): A. Mantzaflaris, D. Mokris
+*/
+
+#include <gsParasolid/gsPKUtils.h>
+
+#include <gsParasolid/gsFrustrum.h>
+
+#include <gsCore/gsLinearAlgebra.h>
+#include <gsNurbs/gsKnotVector.h>
+#include <gsNurbs/gsTensorBSpline.h>
+#include <gsNurbs/gsBSpline.h>
+
+namespace gismo {
+
+namespace extensions {
+
+bool validMultiplicities(const std::vector<index_t>& mult,
+                         const int deg)
+{
+    for (size_t i = 1; i != mult.size() - 1; i++)
+    {
+        if (mult[i] == deg + 1)
+        {
+            std::cout <<
+                "Only B-Splines with (inner) multiplicity less (<) "
+                "than degree + 1 are supported. \n"
+                "Parasolid restriction."
+                      << std::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+template<class T>
+bool createPK_BSURF(const gsTensorBSpline< 2, T> & bsp,
+                    PK_BSURF_t & bsurf,
+                    bool closed_u,
+                    bool closed_v)
+{
+    typedef typename gsKnotVector<T>::mult_t mult_t;
+    std::vector<mult_t> mult;
+
+    // Gismo and Parasolid store the coefficients in different order.
+    // Therefore we create the BSURF with u and v swapped and then transpose it.
+    for (index_t dim = 0; dim != 2; dim++)
+    {
+        const int deg = bsp.basis().degree(dim);
+        mult = bsp.basis().knots(dim).multiplicities();
+
+        if (!validMultiplicities(mult, deg))
+        {
+            return false;
+        }
+    }
+
+    // Translate to parasolid standard form, ie fill up parasolid
+    // spline data record
+    PK_BSURF_sf_t sform;   // B-spline data holder (standard form)
+
+    // Degrees
+    sform.u_degree      = bsp.basis().degree(1);
+    sform.v_degree      = bsp.basis().degree(0);
+
+    // Knots in u-direction
+    std::vector<T> gknot0 = bsp.basis().knots(1).unique();
+    std::vector<mult_t> gmult0 = bsp.basis().knots(1).multiplicities();
+    sform.n_u_knots     = gknot0.size();
+    sform.u_knot        = gknot0.data();
+    sform.u_knot_mult   = gmult0.data();
+
+    // Knots in v-direction
+    std::vector<T> gknot1 = bsp.basis().knots(0).unique();
+    std::vector<mult_t> gmult1 = bsp.basis().knots(0).multiplicities();
+    sform.n_v_knots     = gknot1.size();
+    sform.v_knot        = gknot1.data();
+    sform.v_knot_mult   = gmult1.data();
+
+    // Control points
+    sform.n_u_vertices  = bsp.basis().size(1);
+    sform.n_v_vertices  = bsp.basis().size(0);
+    gsMatrix<T> coefs   = bsp.coefs();
+    const int n = bsp.geoDim();
+    if ( n < 3 )
+    {
+        coefs.conservativeResize(gsEigen::NoChange, 3);
+        coefs.rightCols(3-n).setZero();
+    }
+    coefs.transposeInPlace();
+    coefs.resize(3*bsp.basis().size(), 1);
+    sform.vertex_dim    = 3; // always 3 for surfaces
+    sform.vertex        = coefs.data();
+
+    // Attributes
+    sform.is_rational   = PK_LOGICAL_false;
+    sform.form          = PK_BSURF_form_unset_c;
+    sform.u_knot_type   = PK_knot_unset_c;
+    sform.v_knot_type   = PK_knot_unset_c;
+    sform.is_u_periodic = PK_LOGICAL_false;
+    sform.is_v_periodic = PK_LOGICAL_false;
+    sform.is_u_closed   = PK_LOGICAL_false;
+    sform.is_v_closed   = PK_LOGICAL_false;
+
+    if (closed_u)
+    {
+        sform.is_v_closed = PK_LOGICAL_true;
+    }
+
+    if (closed_v)
+    {
+        sform.is_u_closed = PK_LOGICAL_true;
+    }
+
+    sform.self_intersecting = PK_self_intersect_unset_c;
+    sform.convexity         = PK_convexity_unset_c;
+
+    // Create parasolid surface with the previous spline data
+    PK_ERROR_code_t err = PK_BSURF_create(&sform, &bsurf);
+    PARASOLID_ERROR(PK_BSURF_create, err);
+
+    // Transposition (new on 2019-02-26).
+    PK_BSURF_reparameterise_o_t options;
+    PK_BSURF_reparameterise_o_m(options);
+    options.transpose = PK_LOGICAL_true;
+
+    err = PK_BSURF_reparameterise(bsurf,&options);
+    PARASOLID_ERROR(PK_BSURF_reparameterise, err);
+
+    return true;
+}
+
+
+template<class T>
+bool createPK_BCURVE( const gsBSpline<T>& curve,
+                      PK_BCURVE_t& bcurve)
+{
+    typedef typename gsKnotVector<T>::mult_t mult_t;
+    
+    PK_BCURVE_sf_t sform; // B-curve data holder (standard form)
+
+    // Degree
+    sform.degree = curve.degree();
+
+    // Knots
+    std::vector<T> knots = curve.basis().knots().unique();
+    std::vector<mult_t> mult = curve.basis().knots().multiplicities();
+    sform.n_knots = knots.size();
+    sform.knot = knots.data();
+    sform.knot_mult = mult.data();
+
+
+    // Control points
+    sform.n_vertices = curve.basis().size();
+    gsMatrix<T> coefs = curve.coefs();
+    const int n = curve.geoDim();
+    if (n < 3)
+    {
+        coefs.conservativeResize(gsEigen::NoChange, 3);
+        coefs.rightCols(3 - n).setZero();
+    }
+    coefs.transposeInPlace();
+    coefs.resize(3 * curve.basis().size(), 1);
+    sform.vertex_dim = 3;
+    sform.vertex = coefs.data();
+
+    // Attributes
+    sform.is_rational = PK_LOGICAL_false;
+    sform.form = PK_BCURVE_form_unset_c;
+    sform.knot_type = PK_knot_unset_c;
+    sform.is_periodic = PK_LOGICAL_false;
+    sform.is_closed = PK_LOGICAL_false;
+    sform.self_intersecting = PK_self_intersect_unset_c;
+
+    PK_ERROR_code_t err = PK_BCURVE_create(&sform, &bcurve);
+    PARASOLID_ERROR(PK_BCURVE_create, err);
+
+    return true;
+}
+
+
+template<class T>
+bool createPK_GEOM( const gsGeometry<T> & ggeo,
+                    PK_GEOM_t & pgeo)
+{
+    // Identify input gismo geometry
+    if ( const gsTensorBSpline<2,T> * tbsp =
+         dynamic_cast<const gsTensorBSpline<2,T> *>(&ggeo) )
+    {
+        return createPK_BSURF(*tbsp, pgeo);
+    }
+// the following lines produce warnings if called from multipatch version of gsWriteParasolid,
+// because it already assumes that the geometries are surfaces
+    else if ( const gsBSpline<>* bspl =
+              dynamic_cast< const gsBSpline<>* >(&ggeo) )
+    {
+        return createPK_BCURVE(*bspl, pgeo);
+    }
+    else
+    {
+        gsInfo << "Cannot write "<<ggeo<<" to parasolid file.\n";
+        return false;
+    }
+}
+
+} // namespace extensions
+
+} // namespace gismo

--- a/optional/gsParasolid/gsWriteParasolid.cpp
+++ b/optional/gsParasolid/gsWriteParasolid.cpp
@@ -22,15 +22,6 @@ namespace extensions {
 CLASS_TEMPLATE_INST gsTrimData<real_t> ;
 
 TEMPLATE_INST bool
-createPK_BSURF( const gsTensorBSpline< 2, real_t> & bsp, 
-                PK_BSURF_t & bsurf,
-                bool closed_u, 
-                bool closed_v);
-
-TEMPLATE_INST bool
-createPK_BCURVE(const gsBSpline<real_t>& curve, PK_BCURVE_t& bcurve);
-
-TEMPLATE_INST bool
 exportTHBsurface<real_t>( const gsTHBSpline<2,real_t>& surface, PK_ASSEMBLY_t& body );
 
 TEMPLATE_INST bool

--- a/optional/gsParasolid/gsWriteParasolid.h
+++ b/optional/gsParasolid/gsWriteParasolid.h
@@ -37,10 +37,8 @@
 #include <gsHSplines/gsTHBSplineBasis.h>
 
 #include <gsParasolid/gsPKSession.h>
+#include <gsParasolid/gsPKUtils.h>
 
-typedef int PK_GEOM_t;
-typedef int PK_BSURF_t;
-typedef int PK_BCURVE_t;
 typedef int PK_BODY_t;
 typedef int PK_ASSEMBLY_t;
 struct PK_UVBOX_s;
@@ -73,26 +71,6 @@ namespace extensions {
     /// Converts \a tp into a PK_SHEET and writes it to filename.xmt_txt.
     template<class T>
     bool gsWritePK_SHEET(const gsTensorBSpline<2, T>& tp, const std::string& filename);
-
-
-    /// Translates a gsTensorBSpline to a PK_BSURF_t
-    /// \param[in] bsp B-spline surface
-    /// \param[out] bsurf Parasolid spline surface
-    template<class T>
-    bool createPK_BSURF( const gsTensorBSpline< 2,T> & bsp, PK_BSURF_t & bsurf,
-			 bool closed_u = false, bool closed_v = false );
-
-    /// Translates a gsBSpline to a PK_BCURVE_t
-    /// \param[in] curve B-Spline surve
-    /// \param[out] bcurve Parasolid spline curve
-    template<class T> 
-    bool createPK_BCURVE( const gsBSpline<T>& curve, PK_BCURVE_t& bcurve );
-
-    /// Translates a gsGeometry to a PK_GEOM_t
-    /// \param[in] ggeo inpute G+SMO geometry
-    /// \param[out] pgeo Parasolid geometric entity
-    template<class T> 
-    bool createPK_GEOM( const gsGeometry<T> & ggeo, PK_GEOM_t & pgeo );
 
     /// Translates a gsMesh to PK_BODY_t
     /// \param[in] mesh input G+Smo mesh

--- a/optional/gsParasolid/gsWriteParasolid.hpp
+++ b/optional/gsParasolid/gsWriteParasolid.hpp
@@ -96,9 +96,6 @@ void getInterval(const bool directionU,
                  const PK_CURVE_t line,
                  PK_INTERVAL_t& result);
 
-bool validMultiplicities(const std::vector<index_t>& mult,
-                         const int deg);
-
 template <class T>
 bool exportCheck(const gsTHBSpline<2, T>& surface);
 
@@ -323,175 +320,6 @@ bool gsWritePK_SHEET(const gsTensorBSpline<2, T>& tp, const std::string& filenam
 
 
 template<class T>
-bool createPK_GEOM( const gsGeometry<T> & ggeo,
-                    PK_GEOM_t & pgeo)
-{
-    // Identify input gismo geometry
-    if ( const gsTensorBSpline<2,T> * tbsp =
-         dynamic_cast<const gsTensorBSpline<2,T> *>(&ggeo) )
-    {
-        return createPK_BSURF(*tbsp, pgeo);
-    }
-// the following lines produce warnings if called from multipatch version of gsWriteParasolid,
-// because it already assumes that the geometries are surfaces
-    else if ( const gsBSpline<>* bspl =
-              dynamic_cast< const gsBSpline<>* >(&ggeo) )
-    {
-        return createPK_BCURVE(*bspl, pgeo);
-    }
-    else
-    {
-        gsInfo << "Cannot write "<<ggeo<<" to parasolid file.\n";
-        return false;
-    }
-}
-
-
-template<class T>
-bool createPK_BSURF(const gsTensorBSpline< 2, T> & bsp,
-                    PK_BSURF_t & bsurf,
-                    bool closed_u,
-                    bool closed_v)
-{
-    typedef typename gsKnotVector<T>::mult_t mult_t;
-    std::vector<mult_t> mult;
-
-    // Gismo and Parasolid store the coefficients in different order.
-    // Therefore we create the BSURF with u and v swapped and then transpose it.
-    for (index_t dim = 0; dim != 2; dim++)
-    {
-        const int deg = bsp.basis().degree(dim);
-        mult = bsp.basis().knots(dim).multiplicities();
-
-        if (!validMultiplicities(mult, deg))
-        {
-            return false;
-        }
-    }
-
-    // Translate to parasolid standard form, ie fill up parasolid
-    // spline data record
-    PK_BSURF_sf_t sform;   // B-spline data holder (standard form)
-
-    // Degrees
-    sform.u_degree      = bsp.basis().degree(1);
-    sform.v_degree      = bsp.basis().degree(0);
-
-    // Knots in u-direction
-    std::vector<T> gknot0 = bsp.basis().knots(1).unique();
-    std::vector<mult_t> gmult0 = bsp.basis().knots(1).multiplicities();
-    sform.n_u_knots     = gknot0.size();
-    sform.u_knot        = gknot0.data();
-    sform.u_knot_mult   = gmult0.data();
-
-    // Knots in v-direction
-    std::vector<T> gknot1 = bsp.basis().knots(0).unique();
-    std::vector<mult_t> gmult1 = bsp.basis().knots(0).multiplicities();
-    sform.n_v_knots     = gknot1.size();
-    sform.v_knot        = gknot1.data();
-    sform.v_knot_mult   = gmult1.data();
-
-    // Control points
-    sform.n_u_vertices  = bsp.basis().size(1);
-    sform.n_v_vertices  = bsp.basis().size(0);
-    gsMatrix<T> coefs   = bsp.coefs();
-    const int n = bsp.geoDim();
-    if ( n < 3 )
-    {
-        coefs.conservativeResize(gsEigen::NoChange, 3);
-        coefs.rightCols(3-n).setZero();
-    }
-    coefs.transposeInPlace();
-    coefs.resize(3*bsp.basis().size(), 1);
-    sform.vertex_dim    = 3; // always 3 for surfaces
-    sform.vertex        = coefs.data();
-
-    // Attributes
-    sform.is_rational   = PK_LOGICAL_false;
-    sform.form          = PK_BSURF_form_unset_c;
-    sform.u_knot_type   = PK_knot_unset_c;
-    sform.v_knot_type   = PK_knot_unset_c;
-    sform.is_u_periodic = PK_LOGICAL_false;
-    sform.is_v_periodic = PK_LOGICAL_false;
-    sform.is_u_closed   = PK_LOGICAL_false;
-    sform.is_v_closed   = PK_LOGICAL_false;
-
-    if (closed_u)
-    {
-        sform.is_v_closed = PK_LOGICAL_true;
-    }
-
-    if (closed_v)
-    {
-        sform.is_u_closed = PK_LOGICAL_true;
-    }
-
-    sform.self_intersecting = PK_self_intersect_unset_c;
-    sform.convexity         = PK_convexity_unset_c;
-
-    // Create parasolid surface with the previous spline data
-    PK_ERROR_code_t err = PK_BSURF_create(&sform, &bsurf);
-    PARASOLID_ERROR(PK_BSURF_create, err);
-
-    // Transposition (new on 2019-02-26).
-    PK_BSURF_reparameterise_o_t options;
-    PK_BSURF_reparameterise_o_m(options);
-    options.transpose = PK_LOGICAL_true;
-
-    err = PK_BSURF_reparameterise(bsurf,&options);
-    PARASOLID_ERROR(PK_BSURF_reparameterise, err);
-
-    return true;
-}
-
-template<class T>
-bool createPK_BCURVE( const gsBSpline<T>& curve,
-                      PK_BCURVE_t& bcurve)
-{
-    typedef typename gsKnotVector<T>::mult_t mult_t;
-    
-    PK_BCURVE_sf_t sform; // B-curve data holder (standard form)
-
-    // Degree
-    sform.degree = curve.degree();
-
-    // Knots
-    std::vector<T> knots = curve.basis().knots().unique();
-    std::vector<mult_t> mult = curve.basis().knots().multiplicities();
-    sform.n_knots = knots.size();
-    sform.knot = knots.data();
-    sform.knot_mult = mult.data();
-
-
-    // Control points
-    sform.n_vertices = curve.basis().size();
-    gsMatrix<T> coefs = curve.coefs();
-    const int n = curve.geoDim();
-    if (n < 3)
-    {
-        coefs.conservativeResize(gsEigen::NoChange, 3);
-        coefs.rightCols(3 - n).setZero();
-    }
-    coefs.transposeInPlace();
-    coefs.resize(3 * curve.basis().size(), 1);
-    sform.vertex_dim = 3;
-    sform.vertex = coefs.data();
-
-    // Attributes
-    sform.is_rational = PK_LOGICAL_false;
-    sform.form = PK_BCURVE_form_unset_c;
-    sform.knot_type = PK_knot_unset_c;
-    sform.is_periodic = PK_LOGICAL_false;
-    sform.is_closed = PK_LOGICAL_false;
-    sform.self_intersecting = PK_self_intersect_unset_c;
-
-    PK_ERROR_code_t err = PK_BCURVE_create(&sform, &bcurve);
-    PARASOLID_ERROR(PK_BCURVE_create, err);
-
-    return true;
-}
-
-template<class T>
 bool exportMesh(const gsMesh<T>& mesh,
                 PK_ASSEMBLY_t& assembly)
 {
@@ -582,25 +410,7 @@ bool exportTHBsurface(const gsTHBSpline<2, T>& surface,
 // ================================================================================
 // utilities
 
-// returns true la all multiplicities in muls are less (<) than deg + 1
-// parasolid restriction
-bool validMultiplicities(const std::vector<index_t>& mult,
-                         const int deg)
-{
-    for (size_t i = 1; i != mult.size() - 1; i++)
-    {
-        if (mult[i] == deg + 1)
-        {
-            std::cout <<
-                "Only B-Splines with (inner) multiplicity less (<) "
-                "than degree + 1 are supported. \n"
-                "Parasolid restriction."
-                      << std::endl;
-            return false;
-        }
-    }
-    return true;
-}
+
 
 
 // computes the parameter interval of the iso-curve (line) on the surface (bspline)


### PR DESCRIPTION
Pull requests can only be merged after at least one review (and
approval) from @gismo/admins.

Code submitted to the dev branch should be clean, well-documented
and free of bugs.

# The commit description must be structured as a list follows:

NEW: Function `gsClosestParam` to compute the parameter values of the closest point on a tensor-product surface using Parasolid. This is a debugged part from the stale branch [Parasolid-parameter-correction](https://github.com/gismo/gismo/tree/Parasolid-parameter-correction).

IMPROVED: Several utility functions have been moved from _gsWriteParasolid_ to newly-created _gsPKUtils_.

For each new/improved/fixed/api change use a new line with the
respective word prefix in capital.

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [ ] Have you written new tests or examples for your changes?
Kind of: they are in a private repository.
-----
