### PR TITLE
Hotfix issue 862: Knot domain iterator fix

### DIFF
--- a/src/gsDomain/gsKnotDomainIterator.h
+++ b/src/gsDomain/gsKnotDomainIterator.h
@@ -28,7 +28,7 @@ private:
     typedef typename gsDomainIterator<T>::uPtr domainIter;
 
     // Data members
-    knotIterator m_it, m_itEnd;
+    knotIterator m_it, m_itBegin, m_itEnd;
 
 public:
 
@@ -36,6 +36,7 @@ public:
     :
     gsDomainIterator<T>(start ? 0 : _knots.numElements()),
     m_it(start ? _knots.domainUBegin() : _knots.domainUEnd()),
+    m_itBegin(_knots.domainUBegin()),
     m_itEnd(_knots.domainUEnd())
     {
 
@@ -71,7 +72,7 @@ public:
     // Documentation in gsDomainIterator.h
     void reset() override
     {
-        m_it.reset();
+        m_it = m_itBegin;
     }
 
     gsVector<T> lowerCorner() const override

--- a/unittests/gsKnotVectors_test.cpp
+++ b/unittests/gsKnotVectors_test.cpp
@@ -221,6 +221,62 @@ SUITE(gsKnotVectors_test)
         gsKnotVector<real_t> kv2(deg,v.begin(),v.end());
         testFindSpan(kv2);
     }
+
+    TEST(notClampedDomainIteration)
+    {
+        std::vector<real_t> knots = {-2, -1.75, -1.5, -1.25, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2};
+        gsKnotVector<real_t> u_knots(3, knots.begin(), knots.end());
+
+        CHECK_CLOSE( *u_knots.domainBegin(), -1.25, 1e-10 );
+        CHECK_CLOSE( *u_knots.domainEnd(),    1.25, 1e-10 );
+
+        gsBSplineBasis<real_t> u_basis(u_knots);
+        typename gsBasis<real_t>::domainIter domIt    = u_basis.domain()->beginAll();
+        typename gsBasis<real_t>::domainIter domItEnd = u_basis.domain()->endAll();
+
+        size_t count = 0;
+        std::vector<real_t> domBreaks = u_knots.breaks();
+        for (; domIt != domItEnd; ++domIt)
+        {
+            CHECK( count < domBreaks.size() - 1 );
+            CHECK_CLOSE( domIt.lowerCorner()(0), domBreaks[count],   1e-10 );
+            CHECK_CLOSE( domIt.upperCorner()(0), domBreaks[count+1], 1e-10 );
+            ++count;
+        }
+        CHECK( count == u_knots.numElements() );
+    }
+
+    TEST(notClampedTensorDomainIteration)
+    {
+        std::vector<real_t> knots = {-2, -1.75, -1.5, -1.25, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2};
+        gsKnotVector<real_t> u_knots(3, knots.begin(), knots.end());
+        gsKnotVector<real_t> v_knots(-1, 1, 3, 4);
+        gsTensorBSplineBasis<2> basis(u_knots, v_knots);
+
+        size_t expectedElements = u_knots.numElements() * v_knots.numElements();
+        CHECK( basis.domain()->numElements() == expectedElements );
+
+        typename gsBasis<real_t>::domainIter domIt    = basis.domain()->beginAll();
+        typename gsBasis<real_t>::domainIter domItEnd = basis.domain()->endAll();
+
+        real_t domStartU = *u_knots.domainBegin();
+        real_t domEndU   = *u_knots.domainEnd();
+        real_t domStartV = *v_knots.domainBegin();
+        real_t domEndV   = *v_knots.domainEnd();
+
+        size_t count = 0;
+        for (; domIt != domItEnd; ++domIt)
+        {
+            gsVector<real_t> lo = domIt.lowerCorner();
+            gsVector<real_t> up = domIt.upperCorner();
+            CHECK( lo(0) >= domStartU - 1e-10 );
+            CHECK( up(0) <= domEndU   + 1e-10 );
+            CHECK( lo(1) >= domStartV - 1e-10 );
+            CHECK( up(1) <= domEndV   + 1e-10 );
+            ++count;
+        }
+        CHECK( count == expectedElements );
+    }
 }
 
 SUITE(gsKnotVectors_test_2)

--- a/unittests/gsKnotVectors_test.cpp
+++ b/unittests/gsKnotVectors_test.cpp
@@ -231,8 +231,8 @@ SUITE(gsKnotVectors_test)
         CHECK_CLOSE( *u_knots.domainEnd(),    1.25, 1e-10 );
 
         gsBSplineBasis<real_t> u_basis(u_knots);
-        typename gsBasis<real_t>::domainIter domIt    = u_basis.domain()->beginAll();
-        typename gsBasis<real_t>::domainIter domItEnd = u_basis.domain()->endAll();
+        gsBasis<real_t>::domainIter domIt    = u_basis.domain()->beginAll();
+        gsBasis<real_t>::domainIter domItEnd = u_basis.domain()->endAll();
 
         size_t count = 0;
         std::vector<real_t> domBreaks = u_knots.breaks();
@@ -256,8 +256,8 @@ SUITE(gsKnotVectors_test)
         size_t expectedElements = u_knots.numElements() * v_knots.numElements();
         CHECK( basis.domain()->numElements() == expectedElements );
 
-        typename gsBasis<real_t>::domainIter domIt    = basis.domain()->beginAll();
-        typename gsBasis<real_t>::domainIter domItEnd = basis.domain()->endAll();
+        gsBasis<real_t>::domainIter domIt    = basis.domain()->beginAll();
+        gsBasis<real_t>::domainIter domItEnd = basis.domain()->endAll();
 
         real_t domStartU = *u_knots.domainBegin();
         real_t domEndU   = *u_knots.domainEnd();


### PR DESCRIPTION
This PR fixes issue #862 .
The problem was that upon a `reset()`, in commit `df1a96f77ead90b383b4ea3e403e4ce707a8fcfe` the knot vector would go back to `domainUBegin()` and in commit `1d7b2b01947ddc2037fc541076a9eba91dc87f16` this changed to `m_upos=0` which is the first unique knot, which in case of non-clamped knot vectors is a ghost knot.

This happened because `nextLexicographic` and `nextLexicographicIter` called, respectively, `cur[i]=start[i]` and `cur[i].reset()` to reset a current dimension. This lexicographic iterator is used for the `gsTensorDomainIterator`, which is constructed via breaks for `gsKnotVector`s (is my guess), which sets for `start` the `domainUBegin` of the knot vectors. For non-clamped knot vectors, `cur[i].reset()` did not yield the same result as `cur[i].domainUBegin()` which it should do.

@dominik-mokris-mtu @filiatra , what do you think about this? 

---
The commit description must be structured as a list follows:

NEW: 
Added unittests for non-clamped knot vector iteration, according to #862 

IMPROVED: 

FIXED: 
non-clamped knot vector iteration

API:

---
Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
