### PR TITLE
Fix makeCollection to use a relative path

### DIFF
--- a/src/gsIO/gsParaviewCollection.h
+++ b/src/gsIO/gsParaviewCollection.h
@@ -258,13 +258,16 @@ private:
 inline void makeCollection(std::string const & fn, std::string const & ext, int n = 0)
 {
     gsParaviewCollection pc(fn);
+    // Use only the filename (no directory) so the DataSet path in the .pvd
+    // is relative to the .pvd file itself, not to the working directory.
+    const std::string base = gsFileManager::getFilename(fn);
     if ( n > 0)
     {
         for (int i=0; i<n ; i++)
-            pc.addPart(fn + std::to_string(i) + ext);
+            pc.addPart(base + std::to_string(i) + ext);
     }
     else
-        pc.addPart(fn + ext);
+        pc.addPart(base + ext);
 
     pc.save();
 }


### PR DESCRIPTION
FIXED: The function `makeCollection` in `src/gsIO/gsParaviewCollection` previously used absolute paths for collecting multiple files. This caused errors when the user wanted to store their output files in subfolders of the working directory. The new version uses a relative path so that the paths in the `.pvd` files are now always correct.
API: No API changes. Behavior when storing in the working directory is unaffected.