### PR TITLE
Clang(d) compatibility

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+# We'll use defaults from the LLVM style, but with 4 columns indentation.
+BasedOnStyle: LLVM
+IndentWidth: 4
+---
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+NamespaceIndentation: None
+BreakBeforeBraces: Allman
+AccessModifierOffset: -4
+---

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ submodules.txt
 
 # CLion user-specific files
 .idea
+# Clang user-specific files
+.cache
 
 # Binary directories
 cmake-build-*/


### PR DESCRIPTION
This pull request makes the repository compatible with clang and clangd by adding the `.cache` folder to the `.gitignore` as well as adding a `.clang-format` file that configures the clang language server auto formatter to format in accordance to the format specification from the Gismo Wiki.

NEW: A `.clang-format` file that configures the auto formatter of the clang language server.
IMPROVED: The `.gitignore` now ignores the `.cache` folder.