### PR TITLE
Fix missing cstdint header

### DIFF
--- a/src/gsCore/gsSysInfo.h
+++ b/src/gsCore/gsSysInfo.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <gsCore/gsForwardDeclarations.h>
 
 namespace gismo


### PR DESCRIPTION
Fix missing cstdint header

- https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
- https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes