### PR TITLE
Forward declare nv to avoid conflict with nvidia namespace

### DIFF
--- a/src/gsExpressions/_expr_macros.h
+++ b/src/gsExpressions/_expr_macros.h
@@ -18,6 +18,9 @@ namespace gismo
 {
 namespace expr
 {
+    
+template<class T> class onormal_expr;
+template<class T> EIGEN_STRONG_INLINE onormal_expr<T> nv(const gsGeometryMap<T>&);
 
 // Shortcuts for common quantities, for instance function
 // transformations by the geometry map \a G


### PR DESCRIPTION
As the title says. Without this decl, when compiling through the kokkos toolchain, unqualified name lookup finds the nvidia namespace first.

This change should not affect usual operation whatsoever.