### PR TITLE
Fix a bug in creation of high-dimension control nets

### DIFF
--- a/src/gsIO/gsWriteParaview.hpp
+++ b/src/gsIO/gsWriteParaview.hpp
@@ -1667,7 +1667,7 @@ void gsWriteParaviewPoints(gsMatrix<T> const& points, std::string const & fn)
         gsWriteParaviewPoints<T>(points.row(0), points.row(1), points.row(2), points.row(3), fn);
         break;
     default:
-        GISMO_ERROR("Point plotting is implemented just for 2D and 3D (rows== 1, 2 or 3).");
+        GISMO_ERROR("Point plotting is implemented just for 2D, 3D and 4D (rows== 1, 2, 3 or 4).");
     }
 }
 

--- a/src/gsIO/gsWriteParaview.hpp
+++ b/src/gsIO/gsWriteParaview.hpp
@@ -248,25 +248,39 @@ void writeSingleControlNet(const gsGeometry<T> & Geo,
                            std::string const & fn)
 {
     const int d = Geo.parDim();
+    const unsigned n = Geo.geoDim();
+
+    // We can only write control nets up to dimension 4.
+    // For a 4D net, we need to fall back to an unstructured point cloud.
+    if (n == 4)
+    {
+        gsDebug << "Fallling back to writing 4-dimensional control net as "
+                   "point cloud.\n";
+        const gsMatrix<T>& cp = Geo.coefs();
+        gsWriteParaviewPoints<T>(cp.transpose(), fn);
+        return;
+    }
+
+    // A >4D net is not supported at all.
+    if (n > 4)
+    {
+        gsWarn << "Skipping writing of control net of dimension " << n
+               << ". Control nets are only supported up to dimension 4.";
+        return;
+    }
+
+    // A <4D net works with the normal process.
     gsMesh<T> msh;
     Geo.controlNet(msh);
-    const unsigned n = Geo.geoDim();
-    if ( n == 1 )
+    if (n == 1)
     {
         gsMatrix<T> anch = Geo.basis().anchors();
         // Lift vertices at anchor positions
-        for (size_t i = 0; i!= msh.numVertices(); ++i)
+        for (size_t i = 0; i != msh.numVertices(); ++i)
         {
             msh.vertex(i)[d] = msh.vertex(i)[0];
             msh.vertex(i).topRows(d) = anch.col(i);
         }
-    }
-    else if (n>3)
-    {
-        gsDebug<<"Writing 4th coordinate\n";
-        const gsMatrix<T> & cp = Geo.coefs();
-        gsWriteParaviewPoints<T>(cp.transpose(), fn );
-        return;
     }
 
     gsWriteParaview(msh, fn, false);


### PR DESCRIPTION
This pull request is a copy of #875 without any formatting changes.

This pull request fixes the following bug:

FIX: Calling `gsWriteParaview` with `control_net=true` on a `gsMultiPatch` whose `geoDim()` returns 4 (or higher) and that has at least one control point whose 4th coordinate value is non-zero causes an invalid free (causing a SIGABRT) at the end of the write call.

Here is a minimal example:
```cpp
gsMultiPatch<> mp(*gsNurbsCreator<>::BSplineSquareDeg(2));
mp.computeTopology();
mp.embed(4);

for (size_t p = 0; p < mp.nPatches(); ++p)
    mp.patch(p).coefs().col(3).setConstant(1.0);

gsWriteParaview(mp, "cnet_4d", 100, false, true);
```

The cause is that the code in `src/gsIO/gsWriteParaview.hpp`, function `writeSingleControlNet`, checks for `geoDim() > 3` too late, creating a `gsMesh` earlier and triggering an asserting in the constructor of `gsVertex`.
This pull request moves the check to an earlier part of the method to avoid these aborts.
- For `geoDim() <= 3`, nothing changes.
- For `geoDim() = 4`, the specified fallback is used.
- For `geoDim() > 4`, the specified fallback actually doesn't work due to limitations of `gsVertex`. Therefore, a warning message is printed and nothing is written.
- The error messages have been updated accordingly.
