### PR TITLE
Provide third derivatives evaluation to gsTensorBSplineBasis

### DIFF
--- a/src/gsCore/gsBasis.h
+++ b/src/gsCore/gsBasis.h
@@ -142,6 +142,14 @@ public:
         return result;
     }
 
+    /// Evaluate the third derivative of a single basis function \a i at points \a u.
+    gsMatrix<T> deriv3Single(index_t i, const gsMatrix<T> & u) const
+    {
+        gsMatrix<T> result;
+        this->deriv3Single_into(i, u, result);
+        return result;
+    }
+
     /** \brief Number of active basis functions at an arbitrary parameter value.
      *
      *  Usually, this is used for getting the active functions on one
@@ -663,10 +671,17 @@ public:
      */
     virtual void deriv2_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const;
 
+    virtual void deriv3_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const;
+
     /// @brief Evaluate the (partial) derivatives of the \a i-th basis function
     /// at points \a u into \a result.
     // hessianSingle_into
     virtual void deriv2Single_into(index_t i,
+                                   const gsMatrix<T> & u,
+                                   gsMatrix<T>& result ) const;
+
+    /// Like \a deriv2Single_into but for third derivatives.
+    virtual void deriv3Single_into(index_t i,
                                    const gsMatrix<T> & u,
                                    gsMatrix<T>& result ) const;
 

--- a/src/gsCore/gsBasis.hpp
+++ b/src/gsCore/gsBasis.hpp
@@ -486,7 +486,17 @@ void gsBasis<T>::deriv2_into(const gsMatrix<T> &, gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }
 
 template<class T>
+void gsBasis<T>::deriv3_into(const gsMatrix<T> &, gsMatrix<T>&) const
+{ GISMO_NO_IMPLEMENTATION }
+
+template<class T>
 void gsBasis<T>::deriv2Single_into(index_t,
+                                   const gsMatrix<T> &,
+                                   gsMatrix<T>&) const
+{ GISMO_NO_IMPLEMENTATION }
+
+template<class T>
+void gsBasis<T>::deriv3Single_into(index_t,
                                    const gsMatrix<T> &,
                                    gsMatrix<T>&) const
 { GISMO_NO_IMPLEMENTATION }

--- a/src/gsNurbs/gsBSplineBasis.h
+++ b/src/gsNurbs/gsBSplineBasis.h
@@ -353,7 +353,13 @@ public:
     void deriv2_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const ;
 
     // Look at gsBasis class for a description
+    void deriv3_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const ;
+
+    // Look at gsBasis class for a description
     void deriv2Single_into(index_t i, const gsMatrix<T> & u, gsMatrix<T>& result ) const ;
+
+    // Look at gsBasis class for a description
+    void deriv3Single_into(index_t i, const gsMatrix<T> & u, gsMatrix<T>& result ) const ;
 
     // Look at gsBasis class for a description
     void deriv2_into(const gsMatrix<T> & u, const gsMatrix<T> & coefs, gsMatrix<T>& result ) const ;

--- a/src/gsNurbs/gsBSplineBasis.hpp
+++ b/src/gsNurbs/gsBSplineBasis.hpp
@@ -849,7 +849,7 @@ void gsTensorBSplineBasis<1,T>::deriv3Single_into(index_t i, const gsMatrix<T> &
 
     for (index_t j = 0; j < u.cols(); ++j)
     {
-        const unsigned first = firstActive(u(0,j));
+        const index_t first = firstActive(u(0,j));
         if ( (i>= first) && (i<= first + m_p) )
             result(0,j) = tmp(i-first,j);
         else

--- a/src/gsNurbs/gsBSplineBasis.hpp
+++ b/src/gsNurbs/gsBSplineBasis.hpp
@@ -666,6 +666,15 @@ void gsTensorBSplineBasis<1,T>::deriv2_into(const gsMatrix<T> & u,
     result.swap(ev[2]);
 }
 
+template <class T> inline
+void gsTensorBSplineBasis<1,T>::deriv3_into(const gsMatrix<T> & u,
+                                            gsMatrix<T>& result ) const
+{
+    std::vector<gsMatrix<T> > ev;
+    this->evalAllDers_into(u, 3, ev);
+    result.swap(ev[3]);                         // Should be 3?
+}
+
 template <class T>  inline
 void gsTensorBSplineBasis<1,T>::derivSingle_into(index_t i,
                                                  const gsMatrix<T> & u,
@@ -827,6 +836,24 @@ void gsTensorBSplineBasis<1,T>::deriv2Single_into(index_t i, const gsMatrix<T> &
             result(0,j) = tmp(i-first,j);
         else
             result(0,j) = (T)(0.0);
+    }
+}
+
+template <class T>  inline
+void gsTensorBSplineBasis<1,T>::deriv3Single_into(index_t i, const gsMatrix<T> & u, gsMatrix<T>& result ) const
+{
+    // \todo Redo an efficient implementation p. 76, Alg. A2.5 Nurbs book
+    result.resize(1, u.cols() );
+    gsMatrix<T> tmp;
+    gsTensorBSplineBasis<1,T>::deriv3_into(u, tmp);
+
+    for (index_t j = 0; j < u.cols(); ++j)
+    {
+        const unsigned first = firstActive(u(0,j));
+        if ( (i>= first) && (i<= first + m_p) )
+            result(0,j) = tmp(i-first,j);
+        else
+            result(0,j) = T(0.0);
     }
 }
 

--- a/src/gsNurbs/gsDeboor.hpp
+++ b/src/gsNurbs/gsDeboor.hpp
@@ -219,6 +219,34 @@ void gsTensorDeriv2_into(const gsMatrix<T>& u,
 }
 
 // =============================================================================
+// ===== third derivatives for BSpline
+// =============================================================================
+
+template<short_t d, typename T, typename KnotVectorType, typename Mat>
+inline
+void gsTensorDeriv3_into(const gsMatrix<T>& u,
+                        const gsTensorBSplineBasis<d, T>& base,
+                        const Mat& coefs,
+                        gsMatrix<T>& result)
+{//LC
+    const unsigned nPts = u.cols(); // number points
+    const unsigned n3der = (d * (d + 1) * (d + 2)) / (3*2*1); // number of third derivatives
+
+    result.setZero(n3der, nPts);
+    gsMatrix<T> deriv3; // third derivatives
+    gsMatrix<unsigned> ind;
+
+
+    base.deriv3_into(u, deriv3);
+    base.active_into(u, ind);
+
+    for (unsigned j = 0; j < nPts; j++)
+        for (unsigned k = 0; k < n3der; k++)
+            for (index_t i = 0; i < ind.rows(); i++)
+                result(k, j) += coefs(ind(i, j)) * deriv3(k + i * n3der, j);
+}
+
+// =============================================================================
 // other version of evaluation via knot insertion
 // =============================================================================
 

--- a/src/gsTensor/gsTensorBasis.h
+++ b/src/gsTensor/gsTensorBasis.h
@@ -268,6 +268,9 @@ public:
     // Evaluates the second derivatives of the non-zero basis functions at value u.
     virtual void deriv2_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const override;
 
+    // Evaluates the second derivatives of the non-zero basis functions at value u.
+    virtual void deriv3_into(const gsMatrix<T> & u, gsMatrix<T>& result ) const;
+
 private:
     // Internal function
     //
@@ -284,12 +287,18 @@ private:
                    const gsVector<unsigned, d> & size,
                    gsMatrix<T>& result);
 
+    static void deriv3_tp(const std::vector< gsMatrix<T> > values[],
+                          const gsVector<unsigned, d> & size,
+                          gsMatrix<T>& result);
+
 public:
     // see gsBasis for doxygen documentation
     // Evaluate the i-th basis function derivative at all columns of
     virtual void derivSingle_into(index_t i, const gsMatrix<T> & u, gsMatrix<T>& result) const override;
 
     virtual void deriv2Single_into(index_t i, const gsMatrix<T> & u, gsMatrix<T>& result) const override;
+
+    virtual void deriv3Single_into(index_t i, const gsMatrix<T> & u, gsMatrix<T>& result) const override;
 
     // Evaluates the (partial) derivatives of an element given by coefs at (the columns of) u.
     //void deriv_into(const gsMatrix<T> & u, const gsMatrix<T> & coefs, gsMatrix<T>& result ) const ;

--- a/src/gsTensor/gsTensorBasis.hpp
+++ b/src/gsTensor/gsTensorBasis.hpp
@@ -499,6 +499,96 @@ void gsTensorBasis<d,T>::deriv2Single_into(index_t i,
 }
 
 template<short_t d, class T>
+void gsTensorBasis<d,T>::deriv3Single_into(index_t i,
+                                           const gsMatrix<T> & u,
+                                           gsMatrix<T>& result) const
+{
+    gsVector<index_t, d> ti;
+    ti.noalias() = tensorIndex(i);
+    gsMatrix<T> ev[d], dev[d], ddev[d], dddev;
+    result.setOnes( (d*d*d + 3*d*d + 2*d)/6.0 , u.cols() );  // number of third derivatives
+
+    // Precompute values and first and second derivatives
+    for (short_t k = 0; k != d; ++k)
+    {
+        m_bases[k]->evalSingle_into  ( ti[k], u.row(k),  ev[k]  );
+        m_bases[k]->derivSingle_into ( ti[k], u.row(k), dev[k]  );
+        m_bases[k]->deriv2Single_into( ti[k], u.row(k), ddev[k] );
+    }
+
+    index_t c = d;
+    for (short_t k = 0; k != d; ++k)
+    {
+        // Pure third derivatives
+        m_bases[k]->deriv3Single_into( ti[k], u.row(k), dddev );
+        result.row(k)                = result.row(k).cwiseProduct(dddev);
+
+        // Multiply values to all other third derivatives
+        result.topRows(k)            = result.topRows(k) * ev[k].asDiagonal();
+        result.middleRows(k+1,d-k-1) = result.middleRows(k+1, d-k-1) * ev[k].asDiagonal();
+
+        // Third mixed derivatives, second + first
+        for (short_t l = 0; l != d; ++l)
+        {
+            if (k != l)
+            {
+                // Multiply with k-th second derivative
+                result.row(c)     = result.row(c).cwiseProduct(ddev[k]);
+                // Multiply with l-th first derivative
+                result.row(c)     = result.row(c).cwiseProduct(dev[l]);
+
+                if (k<l)
+                {
+                    // Multiply with values
+                    for (short_t r = 0; r != k; ++r)
+                        result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                    for (short_t r = k+1; r != l; ++r)
+                        result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                    for (short_t r = l+1; r != d; ++r)
+                        result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                    c++;
+                }
+                else if (l<k)
+                {
+                    // Multiply with values
+                    for (short_t r = 0; r != l; ++r)
+                        result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                    for (short_t r = l+1; r != k; ++r)
+                        result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                    for (short_t r = k+1; r != d; ++r)
+                        result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                    c++;
+                }
+            }
+        }
+        // Third mixed derivatives, first + first + first
+        for (short_t l = k+1; l != d; ++l)
+        {
+            for (short_t m = l+1; m != d; ++m)
+            {
+                // Multiply with k-th second derivative
+                result.row(c)     = result.row(c).cwiseProduct(dev[k]);
+                // Multiply with l-th first derivative
+                result.row(c)     = result.row(c).cwiseProduct(dev[l]);
+                // Multiply with m-th first derivative
+                result.row(c)     = result.row(c).cwiseProduct(dev[m]);
+
+                // Multiply with values
+                for (short_t r = 0; r != k; ++r)
+                    result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                for (short_t r = k+1; r != l; ++r)
+                    result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                for (short_t r = l+1; r != m; ++r)
+                    result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                for (short_t r = m+1; r != d; ++r)
+                    result.row(c) = result.row(c).cwiseProduct(ev[r]);
+                c++;
+            }
+        }
+    }
+}
+
+template<short_t d, class T>
 void gsTensorBasis<d,T>::eval_into(const gsMatrix<T> & u,
                                          gsMatrix<T>& result) const
 {
@@ -744,7 +834,24 @@ void gsTensorBasis<d,T>::deriv2_into(const gsMatrix<T> & u,
     deriv2_tp(values, nb_cwise, result);
 }
 
+template<short_t d, class T>
+void gsTensorBasis<d,T>::deriv3_into(const gsMatrix<T> & u,
+                                           gsMatrix<T> & result ) const
+{
+    std::vector< gsMatrix<T> >values[d];
+    gsVector<unsigned, d> v, nb_cwise;
 
+    unsigned nb = 1;
+    for (short_t i = 0; i < d; ++i)
+    {
+        m_bases[i]->evalAllDers_into( u.row(i), 3, values[i]);
+        const int num_i = values[i].front().rows();
+        nb_cwise[i] = num_i;
+        nb     *= num_i;
+    }
+
+    deriv3_tp(values, nb_cwise, result);
+}
 
 template<short_t d, class T>
 void gsTensorBasis<d,T>::deriv2_tp(const std::vector< gsMatrix<T> > values[],
@@ -783,6 +890,89 @@ void gsTensorBasis<d,T>::deriv2_tp(const std::vector< gsMatrix<T> > values[],
                 for ( short_t i=l+1; i<d; ++i)
                     result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
                 ++m;
+            }
+        }
+
+        r+= stride;
+    } while (nextLexicographic(v, nb_cwise));
+}
+
+template<short_t d, class T>
+void gsTensorBasis<d,T>::deriv3_tp(const std::vector< gsMatrix<T> > values[],
+                                   const gsVector<unsigned, d> & nb_cwise,
+                                   gsMatrix<T>& result)
+{
+    const unsigned nb = nb_cwise.prod();
+    const unsigned stride = d*(d+1)*(d+2)/(3*2*1);    // number third derivatives
+
+    result.resize( stride*nb, values[0][0].cols() );
+
+    gsVector<unsigned, d> v;
+    v.setZero();
+    unsigned r = 0; // r is a local index of a basis function times the stride
+    do
+    {
+        unsigned m = d;
+        for ( short_t k=0; k<d; ++k)// First compute the pure third derivatives
+        {
+            index_t cur = r + k;
+            result.row(cur) = values[k][3].row( v.at(k) ) ;// pure 3nd derivate w.r.t. k-th var
+            for ( short_t i=0; i<k; ++i)
+                result.row(cur).array() *= values[i][0].row( v.at(i) ).array();
+            for ( short_t i=k+1; i<d; ++i)
+                result.row(cur).array() *= values[i][0].row( v.at(i) ).array();
+
+            for (short_t l = 0; l != d; ++l)// Then all mixed derivatives follow in lex order (second+first)
+            {
+                if (k != l)
+                {
+                    cur = r + m;
+                    result.row(cur).noalias() =
+                        values[k][2].row( v.at(k) ).cwiseProduct( values[l][1].row( v.at(l) ) );
+
+                    if(k<l)
+                    {
+                        for ( short_t i=0; i<k; ++i)
+                            result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                        for ( short_t i=k+1; i<l; ++i)
+                            result.row(cur).array() *= values[i][0].row( v.at(i) ).array();
+                        for ( short_t i=l+1; i<d; ++i)
+                            result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                        ++m;
+                    }
+                    if(l<k)
+                    {
+                        for ( short_t i=0; i<l; ++i)
+                            result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                        for ( short_t i=l+1; i<k; ++i)
+                            result.row(cur).array() *= values[i][0].row( v.at(i) ).array();
+                        for ( short_t i=k+1; i<d; ++i)
+                            result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                        ++m;
+                    }
+                }
+            }
+            // Third mixed derivatives, first + first + first
+            for (short_t l = k+1; l != d; ++l)
+            {
+                for (short_t j = l+1; j != d; ++j)
+                {
+                    cur = r + m;
+                    // Multiply with k-th and l-th and j-th first derivative
+                    result.row(cur).noalias() =
+                        values[k][1].row( v.at(k) ).cwiseProduct( values[l][1].row( v.at(l) ) ).cwiseProduct( values[j][1].row( v.at(j) ) );
+
+                    // Multiply with values
+                    for ( short_t i=0; i<k; ++i)
+                        result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                    for ( short_t i=k+1; i<l; ++i)
+                        result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                    for ( short_t i=l+1; i<j; ++i)
+                        result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                    for ( short_t i=j+1; i<d; ++i)
+                        result.row(cur).array() *= values[i][0].row( v.at(i) ).array() ;
+                    ++m;
+                }
             }
         }
 

--- a/unittests/gsDeriv3_test.cpp
+++ b/unittests/gsDeriv3_test.cpp
@@ -1,0 +1,136 @@
+/** @file gsDeriv3_test.cpp
+
+    @brief Tests evaluation of third derivatives.
+
+	@Author(s): D. Mokris
+
+**/
+
+#include "gismo_unittest.h"
+
+using namespace gismo;
+
+SUITE(deriv3_into)
+{
+	// Idea: Univariate cubic Bernstein basis has constant third derivatives.
+	TEST(deriv3_KnownValues_Bernstein)
+	{
+		typedef real_t T;
+
+		// Cubic Bernstein basis
+		gsKnotVector<T> kv(0.0, 1.0, 0, 4); // clamped cubic, no internal knots
+		gsBSplineBasis<T> basis(kv);
+
+		// Sanity: should have 4 basis functions
+		CHECK(basis.size() == 4);
+
+		// Evaluation point (any point in (0,1) works)
+		gsMatrix<T> u(1,1);
+		u << 0.37; // arbitrary
+
+		gsMatrix<T> result;
+		basis.deriv3_into(u, result);
+
+		// result(i,0) = third derivative of basis function i
+
+		CHECK_CLOSE(result(0,0), -6.0,  1e-12);
+		CHECK_CLOSE(result(1,0),  18.0, 1e-12);
+		CHECK_CLOSE(result(2,0), -18.0, 1e-12);
+		CHECK_CLOSE(result(3,0),  6.0,  1e-12);
+	}
+
+	// Idea: Third derivatives of a quadratic basis need to sum to zero in any point.
+	TEST(deriv3_PartitionOfUnity)
+	{
+		typedef real_t T;
+
+		gsKnotVector<T> kv(0.0, 3.0, 1, 3);
+		kv.uniformRefine(2);
+
+		gsTensorBSplineBasis<2,T> basis(kv, kv);
+
+		gsMatrix<T> result;
+
+		for (T uu = 0.2; uu < 2.8; uu += 0.4)
+		{
+			for (T vv = 0.2; vv < 2.8; vv += 0.4)
+			{
+				gsMatrix<T> u(2,1);
+				u << uu, vv;
+
+				basis.deriv3_into(u, result);
+
+				// result: (#basis functions) × (#derivative components)
+				// or transposed depending on G+Smo version
+
+				// Sum over all active basis functions
+				T sum_duuu = 0.0, sum_duuv = 0.0, sum_duvv = 0.0, sum_dvvv = 0.0;
+
+				// There are four derivatives for each active function.
+				for (index_t i = 0; i < result.rows(); i += 4)
+				{
+					sum_duuu += result(i,     0);
+					sum_dvvv += result(i + 1, 0);
+					sum_duuv += result(i + 2, 0);
+					sum_duvv += result(i + 3, 0);
+				}
+
+				CHECK_CLOSE(sum_duuu, 0.0, 1e-10);
+				CHECK_CLOSE(sum_dvvv, 0.0, 1e-10);
+				CHECK_CLOSE(sum_duuv, 0.0, 1e-10);
+				CHECK_CLOSE(sum_duvv, 0.0, 1e-10);
+			}
+		}
+	}
+
+	// Idea: Derivatives of the tensor basis must be products of univariate derivatives.
+	TEST(deriv3_TensorStructure)
+	{
+		typedef real_t T;
+
+		gsKnotVector<T> kv(0.0, 3.0, 1, 3);
+		kv.uniformRefine(1);
+
+		gsBSplineBasis<T> uBasis(kv);
+		gsBSplineBasis<T> vBasis(kv);
+
+		gsTensorBSplineBasis<2,T> tBasis(kv, kv);
+
+		gsMatrix<T> u(1,1), v(1,1);
+		u(0,0) = 1.3;
+		v(0,0) = 1.7;
+
+		gsMatrix<T> Nu, dNu, d2Nu, d3Nu;
+		gsMatrix<T> Nv, dNv, d2Nv, d3Nv;
+
+		uBasis.eval_into(u, Nu);
+		uBasis.deriv_into(u, dNu);
+		uBasis.deriv2_into(u, d2Nu);
+		uBasis.deriv3_into(u, d3Nu);
+
+		vBasis.eval_into(v, Nv);
+		vBasis.deriv_into(v, dNv);
+		vBasis.deriv2_into(v, d2Nv);
+		vBasis.deriv3_into(v, d3Nv);
+
+		gsMatrix<T> uv(2,1);
+		uv << u(0,0), v(0,0);
+
+		gsMatrix<T> result;
+		tBasis.deriv3_into(uv, result);
+
+		index_t nd = 4; // number of derivatives
+		index_t tid = 0; // tensor id
+		for(index_t j=0; j < Nv.rows(); j++)
+			for(index_t i=0; i < Nu.rows(); i++)
+			{
+				CHECK_CLOSE(result(tid * nd,     0), d3Nu(i, 0) *   Nv(j, 0), 1e-10);
+				CHECK_CLOSE(result(tid * nd + 1, 0),   Nu(i, 0) * d3Nv(j, 0), 1e-10);
+				CHECK_CLOSE(result(tid * nd + 2, 0), d2Nu(i, 0) *  dNv(j, 0), 1e-10);
+				CHECK_CLOSE(result(tid * nd + 3, 0),  dNu(i, 0) * d2Nv(j, 0), 1e-10);
+
+				// Move to the next function.
+				tid++;
+			}
+	}
+}


### PR DESCRIPTION
NEW: deriv3, deriv3_into, deriv3Single, deriv3Single_into for gsTensorBSplineBasis

# Suggested change
This code provides evaluation of third derivatives for tensor-product B-spline basis.

# Motivation
We have good experience with using third derivatives for surface smoothing, which we do in a private repository.

#  Why it's not a big deal
The implementation is very analogous to how second derivatives are handled. It is mostly taken from 
the branch [sandra](https://github.com/gismo/gismo/tree/sandra) that we (@Sandra-Merchel-MTU and me) did not merge in 2020.

# Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why you'd like us to include them? _See above._
- [X] Have you documented any new codes using Doxygen comments? _Analogously to deriv2._
- [X] Have you written new tests or examples for your changes? _Yes, there are three new unittests._
-----
