### PR TITLE
Fix precompiler macro in AssignEvaluator.h

### DIFF
--- a/external/gsEigen/src/Core/AssignEvaluator.h
+++ b/external/gsEigen/src/Core/AssignEvaluator.h
@@ -330,9 +330,9 @@ struct dense_assignment_loop<Kernel, AllAtOnceTraversal, Unrolling>
     //G+Smo
 #ifndef EIGEN_NO_DEBUG
     typedef typename Kernel::DstEvaluatorType::XprType DstXprType;
-#endif
     EIGEN_STATIC_ASSERT(int(DstXprType::SizeAtCompileTime) == 0,
       EIGEN_INTERNAL_ERROR_PLEASE_FILE_A_BUG_REPORT)
+#endif
   }
 };
 


### PR DESCRIPTION
When EIGEN_NO_DEBUG is not set, this currently leads to a compilation error

```
/Eigen/src/Core/AssignEvaluator.h:334:5: error: ‘DstXprType’ was not declared in this scope
  334 |     EIGEN_STATIC_ASSERT(int(DstXprType::SizeAtCompileTime) == 0,
````

Thus, we put the ASSERT statement inside the `#ifndef` clause.

FIXED: Precompiler macro placement in gsEigen