### PR TITLE
Add OpenMP critical section to serialize exprhelper interface initialization

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -1051,8 +1051,8 @@ void gsExprAssembler<T>::_computePatternIfc(const ifContainer & iFaces, expr... 
 
     typedef typename gsFunction<T>::uPtr ifacemap;
     const bool flipSide = m_options.askSwitch("flipSide", false);
-    // Call m_exprdata->iface() to initialize the interface data structure
-    m_exprdata->iface();
+    // Call m_exprdata->initializeIface() to initialize the interface data structure
+    m_exprdata->initializeIface();
 #pragma omp parallel
 {
     auto arg_tpl = std::make_tuple(args...);

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -1051,6 +1051,8 @@ void gsExprAssembler<T>::_computePatternIfc(const ifContainer & iFaces, expr... 
 
     typedef typename gsFunction<T>::uPtr ifacemap;
     const bool flipSide = m_options.askSwitch("flipSide", false);
+    // Call m_exprdata->iface() to initialize the interface data structure
+    m_exprdata->iface();
 #pragma omp parallel
 {
     auto arg_tpl = std::make_tuple(args...);
@@ -1288,6 +1290,9 @@ void gsExprAssembler<T>::assembleIfc(const ifContainer & iFaces, expr... args)
         this->_computePatternIfc(iFaces, args...);
 
 // #pragma omp parallel //TODO
+// NOTE: if this region is re-enabled it needs m_exprdata->ensureIfc() called
+// serially before it, like _computePatternIfc above -- its body reaches
+// pointsIfc(), which would otherwise create the mirror inside the region.
 // {
     typedef typename gsFunction<T>::uPtr ifacemap;
 

--- a/src/gsExpressions/gsExprHelper.h
+++ b/src/gsExpressions/gsExprHelper.h
@@ -248,6 +248,7 @@ private:
 
     inline gsExprHelper & iface()
     {
+#       pragma omp critical (exprhelper_iface_init)
         if (nullptr==m_mirror )
             m_mirror = memory::make_shared(new gsExprHelper(this));
         return *m_mirror;

--- a/src/gsExpressions/gsExprHelper.h
+++ b/src/gsExpressions/gsExprHelper.h
@@ -244,15 +244,19 @@ public:
         // gsInfo<< "-cdata: "<< m_cdata.size()<<std::endl;
     }
 
-private:
-
     inline gsExprHelper & iface()
     {
-#       pragma omp critical (exprhelper_iface_init)
-        if (nullptr==m_mirror )
-            m_mirror = memory::make_shared(new gsExprHelper(this));
-        return *m_mirror;
+        gsExprHelper * mirror;
+#       pragma omp critical (m_mirror_init)
+        {
+            if (nullptr==m_mirror )
+                m_mirror = memory::make_shared(new gsExprHelper(this));
+            mirror = m_mirror.get();
+        }
+        return *mirror;    
     }
+
+private:
 
     template <class E1>
     void _parse(const expr::_expr<E1> & a1)

--- a/src/gsExpressions/gsExprHelper.h
+++ b/src/gsExpressions/gsExprHelper.h
@@ -244,6 +244,11 @@ public:
         // gsInfo<< "-cdata: "<< m_cdata.size()<<std::endl;
     }
 
+    /// @brief Initializes the mirror helper, if it is not already initialized. This is needed for interface evaluation.
+    void initializeIface() { iface(); }
+
+private:
+
     inline gsExprHelper & iface()
     {
         gsExprHelper * mirror;
@@ -255,8 +260,6 @@ public:
         }
         return *mirror;    
     }
-
-private:
 
     template <class E1>
     void _parse(const expr::_expr<E1> & a1)


### PR DESCRIPTION
`gsExprHelper::iface()` lazily initializes the shared `m_mirror` pointer. During parallel interface assembly, multiple OpenMP threads can enter this function simultaneously, observe that the pointer is null, and concurrently assign separate objects to the same `shared_ptr`.

This concurrent assignment is undefined behavior and can cause memory corruption or segmentation faults. The named OpenMP critical region serializes the initialization check and assignment.

The following program forces multiple OpenMP threads to perform the first interface-data access simultaneously:

```cpp
#include <gismo.h>

using namespace gismo;

int main()
{
    const index_t trials = 10000;

    for (index_t trial = 0; trial != trials; ++trial)
    {
        gsExprHelper<real_t>::uPtr helper = gsExprHelper<real_t>::make();

#       pragma omp parallel
        {
#           pragma omp barrier
            helper->pointsIfc().resize(1, 1);
        }
    }

    gsInfo << "Completed " << trials
           << " concurrent initializations.\n";
    return 0;
}
```

Place the program temporarily in `examples/exprHelperOpenMP_example.cpp`, then configure and run it with:

```sh
cmake -S . -B build \
    -DGISMO_WITH_OPENMP=ON \
    -DGISMO_BUILD_EXAMPLES=ON
cmake --build build --target exprHelperOpenMP_example
OMP_NUM_THREADS=8 ./build/bin/exprHelperOpenMP_example
```

Tested with GCC 16.2.1 and eight OpenMP threads:

- Before the fix: segmentation fault during the first run.
- After the fix: five consecutive runs completed successfully.

----

FIXED:
Make lazy initialization of `gsExprHelper` interface data thread-safe under OpenMP.

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments? N/A
- [X] Have you written new tests or examples for your changes? 