### PR TITLE
Fix timestep truncation in gsParaviewCollection

### DIFF
--- a/src/gsIO/gsParaviewCollection.cpp
+++ b/src/gsIO/gsParaviewCollection.cpp
@@ -64,7 +64,7 @@ namespace gismo
             m_time += 1.0;
             time = m_time;
         }
-        else { m_time = cast<real_t,int>( time ); }
+        else { m_time = time; }
 
         std::string name;
         if ( m_options.askSwitch("makeSubfolder",true) )

--- a/src/gsIO/gsParaviewCollection.h
+++ b/src/gsIO/gsParaviewCollection.h
@@ -232,7 +232,7 @@ private:
     /// Flag for checking if collection is already saved.
     bool m_isSaved;
 
-    int m_time;
+    real_t m_time;
 
     gsExprEvaluator<> * m_evaluator;
 


### PR DESCRIPTION
`gsParaviewCollection::newTimeStep` accepts an optional `real_t` timestep. However, explicitly supplied values were cast to `int` before being stored.

This could make the collection metadata inconsistent with the generated dataset filename. For example, a dataset generated for timestep `0.25` could have a filename containing `0.250000`, while its `.pvd` entry recorded timestep `0`.

This change stores `m_time` as `real_t` and removes the integer conversion. The automatic no-argument timestep behavior continues to increment the stored value by one.

PR #876 currently retains the integer member and conversion, so this fix should be preserved if that PR is rebased or merged.

----

IMPROVED: 
Store the current Paraview collection timestep using `real_t`, matching the existing timestep API.
FIXED: 
Preserve explicitly supplied floating-point timesteps instead of truncating them to integers.

- [x] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [ ] Have you documented any new codes using Doxygen comments? N/A
- [ ] Have you written new tests or examples for your changes? N/A