### PR TITLE
Add custom quadrature factory to expression assembler

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -23,9 +23,6 @@
 
 #include <gsMatrix/gsFiberMatrix.h>
 
-#include <functional>
-#include <utility>
-
 namespace gismo
 {
 
@@ -154,7 +151,7 @@ public:
     /// quadrature. The factory is invoked only when a new rule is needed, never
     /// in an element or quadrature-point loop.
     void setQuadratureFactory(QuadratureFactory factory)
-    { m_quadratureFactory = std::move(factory); }
+    { m_quadratureFactory = give(factory); }
 
     /// @brief Restores the standard gsQuadrature/options-based rules.
     void clearQuadratureFactory()

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -23,6 +23,9 @@
 
 #include <gsMatrix/gsFiberMatrix.h>
 
+#include <functional>
+#include <utility>
+
 namespace gismo
 {
 
@@ -70,6 +73,28 @@ public:
     typedef typename gsExprHelper<T>::variable    variable;    ///< Variable type
     typedef typename gsExprHelper<T>::space       space;       ///< Space type
     typedef typename expr::gsFeSolution<T>        solution;    ///< Solution type
+
+    typedef typename gsQuadRule<T>::uPtr QuadratureRulePtr;
+
+    /**
+     * @brief Factory for an opt-in custom quadrature rule.
+     *
+     * The factory is called once for every rule instance required by an
+     * assembly operation (in particular, once per OpenMP worker and patch for
+     * volume assembly). It must return a fresh rule and, when OpenMP is enabled,
+     * be safe to call concurrently. @a fixedDirection is -1 for volume
+     * integration and the fixed parametric direction for boundary and interface
+     * integration. Overriding gsQuadRule::mapTo() permits element-dependent
+     * rules.
+     */
+    typedef std::function<QuadratureRulePtr(const gsBasis<T> & basis,
+                                             const gsOptionList & options,
+                                             index_t patch,
+                                             short_t fixedDirection)>
+        QuadratureFactory;
+
+private:
+    QuadratureFactory m_quadratureFactory;
 
 public:
 
@@ -122,6 +147,22 @@ public:
 
     /// Returns a reference to the options structure
     gsOptionList & options() {return m_options;}
+
+    /// @brief Installs a custom quadrature-rule factory.
+    ///
+    /// Passing an empty factory restores the standard option-driven
+    /// quadrature. The factory is invoked only when a new rule is needed, never
+    /// in an element or quadrature-point loop.
+    void setQuadratureFactory(QuadratureFactory factory)
+    { m_quadratureFactory = std::move(factory); }
+
+    /// @brief Restores the standard gsQuadrature/options-based rules.
+    void clearQuadratureFactory()
+    { m_quadratureFactory = QuadratureFactory(); }
+
+    /// @brief Returns whether a custom quadrature factory is installed.
+    bool hasCustomQuadrature() const
+    { return static_cast<bool>(m_quadratureFactory); }
 
     /// Returns the internally stored sparse fiber matrix
     const FiberMatrix & fiberMatrix() const
@@ -467,6 +508,23 @@ public:
                                                   const expr residual, solution  u);
 
 private:
+
+    QuadratureRulePtr makeQuadratureRule(const gsBasis<T> & basis,
+                                         index_t patch,
+                                         short_t fixedDirection = -1) const
+    {
+        if (m_quadratureFactory)
+        {
+            QuadratureRulePtr rule =
+                m_quadratureFactory(basis, m_options, patch, fixedDirection);
+            GISMO_ENSURE(rule,
+                         "Custom quadrature factory returned a null rule for patch "
+                         << patch << ".");
+            return rule;
+        }
+
+        return gsQuadrature::getPtr(basis, m_options, fixedDirection);
+    }
 
     template<class... expr> void _computePattern(const expr &... args);
     template<class... expr> void _computePatternBdr(const bcRefList & BCs, const expr &... args);
@@ -1182,7 +1240,7 @@ void gsExprAssembler<T>::assemble(const expr &... args)
         {
             QuPatch = elem.patch();
             // get Degree of the domain
-            QuRule = gsQuadrature::getPtr<T>(this->trialSpace(0).source().basis(QuPatch), m_options);
+            QuRule = makeQuadratureRule(this->trialSpace(0).source().basis(QuPatch), QuPatch);
         }
 
         // Map the Quadrature rule to the element
@@ -1238,7 +1296,8 @@ void gsExprAssembler<T>::assembleBdr(const bcRefList & BCs, expr&... args)
     {
         const boundary_condition<T> * it = &iit->get();
 
-        QuRule = gsQuadrature::getPtr(this->trialSpace(0).source().basis(it->patch()), m_options, it->side().direction());
+        QuRule = makeQuadratureRule(this->trialSpace(0).source().basis(it->patch()),
+                                    it->patch(), it->side().direction());
 
         // Update boundary function source
         m_exprdata->setMutSource(*it->function());
@@ -1291,8 +1350,8 @@ void gsExprAssembler<T>::assembleBdr(const bContainer & bnd, expr&... args)
     for (gsBoxTopology::const_biterator it = bnd.begin();
          it != bnd.end(); ++it )
     {
-        QuRule = gsQuadrature::getPtr(this->trialSpace(0).source().basis(it->patch),
-                                    m_options, it->side().direction());
+        QuRule = makeQuadratureRule(this->trialSpace(0).source().basis(it->patch),
+                                    it->patch, it->side().direction());
 
         // Initialize domain element iterator for current patch
         typename gsBasis<T>::domainIter domIt =  // add it->patch to domainiter ?
@@ -1366,8 +1425,8 @@ void gsExprAssembler<T>::assembleIfc(const ifContainer & iFaces, expr... args)
         else
             interfaceMap = gsCPPInterface<T>::make(getGeometryMap(), iFace);
 
-        QuRule = gsQuadrature::getPtr(this->trialSpace(0).source().basis(patch1),
-                                   m_options, iFace.first().side().direction());
+        QuRule = makeQuadratureRule(this->trialSpace(0).source().basis(patch1),
+                                    patch1, iFace.first().side().direction());
 
         // TODO [later]: Use beginIfc instead of beginBdr
         typename gsBasis<T>::domainIter domIt =
@@ -1430,7 +1489,7 @@ void gsExprAssembler<T>::assembleJacobian(const expr residual, solution & u)
         {
             QuPatch = elem.patch();
             // get Degree of the domain
-            QuRule = gsQuadrature::getPtr(this->trialSpace(0).source().basis(QuPatch), m_options);
+            QuRule = makeQuadratureRule(this->trialSpace(0).source().basis(QuPatch), QuPatch);
         }
 
         // Map the Quadrature rule to the element
@@ -1486,8 +1545,8 @@ void gsExprAssembler<T>::assembleJacobianIfc(const ifContainer & iFaces,
 
         gsCPPInterface<T> interfaceMap(getGeometryMap(), iFace);
 
-        QuRule = gsQuadrature::getPtr(this->trialSpace(0).source().basis(patch1),
-                                   m_options, iFace.first().side().direction());
+        QuRule = makeQuadratureRule(this->trialSpace(0).source().basis(patch1),
+                                    patch1, iFace.first().side().direction());
 
         // Initialize domain element iterator for current patch
         typename gsBasis<T>::domainIter domIt =  // add patch1 to domainiter ?
@@ -1595,7 +1654,7 @@ void gsExprAssembler<T>::quPointsWeights(std::vector<gsMatrix<T> >&  cPoints, st
     {
         auto & bb = this->trialSpace(0).source().basis(patchInd);
 
-        QuRule = gsQuadrature::getPtr(bb, m_options);
+        QuRule = makeQuadratureRule(bb, patchInd);
         const index_t numNodes = QuRule->numNodes();
 
         // @hverhelst: THIS ASSUMES SAME NUMBER OF QUNODES PER ELEMENT

--- a/unittests/gsExprAssembler_test.cpp
+++ b/unittests/gsExprAssembler_test.cpp
@@ -79,8 +79,9 @@ SUITE(gsExprAssembler_test)
         CHECK(custom.hasCustomQuadrature());
         custom.assemble(uCustom * uCustom.tr());
         const gsSparseMatrix<real_t> Mcustom = custom.matrix();
-
-        CHECK(calls.load() > 0);
+        
+        const index_t current_calls = calls.load();
+        CHECK(current_calls > 0);
         CHECK(contextIsCorrect.load());
         CHECK((Mstandard - Mcustom).norm() > 1e-8);
 
@@ -90,6 +91,7 @@ SUITE(gsExprAssembler_test)
         custom.assemble(uCustom * uCustom.tr());
         const gsSparseMatrix<real_t> Mrestored = custom.matrix();
 
+        CHECK_EQUAL(current_calls, calls.load());
         CHECK_EQUAL(Mstandard.rows(), Mrestored.rows());
         CHECK_EQUAL(Mstandard.cols(), Mrestored.cols());
         CHECK((Mstandard - Mrestored).norm() < 1e-14);

--- a/unittests/gsExprAssembler_test.cpp
+++ b/unittests/gsExprAssembler_test.cpp
@@ -13,9 +13,88 @@
 
 #include "gismo_unittest.h"
 
+#include <atomic>
+
+namespace
+{
+
+/// Deliberately simple non-G+Smo rule used to verify that the assembler accepts
+/// arbitrary gsQuadRule implementations, rather than merely another quRule
+/// option.
+template <class T>
+class MidpointRule : public gismo::gsQuadRule<T>
+{
+public:
+    explicit MidpointRule(index_t dim)
+    {
+        this->m_nodes.setZero(dim, 1);
+        this->m_weights.resize(1);
+        this->m_weights[0] = T(1);
+        for (index_t i = 0; i < dim; ++i)
+            this->m_weights[0] *= T(2);
+    }
+};
+
+} // anonymous namespace
+
 
 SUITE(gsExprAssembler_test)
 {
+    TEST(CustomQuadratureFactory)
+    {
+        gsBSplineBasis<real_t> bb(0.0, 1.0, 3, 3);
+        gsMultiBasis<real_t> mb(bb);
+        gsBoundaryConditions<real_t> bcs;
+
+        gsExprAssembler<real_t> standard(1, 1);
+        standard.setIntegrationElements(mb);
+        auto uStandard = standard.getSpace(mb);
+        uStandard.setup(bcs, dirichlet::homogeneous, 0);
+        standard.initSystem();
+        standard.assemble(uStandard * uStandard.tr());
+        const gsSparseMatrix<real_t> Mstandard = standard.matrix();
+
+        gsExprAssembler<real_t> custom(1, 1);
+        custom.setIntegrationElements(mb);
+        auto uCustom = custom.getSpace(mb);
+        uCustom.setup(bcs, dirichlet::homogeneous, 0);
+        custom.initSystem();
+
+        std::atomic<index_t> calls(0);
+        std::atomic<bool> contextIsCorrect(true);
+        custom.setQuadratureFactory(
+            [&calls, &contextIsCorrect](const gsBasis<real_t> & basis,
+                                        const gsOptionList &,
+                                        index_t patch,
+                                        short_t fixedDirection)
+                -> gsExprAssembler<real_t>::QuadratureRulePtr
+            {
+                ++calls;
+                if (patch != 0 || fixedDirection != -1)
+                    contextIsCorrect = false;
+                return gsExprAssembler<real_t>::QuadratureRulePtr(
+                    new MidpointRule<real_t>(basis.dim()));
+            });
+
+        CHECK(custom.hasCustomQuadrature());
+        custom.assemble(uCustom * uCustom.tr());
+        const gsSparseMatrix<real_t> Mcustom = custom.matrix();
+
+        CHECK(calls.load() > 0);
+        CHECK(contextIsCorrect.load());
+        CHECK((Mstandard - Mcustom).norm() > 1e-8);
+
+        custom.clearQuadratureFactory();
+        CHECK(!custom.hasCustomQuadrature());
+        custom.clearMatrix();
+        custom.assemble(uCustom * uCustom.tr());
+        const gsSparseMatrix<real_t> Mrestored = custom.matrix();
+
+        CHECK_EQUAL(Mstandard.rows(), Mrestored.rows());
+        CHECK_EQUAL(Mstandard.cols(), Mrestored.cols());
+        CHECK((Mstandard - Mrestored).norm() < 1e-14);
+    }
+
     TEST(InterfaceExpression)
     {
         const index_t numRef = 2;


### PR DESCRIPTION
NEW: the ability to inject a quadrature rule into the assembler. 

With the current assembler, quadrature rules can only be requested through an options list, from a predefined set within gsQuadrature. This means that any (new) rule must be incorporated in gsQuadrature, and therefore in the gismo core.

This commit allows quadrature rules to be defined outside the core.