### PR TITLE
Feature/subdomains

### DIFF
--- a/examples/domains_example.cpp
+++ b/examples/domains_example.cpp
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
     // We can iterate over all elements in one go
     gsInfo<<"Interior elements of the multi-domain\nID\tpiece\tlower\tupper\n";
     for (auto it = multiDomain2D->beginAll(); it != multiDomain2D->endAll(); ++it)
-        gsInfo<<it.id()<<"\t"<<it.patch()<<"\t"<<it.lowerCorner().transpose()<<"\t"<<it.upperCorner().transpose()<<"\n";
+        gsInfo<<it.id()<<"\t"<<it.patchIndex()<<"\t"<<it.lowerCorner().transpose()<<"\t"<<it.upperCorner().transpose()<<"\n";
 
     // ======================================================================
     // Points as domains

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -948,7 +948,7 @@ void gsExprAssembler<T>::_computePattern(const expr &... args)
     for ( auto & elem : m_exprdata->domain().allElements() )
     {
         m_exprdata->points() = elem.centerPoint();
-        patchInd = elem.patch();
+        patchInd = elem.patchIndex();
         op_tuple(pp, arg_tpl);
     }
 
@@ -1135,9 +1135,9 @@ void gsExprAssembler<T>::assemble(const expr &... args)
 
     for ( auto & elem : m_exprdata->domain().allElements() )
     {
-        if (/*changeQuadrature && */QuPatch!=elem.patch())
+        if (/*changeQuadrature && */QuPatch!=elem.patchIndex())
         {
-            QuPatch = elem.patch();
+            QuPatch = elem.patchIndex();
             // get Degree of the domain
             QuRule = gsQuadrature::getPtr(this->trialSpace(0).source().basis(QuPatch), m_options);
         }
@@ -1383,9 +1383,9 @@ void gsExprAssembler<T>::assembleJacobian(const expr residual, solution & u)
 
     for ( auto & elem : m_exprdata->domain().allElements() )
     {
-        if (changeQuadrature && QuPatch!=elem.patch())
+        if (changeQuadrature && QuPatch!=elem.patchIndex())
         {
-            QuPatch = elem.patch();
+            QuPatch = elem.patchIndex();
             // get Degree of the domain
             QuRule = gsQuadrature::getPtr(this->trialSpace(0).source().basis(QuPatch), m_options);
         }

--- a/src/gsAssembler/gsExprEvaluator.h
+++ b/src/gsAssembler/gsExprEvaluator.h
@@ -466,9 +466,9 @@ T gsExprEvaluator<T>::compute_impl(const expr::_expr<E> & expr)
 
         for ( auto & elem : m_exprdata->domain().allElements() )
         {
-            if (changeQuadrature || QuPatch!=elem.patch())
+            if (changeQuadrature || QuPatch!=elem.patchIndex())
             {
-                QuPatch = elem.patch();
+                QuPatch = elem.patchIndex();
                 // get Degree of the domain
                 QuRule = gsQuadrature::getPtr(*m_exprdata->domain().subdomain(QuPatch), m_options);
             }

--- a/src/gsDomain/gsCompositeDomain.h
+++ b/src/gsDomain/gsCompositeDomain.h
@@ -176,7 +176,7 @@ public:
     }
 
     // Caller is responsible for tagging patch indices on the supplied domains
-    // via setPatchIndex(); untagged domains keep patchIndex()==-1.
+    // via setPatchIndex(); untagged domains default to patchIndex()==0.
     gsCompositeDomain(domainContainer domains)
     : Base(), m_domains(give(domains)) { }
 

--- a/src/gsDomain/gsCompositeDomain.h
+++ b/src/gsDomain/gsCompositeDomain.h
@@ -27,8 +27,16 @@ template<class T> class gsCompositeDomain;
 
 /**
    @brief A domain typically coming from a multipatch basis/geometry
- */
 
+
+   patchIndex() : The index of the patch where we are at
+   subdomainIndex() : The index of the subdomain where we are at
+   id(): The global element index of the current element
+   localId(): The index of the current element in its containing subdomain
+   
+   
+   side(): The index of side where this elemement lies (if applicable)
+ */
 template <class T>
 class gsCompositeDomainIterator : public gsDomainIterator<T>
 {
@@ -41,6 +49,8 @@ class gsCompositeDomainIterator : public gsDomainIterator<T>
     std::vector<size_t> m_numEl; //offsets
     gsDomainIteratorWrapper<T> m_cur;
 
+    index_t m_sid; //< Composite (sub-domain) id
+
 public:
     explicit gsCompositeDomainIterator(index_t _id = 0) : Base(_id) { }
 
@@ -50,8 +60,11 @@ public:
         GISMO_ASSERT(!m_domains.empty(), "Empty..");
         m_numEl.reserve(m_domains.size()+1);
         m_numEl.push_back(0);
+        m_sid = 0;
         for( auto & sd : m_domains )
+        {
             m_numEl.push_back(m_numEl.back()+sd->numElements());
+        }
         m_cur = m_domains.front()->beginAll();
     }
 
@@ -60,20 +73,27 @@ public:
 
     virtual ~gsCompositeDomainIterator() { }
 
-private:
+    
+    index_t subdomainIndex() const { return m_sid; }
 
     virtual size_t localId() const { return m_cur.id(); }
 
+    index_t patchIndex() const { return m_cur.patchIndex(); };
+    
+private:
+
     void next() override
     {
+        // previous
         //note: we cannot rely on this->id()
-        if (m_cur.id() + 1 == m_numEl[this->patch()+1]-m_numEl[this->patch()])
+        //if (m_cur.id() + 1 == m_numEl[m_sid+1]-m_numEl[m_sid])
+
+        if ( this->id() + 1 == m_numEl[m_sid])
         {
-            ++this->patch();
-            if ((size_t)this->patch()<m_domains.size())
+            ++m_sid;
+            if ((size_t)m_sid<m_domains.size())
             {
-                m_cur = m_domains[this->patch()]->beginAll();
-                //m_cur->get()->patch() = this->patch(); // not needed
+                m_cur = m_domains[m_sid]->beginAll();
             }
             else
                 return;
@@ -87,17 +107,17 @@ private:
     void next(index_t increment) override
     {
         const size_t pos = this->id() + increment;
-        if ( pos < m_numEl[this->patch()+1])
+        if ( pos < m_numEl[m_sid+1])
         {
             m_cur += increment;
             return;
         }
 
         //note: could end at min( --m_numEl.end(), m_numEl.begin() + increment)
-        auto it = --std::upper_bound(m_numEl.begin()+this->patch(), --m_numEl.end(), pos);
-        this->patch() = it - m_numEl.begin();
-        m_cur  = m_domains[this->patch()]->beginAll();
-        m_cur +=  pos - m_numEl[this->patch()];
+        auto it = --std::upper_bound(m_numEl.begin()+m_sid, --m_numEl.end(), pos);
+        m_sid = it - m_numEl.begin();
+        m_cur  = m_domains[m_sid]->beginAll();
+        m_cur +=  pos - m_numEl[m_sid];
         return;
     }
 
@@ -134,7 +154,10 @@ public:
     : Base(), m_domains(multiBasis.nPieces()), m_topology(&multiBasis.topology())
     {
         for (index_t i = 0; i != multiBasis.nPieces(); ++i)
+        {
             m_domains[i] = multiBasis.basis(i).domain();
+            m_domains[i]->setPatchIndex(i);
+        }
     }
 
     /** @brief Constructor from a \ref gsMultipatch.
@@ -146,8 +169,14 @@ public:
     : Base(), m_domains(mp.nPieces()), m_topology(&mp.topology())
     {
         for (index_t i = 0; i != mp.nPieces(); ++i)
+        {
             m_domains[i] = mp.patch(i).basis().domain();
+            m_domains[i]->setPatchIndex(i);
+        }
     }
+
+    gsCompositeDomain(const domainContainer domains)
+    : Base(), m_domains(give(domains)) { }
 
     // void insert(Ptr other);
 

--- a/src/gsDomain/gsCompositeDomain.h
+++ b/src/gsDomain/gsCompositeDomain.h
@@ -46,7 +46,7 @@ class gsCompositeDomainIterator : public gsDomainIterator<T>
     typedef typename gsDomainIterator<T>::uPtr domainIter;
 
     domainContainer m_domains;
-    std::vector<size_t> m_numEl; //offsets
+    std::vector<size_t> m_numElOffset; //offsets
     gsDomainIteratorWrapper<T> m_cur;
 
     index_t m_sid; //< Composite (sub-domain) id
@@ -58,12 +58,12 @@ public:
     : Base(), m_domains(give(_dom))
     {
         GISMO_ASSERT(!m_domains.empty(), "Empty..");
-        m_numEl.reserve(m_domains.size()+1);
-        m_numEl.push_back(0);
+        m_numElOffset.reserve(m_domains.size()+1);
+        m_numElOffset.push_back(0);
         m_sid = 0;
         for( auto & sd : m_domains )
         {
-            m_numEl.push_back(m_numEl.back()+sd->numElements());
+            m_numElOffset.push_back(m_numElOffset.back()+sd->numElements());
         }
         m_cur = m_domains.front()->beginAll();
     }
@@ -74,11 +74,11 @@ public:
     virtual ~gsCompositeDomainIterator() { }
 
     
-    index_t subdomainIndex() const { return m_sid; }
+    index_t subdomainIndex() const override { return m_sid; }
 
     virtual size_t localId() const { return m_cur.id(); }
 
-    index_t patchIndex() const { return m_cur.patchIndex(); };
+    index_t patchIndex() const override { return m_cur.patchIndex(); }
     
 private:
 
@@ -88,7 +88,7 @@ private:
         //note: we cannot rely on this->id()
         //if (m_cur.id() + 1 == m_numEl[m_sid+1]-m_numEl[m_sid])
 
-        if ( this->id() + 1 == m_numEl[m_sid])
+        if ( this->id() + 1 == m_numElOffset[m_sid+1])
         {
             ++m_sid;
             if ((size_t)m_sid<m_domains.size())
@@ -107,17 +107,17 @@ private:
     void next(index_t increment) override
     {
         const size_t pos = this->id() + increment;
-        if ( pos < m_numEl[m_sid+1])
+        if ( pos < m_numElOffset[m_sid+1])
         {
             m_cur += increment;
             return;
         }
 
-        //note: could end at min( --m_numEl.end(), m_numEl.begin() + increment)
-        auto it = --std::upper_bound(m_numEl.begin()+m_sid, --m_numEl.end(), pos);
-        m_sid = it - m_numEl.begin();
+        //note: could end at min( --m_numElOffset.end(), m_numElOffset.begin() + increment)
+        auto it = --std::upper_bound(m_numElOffset.begin()+m_sid, --m_numElOffset.end(), pos);
+        m_sid = it - m_numElOffset.begin();
         m_cur  = m_domains[m_sid]->beginAll();
-        m_cur +=  pos - m_numEl[m_sid];
+        m_cur +=  pos - m_numElOffset[m_sid];
         return;
     }
 
@@ -175,7 +175,9 @@ public:
         }
     }
 
-    gsCompositeDomain(const domainContainer domains)
+    // Caller is responsible for tagging patch indices on the supplied domains
+    // via setPatchIndex(); untagged domains keep patchIndex()==-1.
+    gsCompositeDomain(domainContainer domains)
     : Base(), m_domains(give(domains)) { }
 
     // void insert(Ptr other);

--- a/src/gsDomain/gsCompositeDomain.h
+++ b/src/gsDomain/gsCompositeDomain.h
@@ -35,7 +35,7 @@ template<class T> class gsCompositeDomain;
    localId(): The index of the current element in its containing subdomain
    
    
-   side(): The index of side where this elemement lies (if applicable)
+   side(): The index of side where this element lies (if applicable)
  */
 template <class T>
 class gsCompositeDomainIterator : public gsDomainIterator<T>

--- a/src/gsDomain/gsDomain.h
+++ b/src/gsDomain/gsDomain.h
@@ -84,7 +84,7 @@ class gsDomain
 
     typedef gsDomainIteratorWrapper<T> iterator;
 
-    gsDomain() : m_patch(-1) { }
+    gsDomain() : m_patch(0) { }
 
     virtual ~gsDomain() { }
 

--- a/src/gsDomain/gsDomain.h
+++ b/src/gsDomain/gsDomain.h
@@ -75,6 +75,8 @@ namespace gismo
 template<class T>
 class gsDomain
 {
+    index_t m_patch;
+
     public:
 
     typedef typename memory::shared_ptr<gsDomain<T> > Ptr;
@@ -82,11 +84,14 @@ class gsDomain
 
     typedef gsDomainIteratorWrapper<T> iterator;
 
+    gsDomain() : m_patch(-1) { }
+
     virtual ~gsDomain() { }
 
+    index_t patchIndex() const { return m_patch; }
+    
 #if EIGEN_HAS_RVALUE_REFERENCES && EIGEN_GNUC_AT_MOST(4,7) && !EIGEN_COMP_PGI
     // defaulted declaration required at least in Gcc 4.7.2
-    gsDomain() = default;
     gsDomain(const gsDomain&) = default;
     gsDomain(gsDomain&&) = default;
     gsDomain & operator=(const gsDomain&) = default;
@@ -106,8 +111,9 @@ public:
         iterator & end()   { return end_;   }
     };
 
-public:
-
+        void setPatchIndex(index_t k) { m_patch = k; }
+    
+protected:
 
     // iterator(index_t i)
 
@@ -142,7 +148,7 @@ public:
      */
 
 public:
-
+    
     /// Return the k-th subdomain, in the case that there are more than one
     virtual Ptr subdomain(index_t k) const
     {

--- a/src/gsDomain/gsDomainIterator.h
+++ b/src/gsDomain/gsDomainIterator.h
@@ -402,9 +402,9 @@ public:
     T volume() const
     { return (upperCorner() - lowerCorner()).prod(); }
 
-    inline  boxSide  side() const {return m_pside.side();}
-    inline  index_t  patchIndex() const {return m_pside.patch;}
-    virtual index_t  subdomainIndex() const { return patchIndex(); }
+    inline   boxSide  side() const {return m_pside.side();}
+    virtual  index_t  patchIndex() const {return m_pside.patch;}
+    virtual  index_t  subdomainIndex() const { return patchIndex(); }
 protected:
 
 

--- a/src/gsDomain/gsDomainIterator.h
+++ b/src/gsDomain/gsDomainIterator.h
@@ -233,8 +233,10 @@ public:
 
     inline boxSide side() const {return m_domainIter->side();}
 
-    inline index_t patch() const {return m_domainIter->patch();}
+    inline index_t patchIndex() const {return m_domainIter->patchIndex();}
 
+    inline index_t  subdomainIndex() const { return m_domainIter->subdomainIndex(); }
+    
     inline index_t localId() const {return m_domainIter->localId();}
     
     /// Fetches data of integer type based on string label
@@ -258,14 +260,14 @@ public:
 public:
 
     explicit gsDomainIterator(index_t _id = 0, const boxSide & _bs = boundary::none)
-    : m_id(_id), m_pside(0,_bs)
+    : m_id(_id), m_pside(0,_bs) // note: Patch defaults to zero
     { }
 
     virtual ~gsDomainIterator() { }
 
     virtual uPtr clone() const { GISMO_NO_IMPLEMENTATION }
 
-    //void setPatch(index_t k) { m_pside.patch = k; }
+    void setPatchIndex(index_t k) { m_pside.patch = k; }
 
 private:
 
@@ -400,9 +402,9 @@ public:
     T volume() const
     { return (upperCorner() - lowerCorner()).prod(); }
 
-    inline boxSide side() const {return m_pside.side();}
-    inline index_t patch() const {return m_pside.patch;}
-    inline index_t & patch() {return m_pside.patch;}
+    inline  boxSide  side() const {return m_pside.side();}
+    inline  index_t  patchIndex() const {return m_pside.patch;}
+    virtual index_t  subdomainIndex() const { return patchIndex(); }
 protected:
 
 

--- a/src/gsDomain/gsTensorDomainBoundaryIterator.h
+++ b/src/gsDomain/gsTensorDomainBoundaryIterator.h
@@ -45,6 +45,8 @@ public:
     : gsDomainIterator<T>(0, s),
       d( domain.dim() )
     {
+        this->setPatchIndex(domain.patchIndex());
+
         par = s.parameter();
         dir = s.direction();
         meshStart.resize(d);

--- a/src/gsDomain/gsTensorDomainIterator.h
+++ b/src/gsDomain/gsTensorDomainIterator.h
@@ -41,6 +41,8 @@ public:
     explicit gsTensorDomainIterator(const gsTensorDomain<T,D> & domain)
     : gsDomainIterator<T>()
     {
+        this->setPatchIndex(domain.patchIndex());
+
         // compute breaks and mesh size
         // meshStart.resize(D);
         // meshEnd.resize(D);

--- a/src/gsHSplines/gsHElementMarker.hpp
+++ b/src/gsHSplines/gsHElementMarker.hpp
@@ -77,7 +77,7 @@ namespace gismo
         {
             // Create a pair of element and its associated error
             elementLevel = static_cast<const gsHDomainIterator<T,d> *>(it.get())->getLevel();
-            element = m_helper.toElement(it.lowerCorner(), it.upperCorner(), elementLevel, it.patch());
+            element = m_helper.toElement(it.lowerCorner(), it.upperCorner(), elementLevel, it.patchIndex());
             // m_elementErrors[elem] = it.id();
             m_elementErrors[it.id()] = std::make_pair(element, errors[it.id()]);
         }


### PR DESCRIPTION
Distinguish between `patch` and `subdomain` in `gsDomain` and `gsDomainIterator`.

### Old behavior
`gsCompositeDomain` was a "domain container" constructed from `gsMultiPatch` or `gsMultiBasis`, with size the number of patches/bases. In this way, a `subdomain` would be one single patch or basis on which one iterates.

### New behavior
The number of domains in a `gsCompositeDomain` can be arbitrary and can consist of subdomains coming from the same patch. In future PRs, we will introduce `gsSubDomain` which consists of a selected number of elements of a patch. A `gsCompositeDomain` can then be consisting of multiple subdomains from the same patch. 
To facilitate this behavior, we needed to add a `m_patch` member inside `gsDomain`.

---

NEW: 

IMPROVED: 

FIXED: 

API:
Replace `gsDomain::patch()` with `gsDomain::patchIndex`, since it represents an index.

---

Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
