### PR TITLE
Hotfixes: numeric limits and space sizes

### DIFF
--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -543,10 +543,10 @@ private:
         {
             rowSizes.resize(m_vrow.size());
             for (index_t r = 0; r != rowSizes.size(); ++r) // for all row-blocks
-                rowSizes[r] = m_vrow[r]->dim() * m_vrow[r]->mapper.freeSize();
+                rowSizes[r] = m_vrow[r]->mapper.freeSize();
             colSizes.resize(m_vcol.size());
             for (index_t c = 0; c != colSizes.size(); ++c) // for all col-blocks
-                colSizes[c] = m_vcol[c]->dim() * m_vcol[c]->mapper.freeSize();
+                colSizes[c] = m_vcol[c]->mapper.freeSize();
         }
     }
 
@@ -988,13 +988,13 @@ template<class T> void gsExprAssembler<T>::resetDimensions()
     {
         if (!m_vcol[i]->valid()) m_vcol[i]->init();
         m_vcol[i]->mapper.setShift(m_vcol[i-1]->mapper.firstIndex() +
-                                   m_vcol[i-1]->dim*m_vcol[i-1]->mapper.freeSize() );
+                                   m_vcol[i-1]->mapper.freeSize() );
 
         if ( i<m_vrow.size() && m_vcol[i] != m_vrow[i] )
         {
             if (!m_vrow[i]->valid()) m_vrow[i]->init();
             m_vrow[i]->mapper.setShift(m_vrow[i-1]->mapper.firstIndex() +
-                                       m_vrow[i-1]->dim*m_vrow[i-1]->mapper.freeSize() );
+                                       m_vrow[i-1]->mapper.freeSize() );
         }
     }
 }

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -393,7 +393,6 @@ public:
         if (m_fmatrix.nonZeros() && save_sparsety_pattern)
         {
             m_fmatrix.assignZero();
-            m_modified = true;
         }
         else
         {
@@ -418,6 +417,14 @@ public:
                                           cast<T, index_t>(nz * (1.0 + bdO)));
             }
         }
+
+        // Both paths leave m_fmatrix inconsistent with the cached m_matrix --
+        // one zeroes the values, the other resizes and drops the pattern -- so
+        // the cache is invalidated here rather than per branch. matrix() is
+        // `m_modified ? makeMatrix() : m_matrix`, so a path that resizes
+        // without setting this returns the stale m_matrix, still 0x0 on the
+        // first initSystem() since nothing has assembled into it yet.
+        m_modified = true;
     }
 
     /// Initializes the pattern of the sparse matrix

--- a/src/gsAssembler/gsExprAssembler.h
+++ b/src/gsAssembler/gsExprAssembler.h
@@ -417,13 +417,7 @@ public:
                                           cast<T, index_t>(nz * (1.0 + bdO)));
             }
         }
-
-        // Both paths leave m_fmatrix inconsistent with the cached m_matrix --
-        // one zeroes the values, the other resizes and drops the pattern -- so
-        // the cache is invalidated here rather than per branch. matrix() is
-        // `m_modified ? makeMatrix() : m_matrix`, so a path that resizes
-        // without setting this returns the stale m_matrix, still 0x0 on the
-        // first initSystem() since nothing has assembled into it yet.
+		
         m_modified = true;
     }
 

--- a/src/gsAssembler/gsExprEvaluator.h
+++ b/src/gsAssembler/gsExprEvaluator.h
@@ -435,52 +435,24 @@ private:
     };
     struct min_op
     {
-        static inline T init() { return math::limits::max(); }
+        static inline T init() { return math::numeric_limits<T>::max(); }
         static inline void acc (const T contrib, const T, T & res)
         {res = math::min(contrib, res);	}
         static inline void acc_global(const T contrib, T & res)
         {
-            if_autodiff_use_critical(contrib, res);
-        }
-    private:
-        // For autodiff types: use critical section
-        template<typename U, typename std::enable_if<gismo::is_autodiff_type<U>::value, int>::type = 0>
-        static inline void if_autodiff_use_critical(const U contrib, U & res)
-        {
-#           pragma omp critical
-            res = math::min(contrib, res);
-        }
-        // For standard types: use atomic operation
-        template<typename U, typename std::enable_if<!gismo::is_autodiff_type<U>::value, int>::type = 0>
-        static inline void if_autodiff_use_critical(const U contrib, U & res)
-        {
-#           pragma omp atomic write
+#           pragma omp critical (gsExprEvaluator_minmax_acc_global)
             res = math::min(contrib, res);
         }
 
     };
     struct max_op
     {
-        static inline T init() { return math::limits::min(); }
+        static inline T init() { return math::numeric_limits<T>::lowest(); }
         static inline void acc (const T contrib, const T, T & res)
         { res = math::max(contrib, res); }
         static inline void acc_global(const T contrib, T & res)
         {
-            if_autodiff_use_critical(contrib, res);
-        }
-    private:
-        // For autodiff types: use critical section
-        template<typename U, typename std::enable_if<gismo::is_autodiff_type<U>::value, int>::type = 0>
-        static inline void if_autodiff_use_critical(const U contrib, U & res)
-        {
-#           pragma omp critical
-            res = math::max(contrib, res);
-        }
-        // For standard types: use atomic operation
-        template<typename U, typename std::enable_if<!gismo::is_autodiff_type<U>::value, int>::type = 0>
-        static inline void if_autodiff_use_critical(const U contrib, U & res)
-        {
-#           pragma omp atomic write
+#           pragma omp critical (gsExprEvaluator_minmax_acc_global)
             res = math::max(contrib, res);
         }
     };

--- a/src/gsAssembler/gsExprEvaluator.h
+++ b/src/gsAssembler/gsExprEvaluator.h
@@ -422,7 +422,7 @@ private:
         template<typename U, typename std::enable_if<gismo::is_autodiff_type<U>::value, int>::type = 0>
         static inline void if_autodiff_use_critical(const U contrib, U & res)
         {
-#           pragma omp critical
+#           pragma omp critical (gsExprEvaluator_plus_acc_global)
             res += contrib;
         }
         // For standard types: use atomic operation
@@ -435,7 +435,12 @@ private:
     };
     struct min_op
     {
-        static inline T init() { return math::numeric_limits<T>::max(); }
+        static inline T init()
+        {
+            GISMO_STATIC_ASSERT(std::numeric_limits<T>::is_specialized,
+            "std::numeric_limits is not specialised for T, so the reduction would be seeded with T() instead of the extreme value.");
+            return math::numeric_limits<T>::max();
+        }
         static inline void acc (const T contrib, const T, T & res)
         {res = math::min(contrib, res);	}
         static inline void acc_global(const T contrib, T & res)
@@ -447,7 +452,12 @@ private:
     };
     struct max_op
     {
-        static inline T init() { return math::numeric_limits<T>::lowest(); }
+        static inline T init()
+        {
+            GISMO_STATIC_ASSERT(std::numeric_limits<T>::is_specialized,
+            "std::numeric_limits is not specialised for T, so the reduction would be seeded with T() instead of the extreme value.");
+            return math::numeric_limits<T>::lowest();
+        }
         static inline void acc (const T contrib, const T, T & res)
         { res = math::max(contrib, res); }
         static inline void acc_global(const T contrib, T & res)

--- a/src/gsAssembler/gsExprEvaluator.h
+++ b/src/gsAssembler/gsExprEvaluator.h
@@ -445,7 +445,7 @@ private:
         {res = math::min(contrib, res);	}
         static inline void acc_global(const T contrib, T & res)
         {
-#           pragma omp critical (gsExprEvaluator_minmax_acc_global)
+#           pragma omp critical (gsExprEvaluator_min_acc_global)
             res = math::min(contrib, res);
         }
 
@@ -462,7 +462,7 @@ private:
         { res = math::max(contrib, res); }
         static inline void acc_global(const T contrib, T & res)
         {
-#           pragma omp critical (gsExprEvaluator_minmax_acc_global)
+#           pragma omp critical (gsExprEvaluator_max_acc_global)
             res = math::max(contrib, res);
         }
     };

--- a/src/gsCore/gsMath.h
+++ b/src/gsCore/gsMath.h
@@ -37,6 +37,9 @@ namespace gismo {
 */
 namespace math {
 
+/// Numeric limits of \a real_t. For a type other than \a real_t -- in
+/// particular inside a class template parameterised on the scalar type -- use
+/// math::numeric_limits<T> below instead.
 typedef std::numeric_limits<real_t> limits;
 
 // Math functions
@@ -216,8 +219,20 @@ inline sw::universal::posit<nbits,es> nextafter(sw::universal::posit<nbits,es> x
 // }
 
 
-/** Numeric precision (number of exact decimal digits expected) for
-    real_t
+/** Numeric precision and range of the scalar type \a T.
+
+    Wraps std::numeric_limits<T> so that types whose members are functions
+    rather than constants (mpfr::mpreal) can be used through one interface.
+
+    \note For a floating point type, min() is the smallest positive NORMAL
+    value, not the smallest value. Seed a maximum-reduction with lowest(),
+    which is the most negative finite value; min() would make the reduction
+    return a tiny positive number on an everywhere-negative field.
+
+    \note The range accessors are only meaningful where std::numeric_limits
+    is specialised for \a T; the primary standard template returns a
+    value-initialised T. A scalar needing its own mapping must specialise
+    this template, as mpfr::mpreal does below.
 */
 template <typename T>
 struct numeric_limits
@@ -227,6 +242,18 @@ struct numeric_limits
 
     inline static int digits10()
     { return std::numeric_limits<T>::digits10; }
+
+    /// Smallest positive normal value
+    inline static T min()    { return (std::numeric_limits<T>::min)();    }
+
+    /// Largest finite value
+    inline static T max()    { return (std::numeric_limits<T>::max)();    }
+
+    /// Most negative finite value (== -max() for floating point types)
+    inline static T lowest() { return std::numeric_limits<T>::lowest();   }
+
+    /// Difference between 1 and the next representable value
+    inline static T epsilon(){ return std::numeric_limits<T>::epsilon();  }
 };
 
 #ifdef gsMpfr_ENABLED
@@ -238,6 +265,18 @@ struct numeric_limits<mpfr::mpreal>
 
     inline static int digits10()
     { return std::numeric_limits<mpfr::mpreal>::digits10(); }
+
+    inline static mpfr::mpreal min()
+    { return (std::numeric_limits<mpfr::mpreal>::min)(); }
+
+    inline static mpfr::mpreal max()
+    { return (std::numeric_limits<mpfr::mpreal>::max)(); }
+
+    inline static mpfr::mpreal lowest()
+    { return std::numeric_limits<mpfr::mpreal>::lowest(); }
+
+    inline static mpfr::mpreal epsilon()
+    { return std::numeric_limits<mpfr::mpreal>::epsilon(); }
 };
 #endif
 

--- a/unittests/gsExprAssembler_test.cpp
+++ b/unittests/gsExprAssembler_test.cpp
@@ -130,14 +130,34 @@ SUITE(gsExprAssembler_test)
         // 3*7.
         CHECK_EQUAL(expected, A.numDofs());
 
-        // matrix().rows()/cols() are deliberately NOT checked. matrix()
-        // returns m_matrix, which initSystem() leaves default-constructed
-        // (0x0) until an assemble() marks the system modified, so those
-        // checks read 0 with and without the fix -- they would fail here
-        // whatever the block sizing did, and pin nothing.
-        //
-        // This leaves _blockDims itself, which feeds blockView(), uncovered;
-        // the check above reaches the same defect through resetDimensions.
+        // The system matrix is sized by MatrixSizedAfterInitSystem below; the
+        // check here is confined to the block arithmetic. _blockDims itself,
+        // which feeds blockView(), stays uncovered -- the check above reaches
+        // the same defect through resetDimensions.
+    }
+
+    // matrix() is `m_modified ? makeMatrix() : m_matrix`, and m_matrix is only
+    // populated from the fiber matrix by makeMatrix(). clearMatrix() must
+    // therefore invalidate the cache on every path, including the one that
+    // resizes rather than zeroes: initSystem() reaches exactly that path, so
+    // without the flag matrix() reports the default-constructed 0x0 m_matrix
+    // for a system whose dimensions are already known.
+    TEST(MatrixSizedAfterInitSystem)
+    {
+        gsBSplineBasis<real_t> bb(0.0, 1.0, 3, 3);
+        gsMultiBasis<real_t> mb(bb);
+        gsBoundaryConditions<real_t> bcs;
+
+        gsExprAssembler<real_t> A(1, 1);
+        A.setIntegrationElements(mb);
+        auto u = A.getSpace(mb, 1, 0);
+        u.setup(bcs, dirichlet::homogeneous, 0);
+        A.initSystem();
+
+        // No assemble() here: sizing must hold from initSystem() alone.
+        CHECK_EQUAL(A.numTestDofs(), A.matrix().rows());
+        CHECK_EQUAL(A.numDofs(),     A.matrix().cols());
+        CHECK(A.matrix().rows() > 0);
     }
 
     TEST(InterfaceExpression)

--- a/unittests/gsExprAssembler_test.cpp
+++ b/unittests/gsExprAssembler_test.cpp
@@ -99,41 +99,96 @@ SUITE(gsExprAssembler_test)
 
     TEST(MultiSpaceBlockDims)
     {
-        // Regression test for a469c2d04: _blockDims/resetDimensions used
-        // dim()*mapper.freeSize() for block sizes, but freeSize() already
-        // includes dim(), so a space with dim>1 doubled up on its own
-        // dimension in the row/col block sizes and in the shift applied to
-        // later blocks. A single space of dim 1 cannot expose this (the
-        // erroneous factor is 1), so this test needs two spaces of
-        // different, non-trivial dimension sharing one assembler, matching
-        // the "vector space v and scalar space q" example from the fix.
-        gsBSplineBasis<real_t> bb(0.0, 1.0, 3, 3);
-        gsMultiBasis<real_t> mb(bb);
+        // _blockDims sizes the row/column blocks and resetDimensions sets the
+        // shift applied to later blocks. mapper.freeSize() already reports the
+        // component-inclusive dof count of a space, so multiplying it by that
+        // space's dim counts the dimension twice. A single space of dim 1
+        // cannot expose that -- the erroneous factor is 1 -- so this needs two
+        // spaces of different, non-trivial dimension in one assembler.
+        //
+        // A 2D geometry is required: the assemble() arm below needs meas(G)
+        // to build a genuine bilinear form per space, rather than only
+        // inspecting mappers.
+        gsMultiPatch<real_t> mp(*gsNurbsCreator<real_t>::BSplineSquare());
+        gsMultiBasis<real_t> dbasis(mp);
+        dbasis.degreeElevate(2);
+        dbasis.uniformRefine(5);
         gsBoundaryConditions<real_t> bcs;
+        const index_t n = dbasis.basis(0).size();
 
-        gsExprAssembler<real_t> A(2, 2);
-        A.setIntegrationElements(mb);
-        auto v = A.getSpace(mb, 3, 0); // vector-valued space, dim 3
-        auto q = A.getSpace(mb, 1, 1); // scalar space, dim 1
-        v.setup(bcs, dirichlet::homogeneous, 0);
-        q.setup(bcs, dirichlet::homogeneous, 0);
-        A.initSystem();
+        // Control arm: two SCALAR spaces (dim 1 each). Since dim==1 makes
+        // the erroneous factor in the fixed formula equal to 1, this arm
+        // cannot itself fail on the bug -- it exists to pin that the shift
+        // between blocks is otherwise sane, so a failure in the main arm
+        // below can be attributed to the dim>1 handling rather than to the
+        // fixture or to block bookkeeping in general.
+        {
+            gsExprAssembler<real_t> A(2, 2);
+            A.setIntegrationElements(dbasis);
+            auto u0 = A.getSpace(dbasis, 1, 0);
+            auto u1 = A.getSpace(dbasis, 1, 1);
+            u0.setup(bcs, dirichlet::homogeneous, 0);
+            u1.setup(bcs, dirichlet::homogeneous, 0);
+            A.initSystem();
+            CHECK_EQUAL(2*n, A.numDofs());
+            CHECK_EQUAL(n,   u1.mapper().firstIndex());
+        }
 
-        // Expectation computed directly from the per-space dof mappers,
-        // independent of both _blockDims and numDofs()/matrix() sizing:
-        // freeSize() already reports the total (component-inclusive) dof
-        // count for that space, so the system size is simply their sum.
-        const index_t expected = v.mapper().freeSize() + q.mapper().freeSize();
+        // Main arm: a vector-valued space of dimension d sharing an
+        // assembler with a scalar space. Looping d = 2 and d = 3 is
+        // essential -- the erroneous shift was dim()*(dim()*freeSize())
+        // versus the correct dim()*freeSize(), i.e. an extra factor of
+        // dim(). At a single d, a formula quadratic in dim() is
+        // indistinguishable from a linear one with a different constant;
+        // the pair of values pins the exponent.
+        for (index_t d = 2; d <= 3; ++d)
+        {
+            gsExprAssembler<real_t> A(2, 2);
+            A.setIntegrationElements(dbasis);
+            auto G = A.getMap(mp);
+            auto v = A.getSpace(dbasis, d, 0); // vector-valued space, dim d
+            auto p = A.getSpace(dbasis, 1, 1); // scalar space, dim 1
+            v.setup(bcs, dirichlet::homogeneous, 0);
+            p.setup(bcs, dirichlet::homogeneous, 0);
+            A.initSystem();
 
-        // Measured: 28 here (3*7 + 7). Before the fix numDofs() reported 70,
-        // the shift for q's block having been computed as 3*(3*7) instead of
-        // 3*7.
-        CHECK_EQUAL(expected, A.numDofs());
+            CHECK_EQUAL((d+1)*n, A.numDofs());
+            CHECK_EQUAL(0,       v.mapper().firstIndex());
+            CHECK_EQUAL(d*n,     v.mapper().freeSize());
+            CHECK_EQUAL(d*n,     p.mapper().firstIndex());
+            CHECK_EQUAL(n,       p.mapper().freeSize());
 
-        // The system matrix is sized by MatrixSizedAfterInitSystem below; the
-        // check here is confined to the block arithmetic. _blockDims itself,
-        // which feeds blockView(), stays uncovered -- the check above reaches
-        // the same defect through resetDimensions.
+            // Two distinct-block terms in one assemble() call: this is what
+            // actually writes into both diagonal blocks of the system
+            // matrix, so a wrong offset for p's block (computed pre-fix as
+            // d*(d*n) instead of d*n) would either write out of range or
+            // leave part of v's block untouched.
+            A.assemble(v*v.tr()*meas(G), p*p.tr()*meas(G));
+
+            // Counting entirely-zero rows separates "wrong total" from
+            // "structurally broken": pre-fix, each block was internally
+            // self-consistent and merely sat at the wrong offset, so
+            // numDofs() alone does not reveal that (d^2-d)*n rows exist
+            // that nothing ever writes to.
+            const gsSparseMatrix<real_t> & M = A.matrix();
+            gsVector<bool> rowTouched(M.rows());
+            rowTouched.setZero();
+            for (index_t c = 0; c != M.cols(); ++c)
+                for (gsSparseMatrix<real_t>::InnerIterator it(M, c); it; ++it)
+                    rowTouched(it.row()) = true;
+            const index_t zeroRows = M.rows() - rowTouched.array().count();
+            CHECK_EQUAL(0, zeroRows);
+
+            // matrixBlockView() is the only assertion here reaching
+            // _blockDims directly (numDofs()/firstIndex() above reach the
+            // same defect only through resetDimensions): the block sizes
+            // must match the per-space free dof counts exactly.
+            auto view = A.matrixBlockView();
+            CHECK_EQUAL(d*n, view(0,0).rows());
+            CHECK_EQUAL(d*n, view(0,0).cols());
+            CHECK_EQUAL(n,   view(1,1).rows());
+            CHECK_EQUAL(n,   view(1,1).cols());
+        }
     }
 
     // matrix() is `m_modified ? makeMatrix() : m_matrix`, and m_matrix is only

--- a/unittests/gsExprAssembler_test.cpp
+++ b/unittests/gsExprAssembler_test.cpp
@@ -97,6 +97,49 @@ SUITE(gsExprAssembler_test)
         CHECK((Mstandard - Mrestored).norm() < 1e-14);
     }
 
+    TEST(MultiSpaceBlockDims)
+    {
+        // Regression test for a469c2d04: _blockDims/resetDimensions used
+        // dim()*mapper.freeSize() for block sizes, but freeSize() already
+        // includes dim(), so a space with dim>1 doubled up on its own
+        // dimension in the row/col block sizes and in the shift applied to
+        // later blocks. A single space of dim 1 cannot expose this (the
+        // erroneous factor is 1), so this test needs two spaces of
+        // different, non-trivial dimension sharing one assembler, matching
+        // the "vector space v and scalar space q" example from the fix.
+        gsBSplineBasis<real_t> bb(0.0, 1.0, 3, 3);
+        gsMultiBasis<real_t> mb(bb);
+        gsBoundaryConditions<real_t> bcs;
+
+        gsExprAssembler<real_t> A(2, 2);
+        A.setIntegrationElements(mb);
+        auto v = A.getSpace(mb, 3, 0); // vector-valued space, dim 3
+        auto q = A.getSpace(mb, 1, 1); // scalar space, dim 1
+        v.setup(bcs, dirichlet::homogeneous, 0);
+        q.setup(bcs, dirichlet::homogeneous, 0);
+        A.initSystem();
+
+        // Expectation computed directly from the per-space dof mappers,
+        // independent of both _blockDims and numDofs()/matrix() sizing:
+        // freeSize() already reports the total (component-inclusive) dof
+        // count for that space, so the system size is simply their sum.
+        const index_t expected = v.mapper().freeSize() + q.mapper().freeSize();
+
+        // Measured: 28 here (3*7 + 7). Before the fix numDofs() reported 70,
+        // the shift for q's block having been computed as 3*(3*7) instead of
+        // 3*7.
+        CHECK_EQUAL(expected, A.numDofs());
+
+        // matrix().rows()/cols() are deliberately NOT checked. matrix()
+        // returns m_matrix, which initSystem() leaves default-constructed
+        // (0x0) until an assemble() marks the system modified, so those
+        // checks read 0 with and without the fix -- they would fail here
+        // whatever the block sizing did, and pin nothing.
+        //
+        // This leaves _blockDims itself, which feeds blockView(), uncovered;
+        // the check above reaches the same defect through resetDimensions.
+    }
+
     TEST(InterfaceExpression)
     {
         const index_t numRef = 2;

--- a/unittests/gsExpressions_test.cpp
+++ b/unittests/gsExpressions_test.cpp
@@ -204,6 +204,122 @@ SUITE(gsExpressions_test)
 
     }
 
+/*
+    MIN/MAX REDUCTIONS
+*/
+    // Pins gsExprEvaluator::max()/min() against an everywhere-negative /
+    // everywhere-positive constant field, whose true extremum is exact
+    // regardless of quadrature (a constant integrand needs no sampling
+    // accuracy). max_op::init() must start below every attainable value;
+    // starting at the smallest positive normal double instead (the historic
+    // defect) would leave that spurious positive seed as the reported
+    // maximum of an always-negative field, so a positive returned value is
+    // the unmistakable fingerprint of the bug, checked here via CHECK(<0)
+    // in addition to the value.
+    TEST(minmax_reduction_seed)
+    {
+        gsFunctionExpr<real_t> negConst("-1.0", 2);
+        gsFunctionExpr<real_t> posConst("1.0", 2);
+
+        gsExprAssembler<real_t> Aloc(1,1);
+        // max()/min() iterate the integration domain, unlike the pointwise
+        // ev.eval() used elsewhere in this file, so the elements must be set.
+        Aloc.setIntegrationElements(mb);
+        Aloc.getMap(mp);
+        Aloc.getSpace(mb);
+        auto negC = Aloc.getCoeff(negConst);
+        auto posC = Aloc.getCoeff(posConst);
+        gsExprEvaluator<real_t> evloc(Aloc);
+
+        const real_t tol = 1e2 * std::numeric_limits<real_t>::epsilon();
+
+        real_t maxNeg = evloc.max(negC.val());
+        CHECK(maxNeg < 0.0);
+        CHECK_CLOSE(-1.0, maxNeg, tol);
+
+        // mirror case: min_op::init() must start above every attainable
+        // value, pinning the symmetric defect for min() on a positive field
+        real_t minPos = evloc.min(posC.val());
+        CHECK(minPos > 0.0);
+        CHECK_CLOSE(1.0, minPos, tol);
+    }
+
+    // Only meaningful with OpenMP: without it there is one accumulator, the
+    // merge under test never happens, and the test would pass while covering
+    // nothing. Omitted outright rather than left to degenerate silently.
+#ifdef _OPENMP
+
+    // Exercises the merge of the per-thread accumulators in acc_global.
+    //
+    // compute_impl gives every thread its own thValue and merges each one
+    // into m_value exactly once, at the end. A CONSTANT field therefore has
+    // no power here at all: every thread arrives with the same number, so
+    // any interleaving of the merge -- protected or not -- still yields the
+    // correct answer. The field below varies over the domain so that the
+    // thread-local extrema genuinely differ, which is the precondition for a
+    // lost merge to change the result.
+    //
+    // The oracle is the same reduction on a single thread, where acc_global
+    // runs once and no interleaving exists. Both runs sample identical
+    // quadrature points, and min/max is a selection rather than an
+    // arithmetic reduction -- it is associative and returns one of the
+    // sampled values unchanged -- so the comparison is an exact equality.
+    // (That is why byte-identity is legitimate here and is not for a sum,
+    // whose floating point result depends on the order of accumulation.)
+    //
+    // This still cannot prove the absence of a race; only ThreadSanitizer
+    // with libarcher measures that. Unlike a constant field, it can fail
+    // when one occurs.
+    TEST(minmax_reduction_threads)
+    {
+        // Sign-definite on the unit square (ranges [-2,-1] and [1,2]) so the
+        // seed defect above is still caught, but varying across elements.
+        gsFunctionExpr<real_t> negRamp("x - 2.0", 2);
+        gsFunctionExpr<real_t> posRamp("x + 1.0", 2);
+
+        gsMultiBasis<real_t> mbFine(mp);
+        mbFine.uniformRefine(4); // many elements -> more work per thread
+
+        gsExprAssembler<real_t> Aloc(1,1);
+        Aloc.setIntegrationElements(mbFine);
+        Aloc.getMap(mp);
+        Aloc.getSpace(mbFine);
+        auto negC = Aloc.getCoeff(negRamp);
+        auto posC = Aloc.getCoeff(posRamp);
+        gsExprEvaluator<real_t> evloc(Aloc);
+
+        // The reference is taken on one thread, where acc_global runs once
+        // and no interleaving exists.
+        const int nThreads = omp_get_max_threads();
+
+        omp_set_num_threads(1);
+        const real_t maxRef = evloc.max(negC.val());
+        const real_t minRef = evloc.min(posC.val());
+
+        CHECK(maxRef < 0.0);
+        CHECK(minRef > 0.0);
+
+        // The loop runs on as many threads as the host offers, and never
+        // fewer than four. A host or CI runner pinned to one thread would
+        // otherwise turn this into a serial check that passes while
+        // exercising none of the merge it exists to cover, so the thread
+        // count is asserted rather than assumed.
+        omp_set_num_threads(nThreads > 4 ? nThreads : 4);
+        CHECK(omp_get_max_threads() > 1);
+
+        for (int i = 0; i != 20; ++i)
+        {
+            CHECK_EQUAL(maxRef, evloc.max(negC.val()));
+            CHECK_EQUAL(minRef, evloc.min(posC.val()));
+        }
+
+        // Restore: the thread count is process-wide and would otherwise
+        // change how every later test in this binary runs.
+        omp_set_num_threads(nThreads);
+    }
+
+#endif // _OPENMP
+
     // Test for the positive part of an expression ( Macaulay bracket )
     TEST(ppart_expr)
     {


### PR DESCRIPTION
This PR fixes some issues with numeric limits and block sizes in `gsExprAssembler`, and the `max_op` in `gsExprEvaluator`.

----

The commit description must be structured as a list follows:

NEW: 

IMPROVED: 

FIXED: 
For multiple spaces (e.g., vector space v and scalar space q) `_blockDims` and `resetDimensions` would use the wrong sizes for rows and columns. They'd use `dim*freeSize` but `freeSize` does already include `dim`. The `numDofs` in `gsExprAssembler` already does this correct.
In `gsExprEvaluator` the `max_op` would not work on pure negative functions. It was initialized with `numeric_limits::min` which is `1e-300` which can still be the maximum, for any function with a maximum <0 in the domain. It is replaced with `numeric_limits::lowest` which is minus infinity. 
 

API:

----

Please consider the following checklist before issuing a pull
request:
- [X] Have you added an explanation of what your changes do and why
  you'd like us to include them?
- [X] Have you documented any new codes using Doxygen comments?
- [X] Have you written new tests or examples for your changes?
-----
